### PR TITLE
forge: learn 4 warden rule(s) from PR #329 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -645,7 +645,7 @@ rules:
       category: other
       pattern: Adding a new entry to warden-rules.yaml or any rules/config YAML file where an existing entry already covers the same or overlapping category, pattern, and check
       check: Verify the new rule does not duplicate or significantly overlap an existing rule. If the scope overlaps, consolidate by broadening the existing rule or clearly differentiating the two. If the intent is only to update attribution (e.g., source PR), update the existing entry instead of adding a duplicate.
-      source: copilot:PR#285,PR#322,PR#324,PR#326,PR#329
+      source: copilot:PR#285,PR#322,PR#324,PR#326,PR#328,PR#329
       added: "2026-03-16"
     - id: windows-exe-rename-lock
       category: error-handling
@@ -812,7 +812,7 @@ rules:
     - id: distinguish-empty-from-error
       category: error-handling
       pattern: Refactors or extensions of existing scan/search/collection APIs to introduce or clarify a third 'not applicable/unsupported' state in addition to 'no results found' and 'error occurred' (for example, changing a bool+error or slice+error signature to return an explicit status enum or tri-state result)
-      check: When evolving an existing API to expose three distinct outcomes ('no results found', 'not applicable/unsupported', and 'error occurred'), verify that the new tri-state contract is clearly documented, all direct and indirect callers are updated to handle each state explicitly, and tests cover the migration semantics (including backward-compatibility where required). Use this rule for API evolution and migration concerns; rely on distinguish-empty-from-error for more general empty-vs-error result handling.
+      check: When evolving an existing API to expose three distinct outcomes ('no results found', 'not applicable/unsupported', and 'error occurred'), verify that the new tri-state contract is clearly documented, all direct and indirect callers are updated to handle each state explicitly, and tests cover the migration semantics (including backward-compatibility where required).
       source: copilot:PR#327,PR#329
       added: "2026-03-20"
     - id: silent-error-discard
@@ -850,4 +850,10 @@ rules:
       pattern: A message or command handler updates state on the backend (e.g. moves, edits, deletes an item) but only handles the error path, without refreshing or updating the local in-memory data on success
       check: After a successful mutation (move, update, delete), verify that the local view state (e.g. in-memory lists, cached entries, UI lanes) is updated or a refresh is triggered so all views reflect the change immediately, rather than waiting for the next periodic tick
       source: copilot:PR#330
+      added: "2026-03-20"
+    - id: tri-state-return-distinction
+      category: error-handling
+      pattern: APIs or helper functions whose return types cannot clearly represent the three distinct states 'no results found', 'not applicable/unsupported', and 'error occurred' (for example, returning only an empty slice plus an error, or a bool+error that conflates these cases)
+      check: When designing or reviewing scan/search/collection API signatures, ensure the return type can explicitly represent all three outcomes — 'no results found', 'not applicable/unsupported', and 'an error occurred' — for example via a dedicated status enum, sentinel values, or clearly documented nil/empty/error semantics. Callers must be able to report accurate status rather than collapsing different empty/failure states into a single generic result. This rule addresses API design and return-type representation; see distinguish-empty-from-error for the related concern of migrating an existing API to a tri-state contract.
+      source: copilot:PR#329
       added: "2026-03-20"


### PR DESCRIPTION
## Warden Rule Learning

Learned **4** new review rule(s) from Copilot comments on PR #329.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*