### PR TITLE
Depcheck: log event when skipping duplicate dependency update (Forge-vgv)

### DIFF
--- a/changelog.d/Forge-vgv.md
+++ b/changelog.d/Forge-vgv.md
@@ -1,0 +1,2 @@
+category: Added
+- **Depcheck dedup event logging** - When depcheck skips creating a bead due to deduplication (existing open, in-progress, or recently closed bead), a `depcheck_dedup` event is now logged to the event table so operators can see why an update wasn't created in Hearth's event log. (Forge-vgv)

--- a/internal/depcheck/depcheck.go
+++ b/internal/depcheck/depcheck.go
@@ -231,6 +231,9 @@ func (s *Scanner) createBeads(ctx context.Context, result *CheckResult) {
 	for _, u := range append(result.Patch, result.Minor...) {
 		if DedupCheckWithCache(cache, u.Path) {
 			log.Printf("[depcheck] %s: bead/PR already exists for %s, skipping", result.Anvil, u.Path)
+			_ = s.db.LogEvent(state.EventDepcheckDedup,
+				fmt.Sprintf("Skipped duplicate %s dependency update for %s (%s → %s)", result.Ecosystem, u.Path, u.Current, u.Latest),
+				"", result.Anvil)
 			continue
 		}
 		s.createUpdateBead(ctx, result, "auto", u)
@@ -239,6 +242,9 @@ func (s *Scanner) createBeads(ctx context.Context, result *CheckResult) {
 	for _, u := range result.Major {
 		if DedupCheckWithCache(cache, u.Path) {
 			log.Printf("[depcheck] %s: bead/PR already exists for %s, skipping", result.Anvil, u.Path)
+			_ = s.db.LogEvent(state.EventDepcheckDedup,
+				fmt.Sprintf("Skipped duplicate %s dependency update for %s (%s → %s)", result.Ecosystem, u.Path, u.Current, u.Latest),
+				"", result.Anvil)
 			continue
 		}
 		s.createUpdateBead(ctx, result, "major", u)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1025,6 +1025,7 @@ const (
 	EventDepcheckFound        EventType = "depcheck_found"
 	EventDepcheckFailed       EventType = "depcheck_failed"
 	EventDepcheckBeadCreated  EventType = "depcheck_bead_created"
+	EventDepcheckDedup        EventType = "depcheck_dedup"
 	EventVulnScanStarted      EventType = "vuln_scan_started"
 	EventVulnScanDone         EventType = "vuln_scan_done"
 	EventVulnScanFailed       EventType = "vuln_scan_failed"


### PR DESCRIPTION
## Automated PR by The Forge

**Bead**: Forge-vgv
**Branch**: forge/Forge-vgv

This PR was generated by The Forge autonomous pipeline.
A Smith agent implemented the changes, Temper verified the build,
and Warden approved the code review.

---
*Generated by [The Forge](https://github.com/Robin831/Forge)*