### PR TITLE
Add unit test for OpenPRsWithDetail in state/db_test.go (Forge-0fw1)

### DIFF
--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -1664,7 +1664,7 @@ func TestDB_OpenPRsWithDetail(t *testing.T) {
 	_, err = db.conn.Exec(
 		`UPDATE prs SET ci_passing = 0, is_conflicting = 1, has_unresolved_threads = 1,
 		 has_pending_reviews = 0, has_approval = 1, ci_fix_count = 3, review_fix_count = 2, rebase_count = 1
-		 WHERE number = 1`)
+		 WHERE number = 1 AND anvil = 'anvil-a'`)
 	if err != nil {
 		t.Fatalf("update PR flags: %v", err)
 	}


### PR DESCRIPTION
## Changes

Well-structured unit test for OpenPRsWithDetail covering title resolution, flag mapping, status filtering, and basic fields

## Original Issue (task): Add unit test for OpenPRsWithDetail in state/db_test.go

PR #229 added OpenPRsWithDetail() which resolves titles via queue_cache/workers fallback and maps integer flags to bools. Copilot flagged the lack of a DB-level test. Add a focused test that inserts PRs + queue_cache + workers rows and asserts title resolution order, boolean flag mapping, and correct filtering of terminal PR statuses.

---
Bead: Forge-0fw1 | Branch: forge/Forge-0fw1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)