### PR TITLE
fix(lifecycle): park lifecycle actions for in-flight beads instead of dropping them

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -72,7 +72,7 @@ type Daemon struct {
 
 	// Dispatch state
 	activeBeads    sync.Map       // beadID -> true, currently in-flight
-	pendingActions sync.Map       // beadID -> lifecycle.ActionRequest, queued while in-flight
+	pendingActions sync.Map       // beadID -> lifecycle.ActionRequest; single parked action per bead, latest-wins
 	wg             sync.WaitGroup // tracks running pipeline goroutines
 	worktreeMgr    *worktree.Manager
 	promptBuilder  *prompt.Builder
@@ -278,7 +278,12 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 		defer d.wg.Done()
 		// Drain order: activeBeads.Delete runs first (registered last → LIFO),
 		// then drainPendingAction fires so any parked action sees the bead as free.
-		defer d.drainPendingAction(ctx, req.BeadID)
+		// Skip draining during shutdown to avoid wg.Add after wg.Wait.
+		defer func() {
+			if ctx.Err() == nil {
+				d.drainPendingAction(ctx, req.BeadID)
+			}
+		}()
 		defer d.activeBeads.Delete(req.BeadID)
 
 		// Create/get worktree for the PR branch
@@ -365,7 +370,11 @@ func (d *Daemon) drainPendingAction(ctx context.Context, beadID string) {
 	if !ok {
 		return
 	}
-	req := v.(lifecycle.ActionRequest)
+	req, ok := v.(lifecycle.ActionRequest)
+	if !ok {
+		d.logger.Error("pending lifecycle action has unexpected type", "bead", beadID, "valueType", fmt.Sprintf("%T", v))
+		return
+	}
 	d.logger.Info("draining parked lifecycle action", "bead", beadID, "action", req.Action)
 	d.handleLifecycleAction(ctx, req)
 }
@@ -471,7 +480,12 @@ func (d *Daemon) dispatchBead(ctx context.Context, bead poller.Bead, anvilCfg co
 	defer d.wg.Done()
 	// Drain order: activeBeads.Delete runs first (registered last → LIFO),
 	// then drainPendingAction fires so any parked lifecycle action sees the bead as free.
-	defer d.drainPendingAction(ctx, bead.ID)
+	// Skip draining during shutdown to avoid wg.Add after wg.Wait.
+	defer func() {
+		if ctx.Err() == nil {
+			d.drainPendingAction(ctx, bead.ID)
+		}
+	}()
 	defer d.activeBeads.Delete(bead.ID)
 
 	d.logger.Info("dispatching bead", "bead", bead.ID, "anvil", bead.Anvil, "title", bead.Title)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -162,7 +162,13 @@ func TestHandleIPC_RunBead_Success(t *testing.T) {
 	t.Run("successful dispatch via cache", func(t *testing.T) {
 		// Wait for the goroutine from the previous subtest to finish so its
 		// deferred activeBeads.Delete cannot race with the Store below.
-		d.wg.Wait()
+		done := make(chan struct{})
+		go func() { d.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for goroutines from previous subtest to finish")
+		}
 
 		// Clear activeBeads
 		d.activeBeads.Delete("TEST-1")


### PR DESCRIPTION
## Problem

When a Bellows event arrives (e.g. Copilot posts review comments creating unresolved threads) while the original smith/temper/warden pipeline is still running for that bead, the lifecycle action was silently dropped:

\\\
bead already in flight, skipping lifecycle action
\\\

Since the Bellows snapshot had already advanced (\HasUnresolvedThreads\ flipped to true), the event would never re-fire. The PR would sit with unresolved review threads indefinitely until a daemon restart.

## Fix

- Add \pendingActions sync.Map\ to Daemon (maps \eadID → lifecycle.ActionRequest\)
- When a lifecycle action arrives for an in-flight bead, park it in \pendingActions\ instead of dropping it (always overwrites, so newer events win)
- Add \drainPendingAction(ctx, beadID)\ — checks \pendingActions\, dispatches if found
- Fix defer ordering in \dispatchBead\ and the lifecycle goroutine so drain fires *after* \ctiveBeads.Delete\ (LIFO: Delete registered last → runs first; drain runs second)

Also fixes a latent test race in \TestHandleIPC_RunBead_Success\ where the goroutine from the 'poll fallback' subtest could race its \defer activeBeads.Delete\ against the 'via cache' subtest's \LoadOrStore\. Added \d.wg.Wait()\ between subtests.