### PR TITLE
forge: learn 1 warden rule(s) from PR #230 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -473,3 +473,9 @@ rules:
       check: Verify that test function names and their doc comments accurately describe the behavior being tested, not internal implementation details or leftover naming from earlier drafts
       source: copilot:PR#195
       added: "2026-03-11"
+    - id: iota-label-array-sync
+      category: ui
+      pattern: Adding or reordering iota constants that have a corresponding label/string array
+      check: Verify that all parallel arrays or switch cases indexed by iota constants are updated in sync — inserting a new iota value shifts all subsequent values, so every array, slice literal, or map keyed by those constants must add the new entry at the correct position
+      source: copilot:PR#230
+      added: "2026-03-13"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #230.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*