### PR TITLE
forge: learn 1 warden rule(s) from PR #257 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -533,3 +533,9 @@ rules:
       check: Verify that doc comments for parameters accurately reflect all their usages — if a parameter drives behavior (e.g. sets a header value) in addition to logging, the comment must say so or the parameter should be renamed to reflect its full role
       source: copilot:PR#259
       added: "2026-03-15"
+    - id: env-override-dedup
+      category: other
+      pattern: Appending environment variable overrides to a slice without removing pre-existing keys first
+      check: Verify that before appending new env key=value pairs, any existing entries with the same key are stripped from the slice to avoid duplicate keys with undefined precedence across platforms
+      source: copilot:PR#257
+      added: "2026-03-15"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #257.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*