### PR TITLE
Release: add SBOM generation for supply chain security (Forge-ztgx)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,10 @@ archives:
         format: tar.gz
 
 sboms:
-  - artifacts: archive
+  - id: archive
+    artifacts: archive
+  - id: docker
+    artifacts: docker
 
 checksum:
   name_template: "checksums.txt"

--- a/changelog.d/Forge-ztgx.md
+++ b/changelog.d/Forge-ztgx.md
@@ -1,2 +1,2 @@
 category: Security
-- **Add SBOM generation for releases** - Enabled GoReleaser v2's sboms section to generate SPDX Software Bill of Materials for each archive, improving supply chain security. (Forge-ztgx)
+- **Enable SBOM generation for releases** - Added GoReleaser v2's `sboms` section and installed Syft in the release workflow to generate Software Bill of Materials for supply chain security. (Forge-ztgx)


### PR DESCRIPTION
## Changes

Correctly enables GoReleaser v2 SBOM generation for archives and docker images, including Syft installation in the release workflow.

## Original Issue (task): Release: add SBOM generation for supply chain security

Enable GoReleaser v2's sboms section to generate Software Bill of Materials (SPDX or CycloneDX format) for each release. Attach as a release asset alongside checksums.txt. Good practice for supply chain security and increasingly required in enterprise environments.

---
Bead: Forge-ztgx | Branch: forge/Forge-ztgx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)