### PR TITLE
Crucible: support parent-runs-first mode for beads with own work (Forge-cv0b)

### DIFF
--- a/changelog.d/Forge-cv0b.md
+++ b/changelog.d/Forge-cv0b.md
@@ -1,0 +1,2 @@
+category: Added
+- **Crucible parent-runs-first mode** - When a parent bead has its own implementation work (detected via schematic pre-analysis), the Crucible now runs the parent through the full pipeline before sequencing children, so children build on the parent's committed changes. (Forge-cv0b)

--- a/internal/crucible/crucible.go
+++ b/internal/crucible/crucible.go
@@ -65,6 +65,7 @@ type Params struct {
 	BeadClaimer        func(ctx context.Context, beadID, dir string) error
 	BeadCloser         func(ctx context.Context, beadID, dir string) error
 	EpicBranchCreator  func(ctx context.Context, dir, branch string) error
+	SchematicRunner    func(ctx context.Context, cfg schematic.Config, bead poller.Bead, anvilPath string, pv provider.Provider) *schematic.Result
 }
 
 // Status tracks the current state of a Crucible for monitoring.
@@ -72,7 +73,7 @@ type Status struct {
 	ParentID          string
 	Anvil             string
 	Branch            string
-	Phase             string // "started", "dispatching", "waiting", "final_pr", "complete", "paused"
+	Phase             string // "started", "parent", "dispatching", "waiting", "final_pr", "complete", "paused"
 	TotalChildren     int
 	CompletedChildren int
 	CurrentChild      string
@@ -110,16 +111,124 @@ func Run(ctx context.Context, p Params) *Result {
 		return &Result{Error: fmt.Errorf("creating feature branch: %w", err)}
 	}
 
+	// 1b. Run schematic on the parent bead to detect parent-has-work mode.
+	parentHasWork := false
+	if p.SchematicConfig != nil && len(p.Providers) > 0 {
+		schemResult := p.runSchematic(ctx, *p.SchematicConfig, p.ParentBead, anvilPath, p.Providers[0])
+		if schemResult != nil && schemResult.Action == schematic.ActionPlan {
+			parentHasWork = true
+			log.Info("parent bead has own work, running parent-first mode", "plan_len", len(schemResult.Plan))
+			p.emitEvent(state.EventCrucibleStarted,
+				fmt.Sprintf("Crucible %s: parent has implementation work, running parent-first", p.ParentBead.ID),
+				p.ParentBead.ID)
+
+			p.updateStatus(Status{
+				ParentID:  p.ParentBead.ID,
+				Anvil:     p.AnvilName,
+				Branch:    branch,
+				Phase:     "parent",
+				StartedAt: time.Now(),
+			})
+
+			// Run parent through the pipeline targeting the feature branch.
+			parentOutcome := p.runChildPipeline(ctx, p.ParentBead, branch)
+
+			if parentOutcome.NeedsHuman || parentOutcome.Error != nil || !parentOutcome.Success {
+				reason := "parent pipeline failed"
+				if parentOutcome.Error != nil {
+					reason = parentOutcome.Error.Error()
+				}
+				// NoDiff from parent is acceptable — continue to children.
+				if parentOutcome.ReviewResult != nil && parentOutcome.ReviewResult.NoDiff {
+					log.Info("parent pipeline produced no diff, continuing to children")
+					parentHasWork = false // no actual changes to merge
+				} else {
+					log.Error("parent pipeline failed", "reason", reason)
+					p.emitEvent(state.EventCruciblePaused,
+						fmt.Sprintf("Crucible %s paused: parent pipeline failed — %s", p.ParentBead.ID, reason),
+						p.ParentBead.ID)
+					p.updateStatus(Status{
+						ParentID: p.ParentBead.ID,
+						Anvil:    p.AnvilName,
+						Branch:   branch,
+						Phase:    "paused",
+					})
+					return &Result{
+						PausedChildID: p.ParentBead.ID,
+						Error:         fmt.Errorf("parent pipeline failed: %s", reason),
+					}
+				}
+			}
+
+			// If parent produced changes, create a PR and merge into the feature branch.
+			if parentHasWork && parentOutcome.Branch != "" {
+				var changeSummary string
+				if parentOutcome.ReviewResult != nil && parentOutcome.ReviewResult.Summary != "" {
+					changeSummary = parentOutcome.ReviewResult.Summary
+				}
+
+				pr, err := p.createPR(ctx, ghpr.CreateParams{
+					WorktreePath:    anvilPath,
+					BeadID:          p.ParentBead.ID,
+					Title:           fmt.Sprintf("%s (parent) (%s)", p.ParentBead.Title, p.ParentBead.ID),
+					Branch:          parentOutcome.Branch,
+					Base:            branch,
+					AnvilName:       p.AnvilName,
+					DB:              p.DB,
+					BeadTitle:       p.ParentBead.Title,
+					BeadDescription: p.ParentBead.Description,
+					BeadType:        p.ParentBead.IssueType,
+					ChangeSummary:   changeSummary,
+				})
+				if err != nil {
+					log.Error("failed to create parent PR", "error", err)
+					// Continue — the branch changes are still pushed.
+				} else if p.AutoMergeCrucibleChildren {
+					if err := p.mergePR(ctx, pr.Number, anvilPath); err != nil {
+						log.Error("failed to merge parent PR", "pr", pr.Number, "error", err)
+						p.emitEvent(state.EventCruciblePaused,
+							fmt.Sprintf("Crucible %s paused: parent PR #%d merge failed", p.ParentBead.ID, pr.Number),
+							p.ParentBead.ID)
+						p.updateStatus(Status{
+							ParentID: p.ParentBead.ID,
+							Anvil:    p.AnvilName,
+							Branch:   branch,
+							Phase:    "paused",
+						})
+						return &Result{
+							PausedChildID: p.ParentBead.ID,
+							Error:         fmt.Errorf("parent PR #%d merge failed: %w", pr.Number, err),
+						}
+					}
+					log.Info("parent work merged into feature branch", "pr", pr.Number)
+					p.emitEvent(state.EventCrucibleChildMerged,
+						fmt.Sprintf("Crucible %s: parent work merged into %s via PR #%d", p.ParentBead.ID, branch, pr.Number),
+						p.ParentBead.ID)
+				}
+			}
+		} else if schemResult != nil && schemResult.Action == schematic.ActionClarify {
+			log.Warn("parent bead needs clarification", "reason", schemResult.Reason)
+			p.emitEvent(state.EventCruciblePaused,
+				fmt.Sprintf("Crucible %s paused: parent needs clarification — %s", p.ParentBead.ID, schemResult.Reason),
+				p.ParentBead.ID)
+			return &Result{
+				PausedChildID: p.ParentBead.ID,
+				Error:         fmt.Errorf("parent needs clarification: %s", schemResult.Reason),
+			}
+		}
+	}
+
 	// 2. Fetch children.
 	children, err := p.fetchChildren(ctx, p.ParentBead.ID, anvilPath)
 	if err != nil {
 		return &Result{Error: fmt.Errorf("fetching children: %w", err)}
 	}
-	if len(children) == 0 {
-		log.Info("no children found, creating final PR directly")
-		// No children — create final PR from feature branch (which is identical to main).
-		// This is a no-op edge case; just return success.
+	if len(children) == 0 && !parentHasWork {
+		log.Info("no children found and no parent work, nothing to do")
 		return &Result{Success: true, ChildrenDone: 0, ChildrenTotal: 0}
+	}
+	if len(children) == 0 {
+		log.Info("no children found but parent has work, skipping to final PR")
 	}
 
 	// 3. Topological sort.
@@ -513,6 +622,14 @@ func unwrapJSONArray(data []byte) []byte {
 		}
 	}
 	return data
+}
+
+// runSchematic runs schematic analysis on a bead (or uses the injected SchematicRunner for testing).
+func (p *Params) runSchematic(ctx context.Context, cfg schematic.Config, bead poller.Bead, anvilPath string, pv provider.Provider) *schematic.Result {
+	if p.SchematicRunner != nil {
+		return p.SchematicRunner(ctx, cfg, bead, anvilPath, pv)
+	}
+	return schematic.Run(ctx, cfg, bead, anvilPath, pv)
 }
 
 // createPR creates a pull request (or uses the injected PRCreator for testing).

