### PR TITLE
Hearth: press 'o' in Workers panel to view Smith log (Forge-x1bs)

### DIFF
--- a/changelog.d/Forge-x1bs.md
+++ b/changelog.d/Forge-x1bs.md
@@ -1,0 +1,2 @@
+category: Added
+- **View Smith log from the Workers panel** - Press `o` on a selected worker in the Workers panel to open that worker's log file in the full-screen viewport overlay. Previously log viewing was only accessible via the Needs Attention action menu. (Forge-x1bs)

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -11,6 +11,7 @@ package hearth
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -610,6 +611,25 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				w := m.workers[m.workerVP.cursor]
 				if m.OnKill != nil {
 					m.OnKill(w.ID, w.PID)
+				}
+			}
+
+		case "o":
+			// Open log viewer for the selected worker
+			if m.focused == PanelWorkers && len(m.workers) > 0 &&
+				m.workerVP.cursor < len(m.workers) {
+				w := m.workers[m.workerVP.cursor]
+				if w.LogPath == "" {
+					m.setStatus(fmt.Sprintf("No log file for %s", w.BeadID), false)
+				} else {
+					data, err := os.ReadFile(w.LogPath)
+					var content string
+					if err != nil {
+						content = fmt.Sprintf("(error reading log: %v)", err)
+					} else {
+						content = strings.TrimRight(string(data), "\n")
+					}
+					m.openLogViewer(fmt.Sprintf("Log: %s — %s", w.BeadID, w.LogPath), content)
 				}
 			}
 
@@ -1560,15 +1580,21 @@ func (m *Model) executeAction(choice ActionMenuChoice) tea.Cmd {
 				m.setStatus(fmt.Sprintf("No logs found for %s", bead.BeadID), false)
 				return nil
 			}
-			m.logViewerTitle = fmt.Sprintf("Logs: %s — %s", bead.BeadID, logPath)
-			m.logViewerEmpty = len(lines) == 0
-			vpWidth, vpHeight := m.logViewerDimensions()
-			m.logViewerVP = viewport.New(vpWidth, vpHeight)
-			m.logViewerVP.SetContent(strings.Join(lines, "\n"))
-			m.showLogViewer = true
+			m.openLogViewer(fmt.Sprintf("Log: %s — %s", bead.BeadID, logPath), strings.Join(lines, "\n"))
 		}
 	}
 	return nil
+}
+
+// openLogViewer initialises and displays the viewport log viewer overlay with
+// the given title and pre-joined content string.
+func (m *Model) openLogViewer(title, content string) {
+	m.logViewerTitle = title
+	m.logViewerEmpty = len(content) == 0
+	vpWidth, vpHeight := m.logViewerDimensions()
+	m.logViewerVP = viewport.New(vpWidth, vpHeight)
+	m.logViewerVP.SetContent(content)
+	m.showLogViewer = true
 }
 
 // removeNeedsAttentionItem removes the item with the given beadID and anvil from the

--- a/internal/hearth/hearth_test.go
+++ b/internal/hearth/hearth_test.go
@@ -2916,3 +2916,147 @@ func TestNotesOverlayView(t *testing.T) {
 		t.Errorf("view missing hint line:\n%s", view)
 	}
 }
