### PR TITLE
forge: learn 1 warden rule(s) from PR #175 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -329,3 +329,9 @@ rules:
       check: Verify that skip/no-op events include all relevant identifiers (bead ID, anvil name) so they are traceable in dashboards and logs. When the skip is caused by upstream failures (e.g., all distillation calls errored), track the failure count and either include it in the skip message or emit a dedicated error event instead of silently skipping.
       source: copilot:PR#171
       added: "2026-03-10"
+    - id: test-exercises-described-scenario
+      category: testing
+      pattern: Test function name describes a specific scenario (e.g. narrow width, negative index, empty input) but the test setup does not actually produce that condition due to hardcoded values or internal logic
+      check: Verify that the test setup actually triggers the scenario described in the test name. If the code under test uses fixed/hardcoded values that ignore the test's input, either refactor the code to accept the relevant parameter or adjust the test to exercise the real code path.
+      source: copilot:PR#175
+      added: "2026-03-11"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #175.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*