### PR TITLE
feat: store log path in DB so Hearth activity panel shows live output (Forge-fv5)

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -167,6 +167,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 				return outcome
 			}
 			_ = p.DB.UpdateWorkerPID(workerID, process.PID)
+			_ = p.DB.UpdateWorkerLogPath(workerID, process.LogPath)
 			smithResult = process.Wait()
 
 			// A process that exits 0, or produces a genuine success result event


### PR DESCRIPTION
When a Smith worker is spawned the log file path is now written to the workers table immediately after the process starts. This allows the Hearth activity panel to read and tail the log file for live output.

**Bead**: Forge-fv5