+
+// ── Workers panel log viewer ('o' key) tests ────────────────────────────────
+
+func TestOpenLogViewerKeyO_WorkersPanel(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "forge-log-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("worker output line\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	m := Model{
+		focused: PanelWorkers,
+		workers: []WorkerItem{
+			{ID: "w1", BeadID: "bd-99", LogPath: f.Name()},
+		},
+	}
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	mm := m2.(*Model)
+	if !mm.showLogViewer {
+		t.Error("pressing 'o' with a valid worker log path should open the log viewer")
+	}
+	if !strings.Contains(mm.logViewerTitle, "bd-99") {
+		t.Errorf("log viewer title should contain bead ID, got %q", mm.logViewerTitle)
+	}
+	if !strings.Contains(mm.logViewerTitle, f.Name()) {
+		t.Errorf("log viewer title should contain log path, got %q", mm.logViewerTitle)
+	}
+	if mm.logViewerEmpty {
+		t.Error("log viewer should not be marked empty when file has content")
+	}
+}
+
+func TestOpenLogViewerKeyO_NoLogPath(t *testing.T) {
+	m := Model{
+		focused: PanelWorkers,
+		workers: []WorkerItem{
+			{ID: "w1", BeadID: "bd-42", LogPath: ""},
+		},
+	}
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	mm := m2.(*Model)
+	if mm.showLogViewer {
+		t.Error("pressing 'o' with no log path should not open the log viewer")
+	}
+	if mm.statusMsg == "" {
+		t.Error("pressing 'o' with no log path should set a status message")
+	}
+}
+
+func TestOpenLogViewerKeyO_EmptyLogFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "forge-log-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close() // empty file
+
+	m := Model{
+		focused: PanelWorkers,
+		workers: []WorkerItem{
+			{ID: "w1", BeadID: "bd-10", LogPath: f.Name()},
+		},
+	}
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	mm := m2.(*Model)
+	if !mm.showLogViewer {
+		t.Error("pressing 'o' on an empty log file should still open the log viewer")
+	}
+	if !mm.logViewerEmpty {
+		t.Error("logViewerEmpty should be true for an empty log file")
+	}
+}
+
+func TestOpenLogViewerKeyO_NotInWorkersPanel(t *testing.T) {
+	m := Model{
+		focused: PanelQueue,
+		workers: []WorkerItem{
+			{ID: "w1", BeadID: "bd-5", LogPath: "/some/path.log"},
+		},
+	}
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	mm := m2.(*Model)
+	if mm.showLogViewer {
+		t.Error("pressing 'o' outside Workers panel should not open the log viewer")
+	}
+}
+
+func TestOpenLogViewerKeyO_LogViewerClosedByEsc(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "forge-log-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("some content\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	m := Model{
+		focused: PanelWorkers,
+		workers: []WorkerItem{
+			{ID: "w1", BeadID: "bd-77", LogPath: f.Name()},
+		},
+	}
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	if !m2.(*Model).showLogViewer {
+		t.Fatal("log viewer should be open after 'o'")
+	}
+	m3, _ := m2.(*Model).Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m3.(*Model).showLogViewer {
+		t.Error("esc should close the log viewer")
+	}
+}
+
+func TestOpenLogViewerKeyO_ViewportHasContent(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "forge-log-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := "line one\nline two\nline three"
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	m := Model{
+		width:   80,
+		height:  24,
+		focused: PanelWorkers,
+		workers: []WorkerItem{
+			{ID: "w1", BeadID: "bd-55", LogPath: f.Name()},
+		},
+	}
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")})
+	mm := m2.(*Model)
+	if !mm.showLogViewer {
+		t.Fatal("log viewer should be open")
+	}
+	vpContent := mm.logViewerVP.View()
+	if !strings.Contains(vpContent, "line one") {
+		t.Errorf("log viewer viewport should contain file content, got: %q", vpContent)
+	}
+}

--- a/internal/hearth/help.go
+++ b/internal/hearth/help.go
@@ -32,6 +32,10 @@ var (
 		key.WithKeys("K"),
 		key.WithHelp("K", "kill worker"),
 	)
+	keyViewLog = key.NewBinding(
+		key.WithKeys("o"),
+		key.WithHelp("o", "view log"),
+	)
 	keyLabel = key.NewBinding(
 		key.WithKeys("l"),
 		key.WithHelp("l", "label for dispatch"),
@@ -119,11 +123,11 @@ func (k needsAttentionKeyMap) FullHelp() [][]key.Binding {
 type workersKeyMap struct{ m *Model }
 
 func (k workersKeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{keyScroll, keyKill, keyTab, k.m.keyMouse(), keyQuit}
+	return []key.Binding{keyScroll, keyKill, keyViewLog, keyTab, k.m.keyMouse(), keyQuit}
 }
 func (k workersKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{keyScroll, keyKill},
+		{keyScroll, keyKill, keyViewLog},
 		{keyTab, keyShiftTab, k.m.keyMouse(), keyQuit},
 	}
 }


### PR DESCRIPTION
Pressing 'o' while the Workers panel is focused opens the selected worker's log file in the full-screen Bubbles viewport overlay.

Previously log viewing was only accessible via the Needs Attention action menu (enter -> View Logs). This adds a direct shortcut from the Workers panel.

Changes:
- hearth.go: add 'o' key handler reading LogPath from the selected WorkerItem, opens viewport log viewer overlay
- help.go: add keyViewLog binding so footer shows 'o: view log' in Workers panel
- hearth_test.go: 6 new tests (valid file, no path, empty file, wrong panel, esc-closes, viewport content)
- changelog.d/Forge-x1bs.md: changelog fragment