### PR TITLE
fix: use 'approve' as example verdict in warden prompt to prevent string-scan false positives

### DIFF
--- a/internal/warden/warden.go
+++ b/internal/warden/warden.go
@@ -256,7 +256,7 @@ After outputting the JSON verdict above, review the following git diff:
 
 %s
 %s`,
-		"Use the following JSON format, replacing each field with your actual verdict, summary, and issues:\n\n```json\n{\"verdict\": \"request_changes\", \"summary\": \"\", \"issues\": []}\n```\n\nSet `verdict` to one of: `approve`, `reject`, `request_changes`.",
+		"Use the following JSON format, replacing each field with your actual verdict, summary, and issues:\n\n```json\n{\"verdict\": \"approve\", \"summary\": \"\", \"issues\": []}\n```\n\nSet `verdict` to one of: `approve`, `reject`, `request_changes`.",
 		beadID,
 		"```diff\n"+truncateDiff(diff, 50000)+"\n```",
 		conditionalSection("## Repository Guidelines (AGENTS.md)", agentsMD),


### PR DESCRIPTION
The warden prompt used `"verdict": "request_changes"` as the example JSON value. When the model echoes or quotes this template in its output and `extractJSON` fails to find clean JSON, the string scanner matches `"verdict":"request_changes"` and returns VerdictRequestChanges, burning an extra Smith iteration.

Changing the example to `"approve"` means an echoed template resolves to approve and goes to human review instead.

Follow-up to #36 (Forge-pax).