### PR TITLE
Bug: lifecycle NeedsFix flag shared between CI and review causes missed review fixes (Forge-uxg)

### DIFF
--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -390,6 +390,7 @@ func (m *Manager) NotifyReviewFixCompleted(anvil string, prNumber int) {
 	}
 	st.ReviewNeedsFix = false
 	dbID := st.ID
+	ciNeedsFix := st.CINeedsFix
 	m.mu.Unlock()
 
 	m.logger.Info("review fix cycle completed, cleared ReviewNeedsFix", "pr", prNumber, "anvil", anvil)
@@ -399,7 +400,13 @@ func (m *Manager) NotifyReviewFixCompleted(anvil string, prNumber int) {
 	// Use a conditional update that only transitions from needs_fix → open;
 	// this prevents overwriting a terminal status (merged/closed) if the PR
 	// was closed while the review-fix worker was still running.
-	if dbID > 0 {
+	//
+	// Only update when CI is not still failing: if CINeedsFix is set, the DB
+	// status must remain needs_fix so the CI failure is preserved across daemon
+	// restarts. Bellows only sets PRNeedsFix on a passing→failing transition, so
+	// clearing it here while CI is still failing would leave the DB permanently
+	// inconsistent (needs_fix would never be re-set while CI stays failing).
+	if dbID > 0 && !ciNeedsFix {
 		if err := m.db.UpdatePRStatusIfNeedsFix(dbID, state.PROpen); err != nil {
 			m.logger.Warn("failed to persist PROpen after review fix completed",
 				"pr", prNumber, "anvil", anvil, "error", err)

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -688,3 +688,47 @@ func TestCIAndReviewFixesAreIndependent(t *testing.T) {
 		t.Error("step 4: CINeedsFix should still be false")
 	}
 }
+
+// TestNotifyReviewFixCompleted_DoesNotClearCINeedsFixWhileFailing verifies that
+// completing a review fix does not clear a CI-related needs-fix state when CI
+// is still failing. This guards against regressions where NotifyReviewFixCompleted
+// would incorrectly clear CI-related flags or status.
+func TestNotifyReviewFixCompleted_DoesNotClearCINeedsFixWhileFailing(t *testing.T) {
+	db := newTestDB(t)
+	var dispatched []ActionRequest
+	handler := func(_ context.Context, req ActionRequest) {
+		dispatched = append(dispatched, req)
+	}
+	m := New(db, testLogger(), handler)
+	ctx := context.Background()
+
+	// Step 1: CI fails → sets CINeedsFix.
+	m.HandleEvent(ctx, makeEvent(200, bellows.EventCIFailed))
+	st := m.GetState("test-anvil", 200)
+	if !st.CINeedsFix {
+		t.Fatal("step 1: expected CINeedsFix=true after CI failure")
+	}
+
+	// Step 2: Review changes arrive while CI is still failing → sets ReviewNeedsFix.
+	dispatched = dispatched[:0]
+	m.HandleEvent(ctx, makeEvent(200, bellows.EventReviewChanges))
+	st = m.GetState("test-anvil", 200)
+	if !st.CINeedsFix {
+		t.Fatal("step 2: expected CINeedsFix to remain true while CI is still failing")
+	}
+	if !st.ReviewNeedsFix {
+		t.Fatal("step 2: expected ReviewNeedsFix=true after review changes")
+	}
+
+	// Step 3: Review fix completes while CI is still failing.
+	m.NotifyReviewFixCompleted("test-anvil", 200)
+	st = m.GetState("test-anvil", 200)
+
+	// ReviewNeedsFix should be cleared, but CINeedsFix must remain true.
+	if st.ReviewNeedsFix {
+		t.Error("step 3: ReviewNeedsFix should be false after NotifyReviewFixCompleted")
+	}
+	if !st.CINeedsFix {
+		t.Error("step 3: CINeedsFix must remain true while CI is still failing")
+	}
+}


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Forge-uxg
**Branch**: forge/Forge-uxg

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*