### PR TITLE
feat: npm and NuGet dependency scanning (Forge-ftx, Forge-hja)

### DIFF
--- a/internal/depcheck/depcheck.go
+++ b/internal/depcheck/depcheck.go
@@ -107,9 +107,8 @@ func (s *Scanner) scanAnvil(ctx context.Context, name, path string) {
 		fn   func(ctx context.Context, anvil, path string) *CheckResult
 	}{
 		{"Go", s.scanGo},
-		// Future ecosystem scanners are added here:
-		// {"dotnet", s.scanDotnet},
-		// {"npm", s.scanNpm},
+		{"NuGet", s.scanDotnet},
+		{"npm", s.scanNpm},
 	}
 
 	for _, sc := range scanners {
@@ -189,8 +188,15 @@ func (s *Scanner) createUpdateBead(ctx context.Context, result *CheckResult, kin
 		desc.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n", update.Path, update.Current, update.Latest, update.Kind))
 		desc.WriteString("\n## Instructions\n\n")
 		desc.WriteString("```bash\n")
-		desc.WriteString(fmt.Sprintf("go get %s@%s\n", update.Path, update.Latest))
-		desc.WriteString("go mod tidy\n")
+		switch result.Ecosystem {
+		case "Go":
+			desc.WriteString(fmt.Sprintf("go get %s@%s\n", update.Path, update.Latest))
+			desc.WriteString("go mod tidy\n")
+		case "NuGet":
+			desc.WriteString(fmt.Sprintf("dotnet add package %s --version %s\n", update.Path, update.Latest))
+		case "npm":
+			desc.WriteString(fmt.Sprintf("npm install %s@%s\n", update.Path, update.Latest))
+		}
 		desc.WriteString("```\n")
 	case "major":
 		priority = "2"

--- a/internal/depcheck/dotnet.go
+++ b/internal/depcheck/dotnet.go
@@ -1,0 +1,193 @@
+package depcheck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/executil"
+)
+
+// scanDotnet runs 'dotnet list package --outdated --format json' in directories
+// containing *.csproj or *.sln files. Skips bin/obj directories.
+// Returns nil if no .NET project is found.
+func (s *Scanner) scanDotnet(ctx context.Context, anvil, path string) *CheckResult {
+	projectFiles := findDotnetProjects(path)
+	if len(projectFiles) == 0 {
+		return nil
+	}
+
+	result := &CheckResult{
+		Anvil:     anvil,
+		Path:      path,
+		Ecosystem: "NuGet",
+		Checked:   time.Now(),
+	}
+
+	for _, projFile := range projectFiles {
+		updates, err := runDotnetOutdated(ctx, s.timeout, filepath.Dir(projFile), projFile)
+		if err != nil {
+			result.Error = fmt.Errorf("dotnet list package in %s: %w", projFile, err)
+			return result
+		}
+
+		for _, u := range updates {
+			switch u.Kind {
+			case "patch":
+				result.Patch = append(result.Patch, u)
+			case "minor":
+				result.Minor = append(result.Minor, u)
+			case "major":
+				result.Major = append(result.Major, u)
+			}
+		}
+	}
+
+	return result
+}
+
+// findDotnetProjects walks the anvil directory for *.sln files first, then
+// *.csproj files. If a .sln is found, its directory's csproj files are skipped
+// (the sln covers them). Skips bin, obj, and .workers directories.
+func findDotnetProjects(root string) []string {
+	slnDirs := map[string]bool{}
+	var slnFiles []string
+	var csprojFiles []string
+
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "bin" || name == "obj" || name == ".workers" || name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if ext == ".sln" {
+			slnFiles = append(slnFiles, path)
+			slnDirs[filepath.Dir(path)] = true
+		} else if ext == ".csproj" {
+			csprojFiles = append(csprojFiles, path)
+		}
+		return nil
+	})
+
+	// Prefer sln files; only include csproj files not covered by a sln.
+	var result []string
+	result = append(result, slnFiles...)
+	for _, csproj := range csprojFiles {
+		dir := filepath.Dir(csproj)
+		covered := false
+		for slnDir := range slnDirs {
+			if strings.HasPrefix(dir, slnDir) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			result = append(result, csproj)
+		}
+	}
+
+	return result
+}
+
+// dotnetOutdatedResponse represents the JSON output of
+// 'dotnet list package --outdated --format json'.
+type dotnetOutdatedResponse struct {
+	Projects []dotnetProject `json:"projects"`
+}
+
+type dotnetProject struct {
+	Path       string              `json:"path"`
+	Frameworks []dotnetFramework   `json:"frameworks"`
+}
+
+type dotnetFramework struct {
+	Framework    string           `json:"framework"`
+	TopLevel     []dotnetPackage  `json:"topLevelPackages"`
+}
+
+type dotnetPackage struct {
+	ID              string `json:"id"`
+	ResolvedVersion string `json:"resolvedVersion"`
+	LatestVersion   string `json:"latestVersion"`
+}
+
+// runDotnetOutdated runs 'dotnet list <project> package --outdated --format json'
+// and parses the output.
+func runDotnetOutdated(ctx context.Context, timeout time.Duration, dir, projFile string) ([]ModuleUpdate, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx,
+		"dotnet", "list", projFile, "package", "--outdated", "--format", "json"))
+	cmd.Dir = dir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("dotnet list package: %w\nstderr: %s", err, stderr.String())
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	if output == "" {
+		return nil, nil
+	}
+
+	var resp dotnetOutdatedResponse
+	if err := json.Unmarshal([]byte(output), &resp); err != nil {
+		return nil, fmt.Errorf("parsing dotnet list package output: %w", err)
+	}
+
+	// Deduplicate across frameworks — same package may appear in multiple TFMs.
+	seen := map[string]bool{}
+	var updates []ModuleUpdate
+
+	for _, proj := range resp.Projects {
+		for _, fw := range proj.Frameworks {
+			for _, pkg := range fw.TopLevel {
+				if pkg.ResolvedVersion == "" || pkg.LatestVersion == "" {
+					continue
+				}
+				if pkg.ResolvedVersion == pkg.LatestVersion {
+					continue
+				}
+				if seen[pkg.ID] {
+					continue
+				}
+				seen[pkg.ID] = true
+
+				kind := classifyUpdate(pkg.ResolvedVersion, pkg.LatestVersion)
+				updates = append(updates, ModuleUpdate{
+					Path:    pkg.ID,
+					Current: pkg.ResolvedVersion,
+					Latest:  pkg.LatestVersion,
+					Kind:    kind,
+				})
+			}
+		}
+	}
+
+	order := map[string]int{"major": 0, "minor": 1, "patch": 2}
+	sort.Slice(updates, func(i, j int) bool {
+		if updates[i].Kind != updates[j].Kind {
+			return order[updates[i].Kind] < order[updates[j].Kind]
+		}
+		return updates[i].Path < updates[j].Path
+	})
+
+	return updates, nil
+}

