### PR TITLE
Bug: merged PR lingers in Ready to Merge panel until next bellows poll (up to 2 min) (Forge-y6m)

### DIFF
--- a/changelog.d/Forge-y6m.md
+++ b/changelog.d/Forge-y6m.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Merged PR no longer lingers in Ready to Merge panel** - After merging a PR via the TUI, the daemon now immediately updates the PR status to 'merged' and completes associated workers, removing it from the Ready to Merge panel instantly instead of waiting up to 2 minutes for the next bellows poll cycle. A bellows refresh is also triggered for prompt downstream cleanup. (Forge-y6m)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1706,6 +1706,15 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			fmt.Sprintf("PR #%d merged successfully (strategy: %s)", mergeNumber, strategy),
 			beadID, mergeAnvil)
 		d.logger.Info("PR merged successfully", "pr_number", mergeNumber, "anvil", mergeAnvil, "strategy", strategy)
+		// Immediately update PR status so it disappears from the Ready to Merge panel
+		// without waiting for the next bellows poll cycle (up to 2 minutes).
+		_ = d.db.UpdatePRStatus(pr.ID, state.PRMerged)
+		_ = d.db.CompleteWorkersByBead(beadID)
+		// Trigger an immediate bellows poll so downstream lifecycle effects
+		// (bead close, worktree cleanup) happen promptly.
+		if d.bellowsMonitor != nil {
+			d.bellowsMonitor.Refresh()
+		}
 		data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("PR #%d merged", mergeNumber)})
 		return ipc.Response{Type: "ok", Payload: data}
 


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Forge-y6m
**Branch**: forge/Forge-y6m

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*