### PR TITLE
forge: learn 1 warden rule(s) from PR #285 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -641,7 +641,7 @@ rules:
       check: Verify that test comments accurately describe what the code actually does — e.g., if the comment says 'skip if set' but the code forcibly clears the value with t.Setenv, update the comment to say 'force env var to be unset'
       source: copilot:PR#286
       added: "2026-03-16"
-    - id: deduplicate-warden-rules
+    - id: deduplicate-error-chain-sentinel-rules
       category: other
       pattern: A new warden rule is added to warden-rules.yaml that requires preserving an underlying error when returning a sentinel or wrapping an error
       check: Verify the new rule does not duplicate an existing rule (e.g. preserve-error-chain-on-sentinel). If the scope overlaps, consolidate or clearly differentiate the two rules to avoid redundant checks and rule list bloat.


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #285.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*