### PR TITLE
Hearth: replace hard-coded event fetch limit 100 with a named constant (Forge-3fl)

### DIFF
--- a/internal/hearth/data.go
+++ b/internal/hearth/data.go
@@ -15,6 +15,9 @@ import (
 // TickInterval is how often the TUI refreshes data.
 const TickInterval = 2 * time.Second
 
+// EventFetchLimit is the maximum number of events retrieved for the Events panel.
+const EventFetchLimit = 100
+
 // TickMsg triggers a data refresh cycle.
 type TickMsg time.Time
 
@@ -291,7 +294,7 @@ func FetchAll(db *state.DB) tea.Cmd {
 	return tea.Batch(
 		FetchQueue(db),
 		FetchWorkers(db),
-		FetchEvents(db, 100),
+		FetchEvents(db, EventFetchLimit),
 	)
 }
 


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Forge-3fl
**Branch**: forge/Forge-3fl

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*