### PR TITLE
forge: learn 1 warden rule(s) from PR #186 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -353,3 +353,9 @@ rules:
       check: Verify that doc comments accurately describe the exact conditions handled by the code. If the code uses <= 0 but the comment says 'when zero', update the comment to say 'when zero or negative' (or tighten the condition to match the comment).
       source: copilot:PR#178
       added: "2026-03-11"
+    - id: cross-repo-token-permissions
+      category: security
+      pattern: CI/CD configuration publishes artifacts to external repositories (e.g., Scoop buckets, Homebrew taps, package registries in separate repos)
+      check: Verify that the workflow provides a token with write access to the target repository. The default GITHUB_TOKEN is scoped to the current repo only and cannot push to external repos — a dedicated PAT or fine-grained token with appropriate permissions must be configured.
+      source: copilot:PR#186
+      added: "2026-03-11"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #186.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*