### PR TITLE
forge: learn 8 warden rule(s) from PR #327 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -793,8 +793,8 @@ rules:
       added: "2026-03-20"
     - id: filtered-zero-results-messaging
       category: ui
-      pattern: Function returns a 'none found' or 'all clear' message when a count is zero, but filters/flags can exclude results
-      check: When displaying a zero-results message, verify whether active filters could be hiding results. If filters are enabled, the message should indicate that no results matched the current filters rather than implying none exist at all.
+      pattern: Function returns a 'none found', 'all clear', or 'up to date' message when a count is zero, but filters/flags can exclude results
+      check: When displaying a zero-results message, verify whether active filters could be hiding results. If filters are enabled, the message must indicate that no results matched the current filters (e.g., by reporting excluded counts or naming the active filter) rather than implying none exist at all. This covers both 'no results found' and 'all up to date' phrasing.
       source: copilot:PR#327
       added: "2026-03-20"
     - id: filter-excludes-all-updates-test
@@ -811,14 +811,14 @@ rules:
       added: "2026-03-20"
     - id: distinguish-empty-from-error
       category: error-handling
-      pattern: Skipping or short-circuiting when a function returns an empty/nil result without distinguishing between 'nothing found', 'not applicable', and 'error occurred'
-      check: Verify that empty or zero-length results are not silently treated as success. Functions that scan, search, or collect should differentiate between 'no results found', 'not applicable/unsupported', and 'an error occurred' so callers can report accurate status and avoid misleading summary messages like 'all clear' when nothing was actually checked.
+      pattern: APIs or helper functions whose return types cannot clearly represent the three distinct states 'no results found', 'not applicable/unsupported', and 'error occurred' (for example, returning only an empty slice plus an error, or a bool+error that conflates these cases)
+      check: When designing or evolving scan/search/collection APIs, ensure the public contract and call sites can explicitly distinguish between 'no results found', 'not applicable/unsupported', and 'an error occurred' — for example via a dedicated status enum, sentinel values, or clearly documented semantics for result+error combinations — so callers can report accurate status rather than collapsing different failure/empty states into a single generic 'success with empty results'.
       source: copilot:PR#327
       added: "2026-03-20"
     - id: silent-error-discard
       category: error-handling
-      pattern: Logging an error then discarding the result or continuing without propagating it to the caller
-      check: Verify that scan/check errors are propagated to callers (returned as part of results or as aggregated errors) rather than logged-and-dropped, so that CLI commands and upstream consumers can accurately report failures instead of falsely indicating success
+      pattern: Top-level scan/check orchestration or CLI command logs an error from a worker/provider and continues without surfacing it in the aggregated result or command status
+      check: For top-level scan/check pipelines (CLI commands, orchestrators, or summary builders), verify that downstream errors are not only logged but also surfaced to callers (e.g., included in aggregated error collections or used to mark the command as failed). This rule is distinct from capture-non-critical-errors and propagate-enrichment-errors, which cover background/enrichment flows; use this rule only when logged errors would otherwise cause a high-level operation to appear fully successful.
       source: copilot:PR#327
       added: "2026-03-20"
     - id: severity-sort-order-consistency
@@ -833,9 +833,4 @@ rules:
       check: Verify that every struct field is actually used. If a field duplicates a method parameter, either wire the field through (use it in methods instead of passing the param) or remove the field to avoid dead state.
       source: copilot:PR#327
       added: "2026-03-20"
-    - id: filtered-results-messaging
-      category: ui
-      pattern: Displaying 'no results' or 'all up to date' messages when query filters are active
-      check: When filters narrow results to zero, the summary message must reflect that filters were applied rather than implying nothing exists. Report excluded counts or name the active filter so the user understands why results are empty.
-      source: copilot:PR#327
-      added: "2026-03-20"
+


### PR DESCRIPTION
## Warden Rule Learning

Learned **8** new review rule(s) from Copilot comments on PR #327.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*