### PR TITLE
Hearth: add toast notifications with Bubbles timer (Forge-xp95)

### DIFF
--- a/changelog.d/Forge-xp95.md
+++ b/changelog.d/Forge-xp95.md
@@ -1,2 +1,2 @@
 category: Added
-- **Toast notifications in Hearth TUI** - Transient toast messages now appear at the bottom of the dashboard for key events: PR created, PR merged, bead closed, warden review passed, smith failure, PR merge failure, lifecycle exhausted, and crucible complete. Toasts auto-dismiss after 4 seconds using a Bubbletea timer and stack up to 3 at once. (Forge-xp95)
+- **Toast notifications in Hearth TUI** - Transient toast messages now appear at the bottom of the dashboard for key events: PR created, PR merged, bead closed, warden review passed, smith failure, PR merge failure, lifecycle exhausted, and crucible complete. Toasts auto-dismiss after 4 seconds using `tea.Tick` and stack up to 3 at once. (Forge-xp95)

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -698,10 +698,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if tmsg, isError, ok := toastForEvent(ev); ok {
 					t := toast{id: m.nextToastID, message: tmsg, isError: isError}
 					m.nextToastID++
-					// Prepend so newest appears first; cap at maxToasts.
-					m.toasts = append([]toast{t}, m.toasts...)
+					// Append so newest is last (closest to footer); cap at maxToasts by dropping oldest.
+					m.toasts = append(m.toasts, t)
 					if len(m.toasts) > maxToasts {
-						m.toasts = m.toasts[:maxToasts]
+						m.toasts = m.toasts[1:]
 					}
 					toastCmds = append(toastCmds, scheduleToastDismiss(t.id))
 				}
@@ -2631,33 +2631,10 @@ func visualToRuneIndex(s string, col int) int {
 	return i
 }
 