--- a/internal/depcheck/dotnet_test.go
+++ b/internal/depcheck/dotnet_test.go
@@ -1,0 +1,58 @@
+package depcheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindDotnetProjects_SlnPreferred(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create solution file
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "MyApp.sln"), []byte(""), 0o644))
+
+	// Create csproj in subdirectory (covered by sln)
+	sub := filepath.Join(dir, "src", "MyApp")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "MyApp.csproj"), []byte(""), 0o644))
+
+	files := findDotnetProjects(dir)
+	// Should only return the sln, not the csproj under it
+	assert.Len(t, files, 1)
+	assert.Equal(t, filepath.Join(dir, "MyApp.sln"), files[0])
+}
+
+func TestFindDotnetProjects_CsprojOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create csproj without a sln
+	sub := filepath.Join(dir, "tools", "MyTool")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "MyTool.csproj"), []byte(""), 0o644))
+
+	files := findDotnetProjects(dir)
+	assert.Len(t, files, 1)
+	assert.Equal(t, filepath.Join(sub, "MyTool.csproj"), files[0])
+}
+
+func TestFindDotnetProjects_SkipsBinObj(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create csproj in bin (should be skipped)
+	bin := filepath.Join(dir, "bin", "Debug")
+	require.NoError(t, os.MkdirAll(bin, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bin, "App.csproj"), []byte(""), 0o644))
+
+	files := findDotnetProjects(dir)
+	assert.Empty(t, files)
+}
+
+func TestFindDotnetProjects_Empty(t *testing.T) {
+	dir := t.TempDir()
+	files := findDotnetProjects(dir)
+	assert.Empty(t, files)
+}

