### PR TITLE
Bellows still flags CI as failed while checks are in progress (Forge-68vu fix insufficient) (Forge-d793)

### DIFF
--- a/changelog.d/Forge-d793.md
+++ b/changelog.d/Forge-d793.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bellows no longer flags CI as failed while checks are still in progress** - Added proper handling for GitHub StatusContext items (legacy commit status API) alongside CheckRun items in CI status evaluation. Fixed edge cases where COMPLETED checks with empty conclusions (transient state) and REQUESTED status were not detected as in-progress. (Forge-d793)

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -624,6 +624,84 @@ func TestCheckPR_PassingThenInProgressThenFailure(t *testing.T) {
 	assert.Contains(t, events, EventCIFailed, "ci_failed must fire when checks finish failing after a pending period")
 }
 
+// TestCheckPR_StatusContextPendingBlocksCIFailed verifies that a StatusContext
+// check in PENDING state prevents ci_failed from firing, even if a CheckRun
+// has already completed with failure. This covers repos that use both GitHub
+// Actions (CheckRun) and legacy commit statuses (StatusContext).
+func TestCheckPR_StatusContextPendingBlocksCIFailed(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    50,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-statusctx",
+		Branch:    "forge/forge-statusctx",
+		Status:    state.PROpen,
+		CIPassing: true,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	// One CheckRun completed with failure, one StatusContext still pending.
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State: "OPEN",
+		StatusCheckRollup: []vcs.CheckRun{
+			{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"},
+			{State: "PENDING", Context: "ci/integration"},
+		},
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventCIFailed, "ci_failed must not fire while StatusContext checks are pending")
+	assert.NotContains(t, events, EventCIPassed, "ci_passed must not fire while StatusContext checks are pending")
+}
+
+// TestCheckPR_CompletedEmptyConclusionBlocksCIFailed verifies that a CheckRun
+// with status COMPLETED but empty conclusion (transient state) prevents
+// premature ci_failed.
+func TestCheckPR_CompletedEmptyConclusionBlocksCIFailed(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    51,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-transient",
+		Branch:    "forge/forge-transient",
+		Status:    state.PROpen,
+		CIPassing: true,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	// One check completed with failure, another COMPLETED but no conclusion yet (transient).
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State: "OPEN",
+		StatusCheckRollup: []vcs.CheckRun{
+			{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"},
+			{Name: "deploy", Status: "COMPLETED", Conclusion: ""},
+		},
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventCIFailed, "ci_failed must not fire when a check has COMPLETED with empty conclusion (transient)")
+}
+
 // fakeVCSProvider is a minimal vcs.Provider that returns a fixed PRStatus.
 type fakeVCSProvider struct {
 	status *vcs.PRStatus

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -205,15 +205,28 @@ func (s *PRStatus) IsClosed() bool {
 
 // CIsInProgress returns true if any CI check is still running (not yet completed).
 // GitHub check runs use Status values like "IN_PROGRESS", "QUEUED", "PENDING",
-// or "WAITING". When a check hasn't completed, its Conclusion is empty.
+// or "WAITING". StatusContext items use State values like "PENDING" or "EXPECTED".
 func (s *PRStatus) CIsInProgress() bool {
 	for _, check := range s.StatusCheckRollup {
+		// Handle StatusContext items (State populated, Status empty).
+		if check.State != "" && check.Status == "" {
+			st := strings.ToUpper(check.State)
+			if st == "PENDING" || st == "EXPECTED" {
+				return true
+			}
+			continue // SUCCESS, FAILURE, ERROR are terminal states
+		}
+
 		st := strings.ToUpper(check.Status)
-		if st == "IN_PROGRESS" || st == "QUEUED" || st == "PENDING" || st == "WAITING" {
+		if st == "IN_PROGRESS" || st == "QUEUED" || st == "PENDING" || st == "WAITING" || st == "REQUESTED" {
 			return true
 		}
-		// Some platforms leave Status empty but Conclusion empty too for
-		// checks that haven't finished yet. Treat that as in-progress.
+		// A check marked COMPLETED but with no conclusion is in a transient
+		// state — treat it as still in progress until the conclusion arrives.
+		if st == "COMPLETED" && check.Conclusion == "" {
+			return true
+		}
+		// Unknown/empty status with no conclusion is likely in progress.
 		if st != "COMPLETED" && check.Conclusion == "" {
 			return true
 		}
@@ -221,13 +234,26 @@ func (s *PRStatus) CIsInProgress() bool {
 	return false
 }
 
-// CIsPassing returns true if all CI checks have passed.
+// CIsPassing returns true if all CI checks have completed with a passing result.
+// Checks that are still in progress are treated as not passing (their empty
+// Conclusion does not match SUCCESS/NEUTRAL/SKIPPED). Use CIsInProgress() to
+// distinguish "failing" from "not yet completed".
 func (s *PRStatus) CIsPassing() bool {
 	if len(s.StatusCheckRollup) == 0 {
 		return true
 	}
 	for _, check := range s.StatusCheckRollup {
-		if check.Conclusion != "SUCCESS" && check.Conclusion != "NEUTRAL" && check.Conclusion != "SKIPPED" {
+		// Handle StatusContext items (State populated, Status empty).
+		if check.State != "" && check.Status == "" {
+			st := strings.ToUpper(check.State)
+			if st != "SUCCESS" {
+				return false // PENDING, EXPECTED, FAILURE, ERROR
+			}
+			continue
+		}
+
+		conclusion := strings.ToUpper(check.Conclusion)
+		if conclusion != "SUCCESS" && conclusion != "NEUTRAL" && conclusion != "SKIPPED" {
 			return false
 		}
 	}
@@ -260,10 +286,22 @@ func (s *PRStatus) HasPendingReviewRequests() bool {
 }
 
 // CheckRun represents a CI check on a PR.
+//
+// GitHub's statusCheckRollup returns two types: CheckRun (GitHub Actions) and
+// StatusContext (legacy commit status API). They use different field schemas:
+//
+//   - CheckRun:      Name, Status (QUEUED/IN_PROGRESS/COMPLETED/…), Conclusion (SUCCESS/FAILURE/…)
+//   - StatusContext:  Context (the check name), State (PENDING/SUCCESS/FAILURE/ERROR/EXPECTED)
+//
+// Both types are deserialized into this struct. Callers should use the helper
+// methods (CIsInProgress, CIsPassing) which handle both schemas.
 type CheckRun struct {
 	Name       string
-	Status     string
-	Conclusion string
+	Status     string // CheckRun: QUEUED, IN_PROGRESS, COMPLETED, WAITING, PENDING, REQUESTED
+	Conclusion string // CheckRun: SUCCESS, FAILURE, NEUTRAL, SKIPPED, CANCELLED, TIMED_OUT, etc.
+	// State and Context are populated for GitHub StatusContext items.
+	State   string // StatusContext: PENDING, SUCCESS, FAILURE, ERROR, EXPECTED
+	Context string // StatusContext: the check name (e.g., "ci/build")
 }
 
 // ReviewAuthor identifies the author of a review.

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -67,6 +67,46 @@ func TestPRStatus_CIsPassing(t *testing.T) {
 			{Conclusion: "FAILURE"},
 		},
 	}).CIsPassing())
+	// Case-insensitive conclusion
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{Conclusion: "success"},
+		},
+	}).CIsPassing(), "lowercase conclusion should be handled")
+	// StatusContext items
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "SUCCESS", Context: "ci/build"},
+		},
+	}).CIsPassing(), "StatusContext SUCCESS = passing")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "FAILURE", Context: "ci/build"},
+		},
+	}).CIsPassing(), "StatusContext FAILURE = not passing")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "PENDING", Context: "ci/build"},
+		},
+	}).CIsPassing(), "StatusContext PENDING = not passing")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "ERROR", Context: "ci/build"},
+		},
+	}).CIsPassing(), "StatusContext ERROR = not passing")
+	// Mixed CheckRun and StatusContext
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			{State: "SUCCESS", Context: "ci/deploy"},
+		},
+	}).CIsPassing(), "mixed CheckRun+StatusContext all passing")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			{State: "FAILURE", Context: "ci/deploy"},
+		},
+	}).CIsPassing(), "mixed CheckRun passing + StatusContext failing = not passing")
 }
 
 func TestPRStatus_CIsInProgress(t *testing.T) {
@@ -100,15 +140,65 @@ func TestPRStatus_CIsInProgress(t *testing.T) {
 	}).CIsInProgress(), "waiting = in progress")
 	assert.True(t, (&PRStatus{
 		StatusCheckRollup: []CheckRun{
+			{Status: "REQUESTED", Conclusion: ""},
+		},
+	}).CIsInProgress(), "requested = in progress")
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
 			{Status: "", Conclusion: ""},
 		},
 	}).CIsInProgress(), "empty status with empty conclusion = in progress")
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{Status: "COMPLETED", Conclusion: ""},
+		},
+	}).CIsInProgress(), "completed with empty conclusion = transient, treat as in progress")
 	assert.False(t, (&PRStatus{
 		StatusCheckRollup: []CheckRun{
 			{Status: "COMPLETED", Conclusion: "SUCCESS"},
 			{Status: "COMPLETED", Conclusion: "NEUTRAL"},
 		},
 	}).CIsInProgress(), "all completed success/neutral = not in progress")
