### PR TITLE
forge: learn 1 warden rule(s) from PR #296 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -677,3 +677,9 @@ rules:
       check: Verify that code waiting for a process to stop uses an active polling loop (e.g., checking IsRunning() with backoff and timeout) rather than a fixed sleep, to avoid races where the process hasn't fully released resources
       source: copilot:PR#293
       added: "2026-03-18"
+    - id: avoid-duplicate-logging-in-helpers-and-callers
+      category: style
+      pattern: A helper function logs a decision/reason AND the caller also logs about the same decision
+      check: When a helper returns a boolean decision, ensure only one site logs the outcome. Prefer returning (bool, reason) from the helper and letting the caller log once with full context (e.g., workerID), rather than having both the helper and caller emit overlapping log lines.
+      source: copilot:PR#296
+      added: "2026-03-19"


### PR DESCRIPTION
## Warden Rule Learning

Learned **1** new review rule(s) from Copilot comments on PR #296.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*