--- a/internal/depcheck/npm.go
+++ b/internal/depcheck/npm.go
@@ -1,0 +1,139 @@
+package depcheck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/executil"
+)
+
+// scanNpm runs 'npm outdated --json' in directories containing package.json.
+// Skips node_modules and .workers directories. Returns nil if no package.json found.
+func (s *Scanner) scanNpm(ctx context.Context, anvil, path string) *CheckResult {
+	pkgDirs := findNpmProjects(path)
+	if len(pkgDirs) == 0 {
+		return nil
+	}
+
+	result := &CheckResult{
+		Anvil:     anvil,
+		Path:      path,
+		Ecosystem: "npm",
+		Checked:   time.Now(),
+	}
+
+	for _, dir := range pkgDirs {
+		updates, err := runNpmOutdated(ctx, s.timeout, dir)
+		if err != nil {
+			result.Error = fmt.Errorf("npm outdated in %s: %w", dir, err)
+			return result
+		}
+
+		for _, u := range updates {
+			switch u.Kind {
+			case "patch":
+				result.Patch = append(result.Patch, u)
+			case "minor":
+				result.Minor = append(result.Minor, u)
+			case "major":
+				result.Major = append(result.Major, u)
+			}
+		}
+	}
+
+	return result
+}
+
+// findNpmProjects walks the anvil directory for package.json files,
+// skipping node_modules and .workers directories.
+func findNpmProjects(root string) []string {
+	var dirs []string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "node_modules" || name == ".workers" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "package.json" {
+			dirs = append(dirs, filepath.Dir(path))
+		}
+		return nil
+	})
+	return dirs
+}
+
+// npmOutdatedEntry represents a single entry from 'npm outdated --json'.
+type npmOutdatedEntry struct {
+	Current string `json:"current"`
+	Wanted  string `json:"wanted"`
+	Latest  string `json:"latest"`
+}
+
+// runNpmOutdated runs 'npm outdated --json' in the given directory and
+// parses the output into ModuleUpdate entries.
+func runNpmOutdated(ctx context.Context, timeout time.Duration, dir string) ([]ModuleUpdate, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "npm", "outdated", "--json"))
+	cmd.Dir = dir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	// npm outdated returns exit code 1 when outdated packages exist,
+	// so we ignore the error and check the output instead.
+	_ = cmd.Run()
+
+	output := strings.TrimSpace(stdout.String())
+	if output == "" || output == "{}" {
+		return nil, nil
+	}
+
+	var outdated map[string]npmOutdatedEntry
+	if err := json.Unmarshal([]byte(output), &outdated); err != nil {
+		return nil, fmt.Errorf("parsing npm outdated output: %w\nstderr: %s", err, stderr.String())
+	}
+
+	var updates []ModuleUpdate
+	for pkg, entry := range outdated {
+		if entry.Current == "" || entry.Latest == "" {
+			continue
+		}
+		if entry.Current == entry.Latest {
+			continue
+		}
+
+		kind := classifyUpdate(entry.Current, entry.Latest)
+		updates = append(updates, ModuleUpdate{
+			Path:    pkg,
+			Current: entry.Current,
+			Latest:  entry.Latest,
+			Kind:    kind,
+		})
+	}
+
+	order := map[string]int{"major": 0, "minor": 1, "patch": 2}
+	sort.Slice(updates, func(i, j int) bool {
+		if updates[i].Kind != updates[j].Kind {
+			return order[updates[i].Kind] < order[updates[j].Kind]
+		}
+		return updates[i].Path < updates[j].Path
+	})
+
+	return updates, nil
+}

--- a/internal/depcheck/npm_test.go
+++ b/internal/depcheck/npm_test.go
@@ -1,0 +1,38 @@
+package depcheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindNpmProjects(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create package.json in root
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+
+	// Create package.json in subdirectory
+	sub := filepath.Join(dir, "client")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "package.json"), []byte("{}"), 0o644))
+
+	// Create package.json inside node_modules (should be skipped)
+	nm := filepath.Join(dir, "node_modules", "foo")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nm, "package.json"), []byte("{}"), 0o644))
+
+	dirs := findNpmProjects(dir)
+	assert.Len(t, dirs, 2)
+	assert.Contains(t, dirs, dir)
+	assert.Contains(t, dirs, sub)
+}
+
+func TestFindNpmProjects_NoPackageJson(t *testing.T) {
+	dir := t.TempDir()
+	dirs := findNpmProjects(dir)
+	assert.Empty(t, dirs)
+}


### PR DESCRIPTION
## Summary
- Add npm dependency scanning (`npm outdated --json`) — Forge-ftx
- Add .NET/NuGet dependency scanning (`dotnet list package --outdated --format json`) — Forge-hja
- Wire both scanners into depcheck.ScanAll alongside Go
- Ecosystem-aware update instructions in bead descriptions

## Test plan
- [x] Unit tests for project discovery (npm, dotnet)
- [x] Full build passes
- [x] Existing depcheck tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)