### PR TITLE
fix(hearth): live activity panel shows content while smith is running

### DIFF
--- a/internal/hearth/data.go
+++ b/internal/hearth/data.go
@@ -184,6 +184,9 @@ func parseWorkerActivity(logPath string, maxEntries int) []string {
 			Content string          `json:"content,omitempty"`
 			Role    string          `json:"role,omitempty"`
 			Status  string          `json:"status,omitempty"`
+			RateLimitInfo *struct {
+				Status string `json:"status"`
+			} `json:"rate_limit_info,omitempty"`
 		}
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			continue
@@ -250,9 +253,9 @@ func parseWorkerActivity(logPath string, maxEntries int) []string {
 				}
 			}
 		case "rate_limit_event":
-			// Claude-style informational event
-			if event.Status != "" {
-				entries = append(entries, fmt.Sprintf("[rate] %s", event.Status))
+			// Claude-style informational event — status is inside rate_limit_info
+			if event.RateLimitInfo != nil && event.RateLimitInfo.Status != "" {
+				entries = append(entries, fmt.Sprintf("[rate] %s", event.RateLimitInfo.Status))
 			}
 		case "result":
 			subtype := event.Subtype

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -161,15 +161,13 @@ func (w *Worker) Run(ctx context.Context, extraFlags []string) (*smith.Result, e
 	}
 	w.process = process
 
-	// Update PID in state DB
+	// Update PID and log path in state DB immediately so Hearth can tail the log
 	_ = w.db.UpdateWorkerPID(w.ID, process.PID)
+	_ = w.db.UpdateWorkerLogPath(w.ID, process.LogPath)
 
 	// Step 4: Wait for Smith to complete
 	log.Printf("[%s] Waiting for Smith (PID %d)", w.ID, process.PID)
 	result = process.Wait()
-
-	// Update log path in state DB
-	_ = w.db.UpdateWorkerLogPath(w.ID, process.LogPath)
 
 	// Step 5: Determine outcome
 	if result.ExitCode == 0 {


### PR DESCRIPTION
Two bugs caused the Live Activity panel to always show 'No activity':

1. **worker.go** — UpdateWorkerLogPath was called *after* process.Wait() returned,
   so the log path was never in the DB while the smith was actually running.
   Hearth polls the DB every 2s and always got an empty log_path → nothing to parse.
   Fixed by moving the call to immediately after Spawn(), alongside UpdateWorkerPID.

2. **data.go** — rate_limit_event entries used event.Status (always empty at the top
   level) instead of event.RateLimitInfo.Status where Claude actually writes it.
   Added RateLimitInfo field to the anonymous struct so it unmarshals correctly.