### PR TITLE
Bug: crucible child failure causes orphan recovery loop and standalone dispatch (Forge-flf0)

### DIFF
--- a/changelog.d/Forge-flf0.md
+++ b/changelog.d/Forge-flf0.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Crucible child failure no longer causes orphan recovery loop** - When a crucible child fails, the child bead is now reset to open and marked needs_human so orphan recovery won't pick it up and dispatch it as a standalone bead outside crucible context. (Forge-flf0)

--- a/internal/crucible/crucible.go
+++ b/internal/crucible/crucible.go
@@ -64,6 +64,7 @@ type Params struct {
 	PRMerger           func(ctx context.Context, prNumber int, dir string) error
 	BeadClaimer        func(ctx context.Context, beadID, dir string) error
 	BeadCloser         func(ctx context.Context, beadID, dir string) error
+	BeadResetter       func(ctx context.Context, beadID, dir string) error
 	EpicBranchCreator  func(ctx context.Context, dir, branch string) error
 }
 
@@ -216,6 +217,15 @@ func Run(ctx context.Context, p Params) *Result {
 				reason = childResult.Error.Error()
 			}
 			log.Error("crucible child failed", "child", child.ID, "reason", reason)
+
+			// Reset the child bead to open so orphan recovery doesn't pick it up,
+			// then mark it needs_human in state.db so the poller won't re-dispatch
+			// it as a standalone bead outside crucible context.
+			if err := p.resetBead(ctx, child.ID, anvilPath); err != nil {
+				log.Warn("failed to reset failed child bead to open", "child", child.ID, "error", err)
+			}
+			p.markChildNeedsHuman(child.ID, reason)
+
 			p.emitEvent(state.EventCrucibleChildFailed,
 				fmt.Sprintf("Crucible %s: child %s failed — %s", p.ParentBead.ID, child.ID, reason),
 				child.ID)
@@ -627,6 +637,37 @@ func (p *Params) closeBead(ctx context.Context, beadID, dir string) error {
 		return fmt.Errorf("bd close %s: %w: %s", beadID, err, out)
 	}
 	return nil
+}
+
+// resetBead resets a bead back to open status.
+func (p *Params) resetBead(ctx context.Context, beadID, dir string) error {
+	if p.BeadResetter != nil {
+		return p.BeadResetter(ctx, beadID, dir)
+	}
+	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "update", beadID, "--status=open", "--json"))
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd update %s --status=open: %w: %s", beadID, err, out)
+	}
+	return nil
+}
+
+// markChildNeedsHuman marks a failed crucible child as needs_human in the
+// state DB so the poller won't dispatch it as a standalone bead.
+func (p *Params) markChildNeedsHuman(beadID, reason string) {
+	if p.DB == nil {
+		return
+	}
+	_ = p.DB.UpsertRetry(&state.RetryRecord{
+		BeadID:     beadID,
+		Anvil:      p.AnvilName,
+		NeedsHuman: true,
+		LastError:  fmt.Sprintf("crucible child failed: %s", reason),
+	})
 }
 
 // createEpicBranch creates the feature branch, using the injected creator if set.

--- a/internal/crucible/crucible_test.go
+++ b/internal/crucible/crucible_test.go
@@ -174,6 +174,8 @@ func TestRun_ChildPipelineFailure_Pauses(t *testing.T) {
 	db := testDB(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
+	var resetBeads []string
+
 	p := Params{
 		DB:     db,
 		Logger: logger,
@@ -204,6 +206,11 @@ func TestRun_ChildPipelineFailure_Pauses(t *testing.T) {
 		BeadClaimer: func(ctx context.Context, beadID, dir string) error {
 			return nil
 		},
+
+		BeadResetter: func(ctx context.Context, beadID, dir string) error {
+			resetBeads = append(resetBeads, beadID)
+			return nil
+		},
 	}
 
 	result := Run(context.Background(), p)
@@ -213,6 +220,26 @@ func TestRun_ChildPipelineFailure_Pauses(t *testing.T) {
 	}
 	if result.PausedChildID != "child-1" {
 		t.Errorf("expected paused child to be child-1, got %q", result.PausedChildID)
+	}
+
+	// Verify child bead was reset to open.
+	if len(resetBeads) != 1 || resetBeads[0] != "child-1" {
+		t.Errorf("expected child-1 to be reset, got %v", resetBeads)
+	}
+
+	// Verify child bead is marked needs_human in state DB.
+	retry, err := db.GetRetry("child-1", "test-anvil")
+	if err != nil {
+		t.Fatalf("failed to get retry record: %v", err)
+	}
+	if retry == nil {
+		t.Fatal("expected retry record for child-1, got nil")
+	}
+	if !retry.NeedsHuman {
+		t.Error("expected child-1 to be marked needs_human")
+	}
+	if retry.LastError == "" {
+		t.Error("expected last_error to contain failure reason")
 	}
 }
 


### PR DESCRIPTION
## bug: Bug: crucible child failure causes orphan recovery loop and standalone dispatch

When a crucible child fails (e.g. warden rejects after max iterations), the crucible returns with an error but leaves the child bead in_progress with no active worker. Orphan recovery then resets it to open, and the poller dispatches it as a standalone bead outside the crucible context. The child should either be marked needs_human or properly reset by the crucible itself so orphan recovery doesnt pick it up. See Forge event log: crucible_child_failed then bead_recovered 2 minutes later.

## Changes

Clean fix for crucible child failure orphan recovery loop — resets failed child to open and marks needs_human with adequate test coverage

---
Bead: Forge-flf0 | Branch: forge/Forge-flf0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)