+	// StatusContext items
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "PENDING", Context: "ci/build"},
+		},
+	}).CIsInProgress(), "StatusContext PENDING = in progress")
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "EXPECTED", Context: "ci/build"},
+		},
+	}).CIsInProgress(), "StatusContext EXPECTED = in progress")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "SUCCESS", Context: "ci/build"},
+		},
+	}).CIsInProgress(), "StatusContext SUCCESS = not in progress")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "FAILURE", Context: "ci/build"},
+		},
+	}).CIsInProgress(), "StatusContext FAILURE = not in progress (completed)")
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{State: "ERROR", Context: "ci/build"},
+		},
+	}).CIsInProgress(), "StatusContext ERROR = not in progress (completed)")
+	// Mixed: one CheckRun completed, one StatusContext pending
+	assert.True(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{Name: "build", Status: "COMPLETED", Conclusion: "FAILURE"},
+			{State: "PENDING", Context: "ci/deploy"},
+		},
+	}).CIsInProgress(), "CheckRun completed+failure with StatusContext pending = in progress")
+	// Mixed: all completed
+	assert.False(t, (&PRStatus{
+		StatusCheckRollup: []CheckRun{
+			{Name: "build", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			{State: "SUCCESS", Context: "ci/deploy"},
+		},
+	}).CIsInProgress(), "all completed across CheckRun and StatusContext = not in progress")
 }
 
 func TestPRStatus_HasApproval(t *testing.T) {


### PR DESCRIPTION
## Changes

- **Bellows no longer flags CI as failed while checks are still in progress** - Added proper handling for GitHub StatusContext items (legacy commit status API) alongside CheckRun items in CI status evaluation. Fixed edge cases where COMPLETED checks with empty conclusions (transient state) and REQUESTED status were not detected as in-progress. (Forge-d793)

## Original Issue (bug): Bellows still flags CI as failed while checks are in progress (Forge-68vu fix insufficient)

## Bug

Forge-68vu (PR #310) was supposed to fix bellows prematurely flagging CI as failed while checks are still running. The fix was merged but the issue recurred immediately:

```
10:21:57 ci_failed [Fhi.Metadata-wql3.8] PR #755 CI checks failed
```

...while CI was still running on PR #755.

### Prior fix
PR #310 attempted to fix this but the logic is still not correct. The check needs to be more thorough.

### Expected behavior
When ANY check run has `status != completed` (i.e. `queued`, `in_progress`, `waiting`, `pending`), bellows should treat the overall CI status as **pending** and skip the PR entirely until the next poll cycle. Only flag `ci_failed` when ALL checks are `completed` AND at least one has a non-success conclusion.

### Investigation
1. Check what PR #310 actually changed in `internal/bellows/bellows.go`
2. Look at how `CheckStatus()` or the GitHub API response is evaluated
3. The issue might be that GitHub returns a `status: completed, conclusion: failure` for one check while others are still `in_progress` — bellows sees the failed one and flags immediately without waiting for all to complete
4. Or the fix may have only addressed one code path but there's a second path that evaluates CI status

### Files
- `internal/bellows/bellows.go` — CI status evaluation
- `internal/vcs/github/github.go` — how check statuses are fetched

---
Bead: Forge-d793 | Branch: forge/Forge-d793
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)