### PR TITLE
Worktree creation fails if branch already exists locally (Forge-jh5)

### DIFF
--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -73,8 +73,8 @@ func (m *Manager) Create(ctx context.Context, anvilPath, beadID string) (*Worktr
 		return nil, fmt.Errorf("resolving base ref: %w", err)
 	}
 
-	// Create worktree with new branch
-	if err := gitCmd(ctx, anvilPath, "worktree", "add", "-b", branch, worktreePath, baseRef); err != nil {
+	// Create worktree with new branch (use -B to reset if branch exists, -f to force if checked out elsewhere)
+	if err := gitCmd(ctx, anvilPath, "worktree", "add", "-f", "-B", branch, worktreePath, baseRef); err != nil {
 		return nil, fmt.Errorf("git worktree add: %w", err)
 	}
 


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Forge-jh5
**Branch**: forge/Forge-jh5

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*