### PR TITLE
fix(warden): output verdict JSON first to survive error_max_turns

### DIFF
--- a/internal/warden/warden.go
+++ b/internal/warden/warden.go
@@ -31,6 +31,12 @@ const (
 	VerdictRequestChanges Verdict = "request_changes"
 )
 
+// wardenMaxTurns is the maximum number of turns the Warden review session may
+// use. Enough to output the verdict JSON first and then do file analysis.
+// Higher than 3 (the previous value) because tool reads can consume turns
+// before the model emits the verdict block.
+const wardenMaxTurns = 5
+
 // ReviewResult captures the Warden's review outcome.
 type ReviewResult struct {
 	// Verdict is the review decision.
@@ -102,7 +108,7 @@ func Review(ctx context.Context, worktreePath, beadID, anvilPath string, db *sta
 	// still parseable. max-turns is set to 5 to give Claude enough room to
 	// output the verdict and then do analysis (even if it reads a few files).
 	logDir := filepath.Join(worktreePath, ".forge-logs")
-	wardenFlags := []string{"--max-turns", "5"}
+	wardenFlags := []string{"--max-turns", fmt.Sprintf("%d", wardenMaxTurns)}
 
 	var smithResult *smith.Result
 	// For non-Claude providers --max-turns is translated/dropped;
@@ -208,15 +214,16 @@ func buildReviewPrompt(beadID, diff, anvilPath string) string {
 
 ## REQUIRED: Output Your Verdict JSON Block First
 
-Before writing anything else, you MUST output the following JSON block as the VERY FIRST content
-in your response — even before any analysis or comments:
+Before writing anything else, output a JSON block in this format as the VERY FIRST content
+in your response — even before any analysis or comments. Replace each field with your actual
+verdict, summary, and list of issues:
 
 %s
 
-Where:
-- verdict is one of: "approve", "reject", "request_changes"
-- summary is a one-line summary of your review
-- issues is an array of specific issues found (empty array if approving)
+Fields:
+- verdict: one of "approve", "reject", or "request_changes" (required — do not copy the example value)
+- summary: a one-line summary of your overall review finding
+- issues: array of specific problems found; use [] when approving
 
 ## Verdict Meanings
 
@@ -240,7 +247,7 @@ After outputting the JSON verdict above, review the following git diff:
 
 %s
 %s`,
-		"```json\n{\"verdict\": \"approve|reject|request_changes\", \"summary\": \"...\", \"issues\": [{\"file\": \"path\", \"line\": 0, \"severity\": \"error|warning|suggestion\", \"message\": \"...\"}]}\n```",
+		"Use the following JSON format, replacing each field with your actual verdict, summary, and issues:\n\n```json\n{\"verdict\": \"request_changes\", \"summary\": \"\", \"issues\": []}\n```\n\nSet `verdict` to one of: `approve`, `reject`, `request_changes`.",
 		beadID,
 		"```diff\n"+truncateDiff(diff, 50000)+"\n```",
 		conditionalSection("## Repository Guidelines (AGENTS.md)", agentsMD),


### PR DESCRIPTION
## Problem

The warden was configured with `--max-turns 3 --tools ""`. The `--tools ""` flag does not reliably disable tool use (confirmed in logs: `turns=4 subtype=error_max_turns hasVerdict=False`). Claude spends its turns on file reads, hits the turn limit, and the result event's `result` field is empty. `parseVerdict` finds no verdict and defaults to "Could not parse structured verdict; defaulting to request_changes".

## Root Cause

1. `--tools ""` does not consistently disable tools — Claude uses file reads anyway
2. `--max-turns 3` is too tight, leaving no room for Claude to output the verdict after tool calls

## Fix

1. **Remove `--tools ""`** (unreliable) and **raise max-turns from 3 to 5**
2. **Restructure `buildReviewPrompt`** to instruct Claude to emit the verdict JSON block **FIRST** before any analysis — so even truncated runs are parseable
