### PR TITLE
Hearth: Live Activity panel expands downward pushing other panels off screen (Forge-zx5)

### DIFF
--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -343,10 +343,8 @@ func (m *Model) renderWorkers(width, height int) string {
 	top := m.renderWorkerList(width, listHeight)
 	bottom := m.renderWorkerActivity(width, activityHeight)
 	combined := lipgloss.JoinVertical(lipgloss.Left, top, bottom)
-	// Hard-clamp output height to prevent any overflow from pushing
-	// sibling panels off screen; keep within the same height budget
-	// used by other columns.
-	return lipgloss.NewStyle().MaxHeight(height).Render(combined)
+
+	return combined
 }
 
 // renderWorkerList renders the top sub-panel: the list of active workers.

--- a/internal/hearth/hearth_test.go
+++ b/internal/hearth/hearth_test.go
@@ -75,8 +75,8 @@ func TestRenderWorkersDoesNotExceedSinglePanel(t *testing.T) {
 	queueLines := strings.Count(strings.TrimRight(queuePanel, "\n"), "\n") + 1
 	workerLines := strings.Count(strings.TrimRight(workerPanel, "\n"), "\n") + 1
 
-	if workerLines > queueLines {
-		t.Errorf("renderWorkers produced %d lines, exceeding renderQueue's %d lines (contentHeight=%d)",
+	if workerLines != queueLines {
+		t.Errorf("renderWorkers produced %d lines, expected same as renderQueue's %d lines (contentHeight=%d)",
 			workerLines, queueLines, contentHeight)
 	}
 }


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Forge-zx5
**Branch**: forge/Forge-zx5

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*