### PR TITLE
docs: add platform field to configuration.md anvil section (Forge-6rfg)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ If no file is found, built-in defaults are used. The daemon hot-reloads the conf
 anvils:
   my-api:
     path: /path/to/repos/my-api
-    platform: github               # VCS platform: github, gitlab, gitea (default: github)
+    platform: github               # VCS platform: github, gitlab, gitea (implemented); bitbucket, azuredevops (recognised but not yet implemented). Default: github
     max_smiths: 2
     auto_dispatch: all
     auto_merge: true               # Automatically merge PRs when ready (default: false)
@@ -98,7 +98,7 @@ Each key under `anvils` is the anvil name. The name is used in CLI output, logs,
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `path` | string | **required** | Filesystem path to the repository root. Must contain a `.beads/` directory. |
-| `platform` | string | `"github"` | VCS hosting platform for this anvil. Valid values: `github`, `gitlab`, `gitea`. Determines which VCS provider handles PR operations. See [Platform Requirements](#platform-requirements) below. |
+| `platform` | string | `"github"` | VCS hosting platform for this anvil. Implemented: `github`, `gitlab`, `gitea`. Recognised but not yet implemented: `bitbucket`, `azuredevops`. Determines which VCS provider handles PR operations. See [Platform Requirements](#platform-requirements) below. |
 | `max_smiths` | int | 1 | Maximum concurrent workers for this anvil. Values <= 0 are treated as 1. Overall concurrency is still limited by `max_total_smiths`. |
 | `auto_dispatch` | string | `"all"` | Dispatch mode — see below. |
 | `auto_dispatch_tag` | string | | Required when `auto_dispatch: tagged`. Beads must have this tag (case-insensitive) to be dispatched. |
@@ -301,7 +301,7 @@ The config is validated at load time. Errors are reported as a list:
 - `depcheck_interval` must be >= 1h when enabled, or 0 to disable
 - `depcheck_timeout` must not be negative
 - Each anvil `path` must be non-empty
-- Each anvil `platform` (if set) must be one of: `github`, `gitlab`, `gitea`
+- Each anvil `platform` (if set) must be one of: `github`, `gitlab`, `gitea`, `bitbucket`, `azuredevops` (note: `bitbucket` and `azuredevops` are recognised by the validator but not yet implemented)
 - Each anvil `max_smiths` must be >= 0
 - `auto_dispatch` must be one of: `all`, `tagged`, `priority`, `off`
 - If `auto_dispatch: tagged`, then `auto_dispatch_tag` must be non-empty


### PR DESCRIPTION
## Changes

Documentation-only change correctly adds platform field docs to configuration.md

## Original Issue (task): docs: add platform field to configuration.md anvil section

After Forge-cdp4 (PR #281) lands, docs/configuration.md needs a platform field entry under the anvils section. Should document: valid values (github/gitlab/gitea), that empty/omitted defaults to github (no forge.yaml changes needed for existing users), and what each platform requires (gh CLI for github, glab CLI for gitlab, GITEA_TOKEN env var for gitea/forgejo).

---
Bead: Forge-6rfg | Branch: forge/Forge-6rfg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)