--- a/internal/crucible/crucible_test.go
+++ b/internal/crucible/crucible_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Robin831/Forge/internal/ghpr"
 	"github.com/Robin831/Forge/internal/pipeline"
 	"github.com/Robin831/Forge/internal/poller"
+	"github.com/Robin831/Forge/internal/provider"
+	"github.com/Robin831/Forge/internal/schematic"
 	"github.com/Robin831/Forge/internal/state"
 	"github.com/Robin831/Forge/internal/warden"
 )
@@ -390,6 +392,286 @@ func TestHasExternalBlockers(t *testing.T) {
 				t.Errorf("hasExternalBlockers() = %v, want %v", got, tt.expect)
 			}
 		})
+	}
+}
+
+func TestRun_ParentHasWork_RunsParentFirst(t *testing.T) {
+	db := testDB(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	var pipelineOrder []string
+	var createdPRs []ghpr.CreateParams
+	var mergedPRs []int
+	var closedBeads []string
+	prCounter := 0
+
+	schemCfg := &schematic.Config{Enabled: true, WordThreshold: 1}
+
+	p := Params{
+		DB:     db,
+		Logger: logger,
+		ParentBead: poller.Bead{
+			ID:          "parent-1",
+			Title:       "Parent with own work",
+			Description: "This parent has implementation work",
+		},
+		AnvilName:                "test-anvil",
+		AnvilConfig:              config.AnvilConfig{Path: t.TempDir()},
+		AutoMergeCrucibleChildren: true,
+		SchematicConfig:          schemCfg,
+		Providers:                []provider.Provider{{Kind: "claude"}},
+
+		EpicBranchCreator: func(ctx context.Context, dir, branch string) error {
+			return nil
+		},
+
+		SchematicRunner: func(ctx context.Context, cfg schematic.Config, bead poller.Bead, anvilPath string, pv provider.Provider) *schematic.Result {
+			return &schematic.Result{
+				Action: schematic.ActionPlan,
+				Plan:   "Step 1: do parent work",
+			}
+		},
+
+		ChildFetcher: func(ctx context.Context, parentID, dir string) ([]poller.Bead, error) {
+			return []poller.Bead{
+				{ID: "child-1", Title: "Child task", DependsOn: []string{"parent-1"}},
+			}, nil
+		},
+
+		PipelineRunner: func(ctx context.Context, pp pipeline.Params) *pipeline.Outcome {
+			pipelineOrder = append(pipelineOrder, pp.Bead.ID)
+			return &pipeline.Outcome{
+				Success: true,
+				Branch:  fmt.Sprintf("forge/%s", pp.Bead.ID),
+			}
+		},
+
+		PRCreator: func(ctx context.Context, pp ghpr.CreateParams) (*ghpr.PR, error) {
+			prCounter++
+			createdPRs = append(createdPRs, pp)
+			return &ghpr.PR{Number: prCounter, URL: fmt.Sprintf("https://github.com/test/pr/%d", prCounter)}, nil
+		},
+
+		PRMerger: func(ctx context.Context, prNumber int, dir string) error {
+			mergedPRs = append(mergedPRs, prNumber)
+			return nil
+		},
+
+		BeadClaimer: func(ctx context.Context, beadID, dir string) error {
+			return nil
+		},
+
+		BeadCloser: func(ctx context.Context, beadID, dir string) error {
+			closedBeads = append(closedBeads, beadID)
+			return nil
+		},
+	}
+
+	result := Run(context.Background(), p)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+
+	// Parent should run BEFORE child.
+	if len(pipelineOrder) != 2 {
+		t.Fatalf("expected 2 pipeline runs, got %d: %v", len(pipelineOrder), pipelineOrder)
+	}
+	if pipelineOrder[0] != "parent-1" {
+		t.Errorf("expected parent-1 first, got %s", pipelineOrder[0])
+	}
+	if pipelineOrder[1] != "child-1" {
+		t.Errorf("expected child-1 second, got %s", pipelineOrder[1])
+	}
+
+	// PRs: parent PR (against feature branch) + child PR (against feature branch) + final PR
+	if len(createdPRs) != 3 {
+		t.Fatalf("expected 3 PRs, got %d", len(createdPRs))
+	}
+	// Parent PR targets feature branch.
+	if createdPRs[0].Base != "feature/parent-1" {
+		t.Errorf("parent PR base should be feature/parent-1, got %s", createdPRs[0].Base)
+	}
+	// Child PR targets feature branch.
+	if createdPRs[1].Base != "feature/parent-1" {
+		t.Errorf("child PR base should be feature/parent-1, got %s", createdPRs[1].Base)
+	}
+	// Final PR targets main.
+	if createdPRs[2].Base != "" {
+		t.Errorf("final PR base should be empty (main), got %s", createdPRs[2].Base)
+	}
+
+	// Both parent and child PRs should be merged, plus final is not merged by crucible.
+	if len(mergedPRs) != 2 {
+		t.Errorf("expected 2 merged PRs (parent + child), got %d", len(mergedPRs))
+	}
+}
+
+func TestRun_SchematicSkip_OrchestratorOnly(t *testing.T) {
+	db := testDB(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	var pipelineOrder []string
+	prCounter := 0
+	schemCfg := &schematic.Config{Enabled: true, WordThreshold: 1}
+
+	p := Params{
+		DB:     db,
+		Logger: logger,
+		ParentBead: poller.Bead{
+			ID:          "parent-1",
+			Title:       "Pure orchestrator",
+			Description: "This parent just coordinates children",
+		},
+		AnvilName:                "test-anvil",
+		AnvilConfig:              config.AnvilConfig{Path: t.TempDir()},
+		AutoMergeCrucibleChildren: true,
+		SchematicConfig:          schemCfg,
+		Providers:                []provider.Provider{{Kind: "claude"}},
+
+		EpicBranchCreator: func(ctx context.Context, dir, branch string) error {
+			return nil
+		},
+
+		SchematicRunner: func(ctx context.Context, cfg schematic.Config, bead poller.Bead, anvilPath string, pv provider.Provider) *schematic.Result {
+			return &schematic.Result{
+				Action: schematic.ActionSkip,
+				Reason: "Simple orchestration bead",
+			}
+		},
+
+		ChildFetcher: func(ctx context.Context, parentID, dir string) ([]poller.Bead, error) {
+			return []poller.Bead{
+				{ID: "child-1", Title: "Child task", DependsOn: []string{"parent-1"}},
+			}, nil
+		},
+
+		PipelineRunner: func(ctx context.Context, pp pipeline.Params) *pipeline.Outcome {
+			pipelineOrder = append(pipelineOrder, pp.Bead.ID)
+			return &pipeline.Outcome{
+				Success: true,
+				Branch:  fmt.Sprintf("forge/%s", pp.Bead.ID),
+			}
+		},
+
+		PRCreator: func(ctx context.Context, pp ghpr.CreateParams) (*ghpr.PR, error) {
+			prCounter++
+			return &ghpr.PR{Number: prCounter}, nil
+		},
+
+		PRMerger: func(ctx context.Context, prNumber int, dir string) error {
+			return nil
+		},
+
+		BeadClaimer: func(ctx context.Context, beadID, dir string) error {
+			return nil
+		},
+
+		BeadCloser: func(ctx context.Context, beadID, dir string) error {
+			return nil
+		},
+	}
+
+	result := Run(context.Background(), p)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+
+	// Only child should run through pipeline (no parent pipeline run).
+	if len(pipelineOrder) != 1 {
+		t.Fatalf("expected 1 pipeline run, got %d: %v", len(pipelineOrder), pipelineOrder)
+	}
+	if pipelineOrder[0] != "child-1" {
+		t.Errorf("expected child-1, got %s", pipelineOrder[0])
+	}
+}
+
+func TestRun_ParentHasWork_NoChildren_CreatesFinalPR(t *testing.T) {
+	db := testDB(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	var createdPRs []ghpr.CreateParams
+	prCounter := 0
+	schemCfg := &schematic.Config{Enabled: true, WordThreshold: 1}
+
+	p := Params{
+		DB:     db,
+		Logger: logger,
+		ParentBead: poller.Bead{
+			ID:          "parent-1",
+			Title:       "Parent with work, no children",
+			Description: "This parent has work but no children to orchestrate",
+		},
+		AnvilName:                "test-anvil",
+		AnvilConfig:              config.AnvilConfig{Path: t.TempDir()},
+		AutoMergeCrucibleChildren: true,
+		SchematicConfig:          schemCfg,
+		Providers:                []provider.Provider{{Kind: "claude"}},
+
+		EpicBranchCreator: func(ctx context.Context, dir, branch string) error {
+			return nil
+		},
+
+		SchematicRunner: func(ctx context.Context, cfg schematic.Config, bead poller.Bead, anvilPath string, pv provider.Provider) *schematic.Result {
+			return &schematic.Result{
+				Action: schematic.ActionPlan,
+				Plan:   "Step 1: do parent work",
+			}
+		},
+
+		ChildFetcher: func(ctx context.Context, parentID, dir string) ([]poller.Bead, error) {
+			return nil, nil // No children
+		},
+
+		PipelineRunner: func(ctx context.Context, pp pipeline.Params) *pipeline.Outcome {
+			return &pipeline.Outcome{
+				Success: true,
+				Branch:  "forge/parent-1",
+			}
+		},
+
+		PRCreator: func(ctx context.Context, pp ghpr.CreateParams) (*ghpr.PR, error) {
+			prCounter++
+			createdPRs = append(createdPRs, pp)
+			return &ghpr.PR{Number: prCounter}, nil
+		},
+
+		PRMerger: func(ctx context.Context, prNumber int, dir string) error {
+			return nil
+		},
+
+		BeadClaimer: func(ctx context.Context, beadID, dir string) error {
+			return nil
+		},
+
+		BeadCloser: func(ctx context.Context, beadID, dir string) error {
+			return nil
+		},
+	}
+
+	result := Run(context.Background(), p)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if !result.Success {
+		t.Fatal("expected success")
+	}
+
+	// Should have parent PR (merged to feature branch) + final PR (feature → main).
+	if len(createdPRs) != 2 {
+		t.Fatalf("expected 2 PRs (parent + final), got %d", len(createdPRs))
+	}
+	// Final PR targets main.
+	if createdPRs[1].Base != "" {
+		t.Errorf("final PR base should be empty (main), got %s", createdPRs[1].Base)
 	}
 }
 

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -136,7 +136,7 @@ type CrucibleItem struct {
 	ParentTitle       string
 	Anvil             string
 	Branch            string
-	Phase             string // "started", "dispatching", "waiting", "final_pr", "complete", "paused"
+	Phase             string // "started", "parent", "dispatching", "waiting", "final_pr", "complete", "paused"
 	TotalChildren     int
 	CompletedChildren int
 	CurrentChild      string
@@ -1477,6 +1477,8 @@ func (m *Model) renderLeftColumn(width, topHeight, bottomHeight int) string {
 // cruciblePhaseStyle returns a styled phase label for Crucible status display.
 func cruciblePhaseStyle(phase string) string {
 	switch phase {
+	case "parent":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("⚙ PARENT")
 	case "dispatching":
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Render("▶ DISPATCH")
 	case "final_pr":


### PR DESCRIPTION
## feature: Crucible: support parent-runs-first mode for beads with own work

Currently the Crucible treats the parent bead as a pure orchestrator — it creates a feature branch, sequences children through the pipeline, and closes the parent when done. But some parent beads have their own implementation work that children depend on.

The Crucible should support both modes:
1. **Parent-has-work**: Run the parent bead through the full pipeline (smith → temper → warden) on the feature branch FIRST, commit its changes, then sequence children on top. Each child builds on the parent's work.
2. **Orchestrator-only** (current behavior): Parent is just a container/coordinator. Only children get smith runs.

**Detection approach**: Run the parent through schematic before starting children. If schematic returns 'plan' (substantive work exists), execute parent-runs-first mode. If schematic returns 'skip' or 'decompose', use the current orchestrator-only flow. This leverages existing infrastructure without needing labels or type conventions.

**Implementation notes**:
- In crucible.Run(), after creating the feature branch, run schematic on the parent bead
- If plan returned: run parent through pipeline on the feature branch, commit results
- Then proceed with children as normal (they'll build on parent's committed work)
- Update crucible status/panel to reflect parent phase (e.g. 'parent' before '1/N children')

## Changes

Well-structured parent-runs-first mode with good test coverage and proper error handling

---
Bead: Forge-cv0b | Branch: forge/Forge-cv0b
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)