### PR TITLE
forge changelog validate: check all fragments have correct format before release (Forge-42fk)

### DIFF
--- a/.beads/formulas/forge-release.formula.toml
+++ b/.beads/formulas/forge-release.formula.toml
@@ -33,6 +33,13 @@ echo "Releasing v$VERSION"
 """
 
 [[steps]]
+name = "validate-fragments"
+run = """
+echo "Validating changelog fragments..."
+forge changelog validate
+"""
+
+[[steps]]
 name = "assemble-changelog"
 run = """
 VERSION="${1:?}"

--- a/changelog.d/Forge-42fk.md
+++ b/changelog.d/Forge-42fk.md
@@ -1,0 +1,2 @@
+category: Added
+- **Changelog fragment format validation** - `forge changelog validate` (no args) now reports all malformed fragments instead of stopping at the first error. The release formula runs this check before assembly so bad fragments are caught early with clear error messages. (Forge-42fk)

--- a/cmd/forge/changelog.go
+++ b/cmd/forge/changelog.go
@@ -88,20 +88,29 @@ If no bead IDs are given, validates all existing fragments for correct format.`,
 		fragDir := filepath.Join(dir, "changelog.d")
 
 		if len(args) == 0 {
-			// Validate all existing fragments
-			fragments, err := changelog.CollectFragments(fragDir)
-			if err != nil {
-				return err
-			}
+			// Validate all existing fragments for correct format
+			valid, errs := changelog.ValidateAllFragments(fragDir)
 
 			if jsonOutput {
+				errStrs := make([]string, len(errs))
+				for i, e := range errs {
+					errStrs[i] = e.Error()
+				}
 				return json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
-					"valid": true,
-					"count": len(fragments),
+					"valid":  len(errs) == 0,
+					"count":  valid,
+					"errors": errStrs,
 				})
 			}
 
-			fmt.Fprintf(os.Stderr, "All %d fragments are valid\n", len(fragments))
+			if len(errs) > 0 {
+				for _, e := range errs {
+					fmt.Fprintf(os.Stderr, "Invalid fragment: %s\n", e.Error())
+				}
+				return fmt.Errorf("%d changelog fragment(s) have invalid format", len(errs))
+			}
+
+			fmt.Fprintf(os.Stderr, "All %d fragments are valid\n", valid)
 			return nil
 		}
 

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -215,6 +215,44 @@ func canonicalCategory(cat string) (string, bool) {
 	return "", false
 }
 
+// FragmentError describes a validation failure for a single fragment file.
+type FragmentError struct {
+	File string
+	Err  error
+}
+
+func (e *FragmentError) Error() string {
+	return fmt.Sprintf("%s: %s", e.File, e.Err)
+}
+
+// ValidateAllFragments checks every .md file in dir for correct format and
+// returns a list of all validation errors. Unlike CollectFragments, it does not
+// stop at the first error — it reports every malformed fragment so the user can
+// fix them all in one pass.
+func ValidateAllFragments(dir string) (valid int, errs []FragmentError) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		errs = append(errs, FragmentError{File: dir, Err: fmt.Errorf("reading directory: %w", err)})
+		return 0, errs
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if _, err := ParseFragment(path); err != nil {
+			errs = append(errs, FragmentError{File: e.Name(), Err: err})
+		} else {
+			valid++
+		}
+	}
+	return valid, errs
+}
+
 // ValidateFragmentExists checks if a changelog fragment exists for the given bead ID.
 func ValidateFragmentExists(dir, beadID string) bool {
 	patterns := []string{

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -172,6 +172,64 @@ func TestValidateFragmentExists(t *testing.T) {
 	}
 }
 
+func TestValidateAllFragments(t *testing.T) {
+	dir := t.TempDir()
+
+	// Mix of valid and invalid fragments
+	os.WriteFile(filepath.Join(dir, "Forge-good.md"), []byte("category: Added\n- **Feature** - desc (Forge-good)\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "Forge-nocategory.md"), []byte("- Just a bullet with no category header\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "Forge-badcat.md"), []byte("category: Bogus\n- **Thing** - stuff\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "Forge-nobullets.md"), []byte("category: Fixed\n\n"), 0644)
+
+	valid, errs := ValidateAllFragments(dir)
+	if valid != 1 {
+		t.Errorf("valid = %d, want 1", valid)
+	}
+	if len(errs) != 3 {
+		t.Fatalf("got %d errors, want 3", len(errs))
+	}
+
+	// All three bad files should be reported
+	combined := ""
+	for _, e := range errs {
+		combined += e.Error() + "\n"
+	}
+	if !strings.Contains(combined, "missing 'category:'") {
+		t.Error("should report missing category")
+	}
+	if !strings.Contains(combined, "invalid category") {
+		t.Error("should report invalid category")
+	}
+	if !strings.Contains(combined, "no changelog entries") {
+		t.Error("should report no bullets")
+	}
+}
+
+func TestValidateAllFragmentsAllValid(t *testing.T) {
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "Forge-a.md"), []byte("category: Added\n- **A** - thing\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "Forge-b.md"), []byte("category: Fixed\n- **B** - thing\n"), 0644)
+
+	valid, errs := ValidateAllFragments(dir)
+	if valid != 2 {
+		t.Errorf("valid = %d, want 2", valid)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %d", len(errs))
+	}
+}
+
+func TestValidateAllFragmentsNonExistent(t *testing.T) {
+	valid, errs := ValidateAllFragments("/nonexistent/path")
+	if valid != 0 {
+		t.Errorf("valid = %d, want 0", valid)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %d", len(errs))
+	}
+}
+
 func TestCollectEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 	fragments, err := CollectFragments(dir)


### PR DESCRIPTION
## Changes

- **Changelog fragment format validation** - `forge changelog validate` (no args) now reports all malformed fragments instead of stopping at the first error. The release formula runs this check before assembly so bad fragments are caught early with clear error messages. (Forge-42fk)

## Original Issue (feature): forge changelog validate: check all fragments have correct format before release

Two malformed changelog fragments (Forge-6gas.md and Forge-74a0.md) were written as free-form markdown docs instead of the required 'category:' header format. This caused the release script to fail mid-way. Need to add a 'forge changelog validate-fragments' (or extend existing 'forge changelog validate') command that checks all files in changelog.d/ have a valid 'category:' header line and at least one bullet. Also update release-forge.ps1 to run this check BEFORE 'changelog assemble' so bad fragments are caught early with a clear error.

---
Bead: Forge-42fk | Branch: forge/Forge-42fk
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)