-// placeOverlay centers the overlay string on top of the background string.
-func placeOverlay(width, height int, overlay, background string) string {
-	overlayLines := strings.Split(overlay, "\n")
-	bgLines := strings.Split(background, "\n")
-
-	// Ensure background has enough lines
-	for len(bgLines) < height {
-		bgLines = append(bgLines, "")
-	}
-
-	overlayHeight := len(overlayLines)
-	overlayWidth := 0
-	for _, l := range overlayLines {
-		if w := lipgloss.Width(l); w > overlayWidth {
-			overlayWidth = w
-		}
-	}
-
-	startY := (height - overlayHeight) / 2
-	startX := (width - overlayWidth) / 2
-	if startY < 0 {
-		startY = 0
-	}
-	if startX < 0 {
-		startX = 0
-	}
-
+// placeOverlayAt composites overlayLines onto bgLines at position (startX, startY).
+// It is the shared ANSI-safe implementation used by placeOverlay and placeToastsOverlay,
+// preventing the two callers from drifting apart over time.
+func placeOverlayAt(startX, startY, overlayWidth int, overlayLines, bgLines []string) {
 	for i, overlayLine := range overlayLines {
 		bgIdx := startY + i
 		if bgIdx >= len(bgLines) {
@@ -2690,7 +2667,36 @@ func placeOverlay(width, height int, overlay, background string) string {
 		}
 		bgLines[bgIdx] = string(result)
 	}
+}
 
+// placeOverlay centers the overlay string on top of the background string.
+func placeOverlay(width, height int, overlay, background string) string {
+	overlayLines := strings.Split(overlay, "\n")
+	bgLines := strings.Split(background, "\n")
+
+	// Ensure background has enough lines
+	for len(bgLines) < height {
+		bgLines = append(bgLines, "")
+	}
+
+	overlayHeight := len(overlayLines)
+	overlayWidth := 0
+	for _, l := range overlayLines {
+		if w := lipgloss.Width(l); w > overlayWidth {
+			overlayWidth = w
+		}
+	}
+
+	startY := (height - overlayHeight) / 2
+	startX := (width - overlayWidth) / 2
+	if startY < 0 {
+		startY = 0
+	}
+	if startX < 0 {
+		startX = 0
+	}
+
+	placeOverlayAt(startX, startY, overlayWidth, overlayLines, bgLines)
 	return strings.Join(bgLines[:height], "\n")
 }
 

--- a/internal/hearth/toast.go
+++ b/internal/hearth/toast.go
@@ -96,16 +96,15 @@ func (m *Model) renderToasts() string {
 // toastEventKey returns a fingerprint string for an EventItem, used to detect
 // which events are new since the last poll cycle.
 func toastEventKey(ev EventItem) string {
-	return ev.Timestamp + "\x00" + ev.Type + "\x00" + ev.Message
+	return ev.Timestamp + "\x00" + ev.Type + "\x00" + ev.BeadID + "\x00" + ev.Message
 }
 
 // toastForEvent returns the toast message, error flag, and true if the event
 // type warrants a toast notification. Returns ("", false, false) otherwise.
 func toastForEvent(ev EventItem) (message string, isError bool, ok bool) {
+	// Use the first line of the event message as the primary display value.
+	// Event-specific synthesized fallbacks (e.g. "bd-55 closed") are used when msg is empty.
 	msg := ev.Message
-	if msg == "" {
-		msg = ev.BeadID
-	}
 	// Trim to first line only — event messages can include multi-line details.
 	if nl := strings.IndexByte(msg, '\n'); nl != -1 {
 		msg = msg[:nl]
@@ -158,6 +157,7 @@ func firstOf(s, fallback string) string {
 
 // placeToastsOverlay places the overlay string at the bottom-center of the
 // background, positioned just above the footer (last footerH rows).
+// It delegates the ANSI-safe line compositing to placeOverlayAt.
 func placeToastsOverlay(width, height, footerH int, overlay, background string) string {
 	overlayLines := strings.Split(overlay, "\n")
 	bgLines := strings.Split(background, "\n")
@@ -183,28 +183,6 @@ func placeToastsOverlay(width, height, footerH int, overlay, background string) 
 		startX = 0
 	}
 
-	for i, overlayLine := range overlayLines {
-		bgIdx := startY + i
-		if bgIdx >= len(bgLines) {
-			break
-		}
-		bgLine := bgLines[bgIdx]
-		bgRunes := []rune(bgLine)
-		olRunes := []rune(overlayLine)
-
-		bgCutStart := visualToRuneIndex(bgLine, startX)
-		var result []rune
-		result = append(result, bgRunes[:bgCutStart]...)
-		for lipgloss.Width(string(result)) < startX {
-			result = append(result, ' ')
-		}
-		result = append(result, olRunes...)
-		bgCutEnd := visualToRuneIndex(bgLine, startX+overlayWidth)
-		if bgCutEnd < len(bgRunes) {
-			result = append(result, bgRunes[bgCutEnd:]...)
-		}
-		bgLines[bgIdx] = string(result)
-	}
-
+	placeOverlayAt(startX, startY, overlayWidth, overlayLines, bgLines)
 	return strings.Join(bgLines[:height], "\n")
 }

--- a/internal/hearth/toast_test.go
+++ b/internal/hearth/toast_test.go
@@ -112,9 +112,9 @@ func TestRenderToasts_MultipleToasts(t *testing.T) {
 	}
 }
 
-// TestRenderToasts_WideCharNoParticle verifies that a wide-character message
+// TestRenderToasts_WideCharNoPanic verifies that a wide-character message
 // does not cause a panic and is truncated to fit within toastMaxWidth.
-func TestRenderToasts_WideCharNoParticle(t *testing.T) {
+func TestRenderToasts_WideCharNoPanic(t *testing.T) {
 	// 35 CJK chars = visual width 70 > toastMaxWidth (60).
 	// Previous code would panic slicing []rune(text)[:57] on a 35-rune slice.
 	msg := strings.Repeat("漢", 35)
@@ -182,7 +182,8 @@ func TestToastForEvent_PRMerged(t *testing.T) {
 	}
 }
 
-// TestToastForEvent_BeadClosed verifies bead_closed event uses BeadID fallback.
+// TestToastForEvent_BeadClosed verifies bead_closed event uses synthesized fallback
+// "bd-55 closed" (not just the raw BeadID) when Message is empty.
 func TestToastForEvent_BeadClosed(t *testing.T) {
 	ev := EventItem{Type: "bead_closed", BeadID: "bd-55", Message: ""}
 	msg, isError, ok := toastForEvent(ev)
@@ -192,8 +193,8 @@ func TestToastForEvent_BeadClosed(t *testing.T) {
 	if isError {
 		t.Error("expected isError=false for bead_closed")
 	}
-	if !strings.Contains(msg, "bd-55") {
-		t.Errorf("expected BeadID in message, got %q", msg)
+	if !strings.Contains(msg, "bd-55 closed") {
+		t.Errorf("expected synthesized fallback 'bd-55 closed' in message, got %q", msg)
 	}
 }
 
@@ -209,7 +210,8 @@ func TestToastForEvent_SmithFailed(t *testing.T) {
 	}
 }
 
-// TestToastForEvent_LifecycleExhausted verifies lifecycle_exhausted is an error toast.
+// TestToastForEvent_LifecycleExhausted verifies lifecycle_exhausted is an error toast
+// with synthesized fallback "bd-7 needs attention" (not just the raw BeadID).
 func TestToastForEvent_LifecycleExhausted(t *testing.T) {
 	ev := EventItem{Type: "lifecycle_exhausted", BeadID: "bd-7", Message: ""}
 	msg, isError, ok := toastForEvent(ev)
@@ -219,8 +221,8 @@ func TestToastForEvent_LifecycleExhausted(t *testing.T) {
 	if !isError {
 		t.Error("expected isError=true for lifecycle_exhausted")
 	}
-	if !strings.Contains(msg, "bd-7") {
-		t.Errorf("expected BeadID in message, got %q", msg)
+	if !strings.Contains(msg, "bd-7 needs attention") {
+		t.Errorf("expected synthesized fallback 'bd-7 needs attention' in message, got %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Changes

Toast notification implementation is correct, rune-safe, well-tested, and follows Hearth conventions.

## Original Issue (feature): Hearth: add toast notifications with Bubbles timer

Show temporary toast-style notifications at the bottom of the TUI for transient events (worker completed, PR merged, bead closed) using a bubbles timer for auto-dismiss after 3-5 seconds. Currently these events only appear in the scrolling Events panel where they can be missed. Toasts surface the important ones prominently.

---
Bead: Forge-xp95 | Branch: forge/Forge-xp95
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)