### PR TITLE
[bug] Orphan recovery races with post-merge bead close (Forge-hp1h)

### DIFF
--- a/changelog.d/Forge-hp1h.md
+++ b/changelog.d/Forge-hp1h.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Orphan recovery no longer races with post-merge bead close** - Extended HasOpenPRForBead to also protect beads with recently-merged PRs (within a 10-minute grace window), preventing orphan recovery from falsely resetting beads to open before the async bd close completes. (Forge-hp1h)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -831,12 +831,29 @@ func (db *DB) queryPRs(query string, args ...any) ([]PR, error) {
 	return prs, rows.Err()
 }
 
-// HasOpenPRForBead returns true if there is a non-terminal PR for the given bead in the given anvil.
+// mergedPRGracePeriod is the window after a PR is merged during which
+// HasOpenPRForBead still returns true. This prevents orphan recovery from
+// racing with handleBeadCloseOnMerge — the bead close via `bd close` is
+// async and may not complete before the next orphan recovery sweep.
+const mergedPRGracePeriod = 10 * time.Minute
+
+// HasOpenPRForBead returns true if there is a non-terminal PR for the given
+// bead in the given anvil, OR if there is a recently-merged PR still within
+// the grace period (mergedPRGracePeriod). The grace window prevents orphan
+// recovery from falsely reclaiming beads whose PR just merged but whose
+// bd close has not yet completed.
 func (db *DB) HasOpenPRForBead(beadID, anvil string) (bool, error) {
 	var exists bool
 	err := db.conn.QueryRow(
-		`SELECT EXISTS(SELECT 1 FROM prs WHERE bead_id = ? AND anvil = ? AND status IN `+nonTerminalPRStatusSQL()+` LIMIT 1)`,
-		beadID, anvil,
+		`SELECT EXISTS(
+			SELECT 1 FROM prs
+			WHERE bead_id = ? AND anvil = ? AND (
+				status IN `+nonTerminalPRStatusSQL()+`
+				OR (status = 'merged' AND last_checked > ?)
+			)
+			LIMIT 1
+		)`,
+		beadID, anvil, time.Now().Add(-mergedPRGracePeriod).Format(dbTimeLayout),
 	).Scan(&exists)
 	if err != nil {
 		return false, err

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -652,7 +652,8 @@ func TestDB_HasOpenPRForBead(t *testing.T) {
 		t.Error("expected no match for different anvil")
 	}
 
-	// Merged PR should not count
+	// Recently-merged PR should still count (grace period protects against
+	// orphan recovery racing with async bead close).
 	pr2 := &PR{
 		Number: 43, Anvil: "anvil-2", BeadID: "bd-2",
 		Branch: "fix-2", Status: PRMerged, CreatedAt: time.Now(),
@@ -660,12 +661,33 @@ func TestDB_HasOpenPRForBead(t *testing.T) {
 	if err := db.InsertPR(pr2); err != nil {
 		t.Fatal(err)
 	}
+	// Set last_checked to now (simulates just-merged).
+	if err := db.UpdatePRStatus(pr2.ID, PRMerged); err != nil {
+		t.Fatal(err)
+	}
+	has, err = db.HasOpenPRForBead("bd-2", "anvil-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Error("recently-merged PR should still count within grace period")
+	}
+
+	// Merged PR with last_checked well outside grace period should NOT count.
+	_, err = db.conn.Exec(
+		`UPDATE prs SET last_checked = ? WHERE id = ?`,
+		time.Now().Add(-mergedPRGracePeriod-time.Hour).Format(dbTimeLayout),
+		pr2.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 	has, err = db.HasOpenPRForBead("bd-2", "anvil-2")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if has {
-		t.Error("merged PR should not count as open")
+		t.Error("old merged PR should not count as open")
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Orphan recovery no longer races with post-merge bead close** - Extended HasOpenPRForBead to also protect beads with recently-merged PRs (within a 10-minute grace window), preventing orphan recovery from falsely resetting beads to open before the async bd close completes. (Forge-hp1h)

## Original Issue (bug): [bug] Orphan recovery races with post-merge bead close

Race between handleBeadCloseOnMerge and RecoverOrphanedBeads causes bead to reset to open after PR merges.

Timeline:
1. PR merges - bellows marks PR status=merged in state.db (not open anymore)
2. handleBeadCloseOnMerge fires async, calls bd close (takes time)
3. Orphan recovery runs, HasOpenPRForBead returns false (merged != open)
4. Bead still in_progress in beads DB (bd close not done yet)
5. Orphan recovery declares it orphaned, resets to open

The orphanMinAge guard (5 min on bead.UpdatedAt) does not protect here because the bead was first claimed at iteration 1, well before the merge.

Observed: Forge-6nrm PR #264 merged 08:54:23, bead_recovered 08:56:00.

Fix: extend HasOpenPRForBead to also return true for PRs with status=merged updated within the last N minutes (e.g. 10 min). This gives handleBeadCloseOnMerge a grace window before orphan recovery can falsely declare the bead orphaned.

---
Bead: Forge-hp1h | Branch: forge/Forge-hp1h
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)