### PR TITLE
forge: learn 2 warden rule(s) from PR #336 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -242,8 +242,8 @@ rules:
     - id: changelog-fragment-bead-id-match
       category: style
       pattern: Adding or modifying files in changelog.d/
-      check: Verify the changelog fragment filename matches the current PR's bead ID (changelog.d/<bead-id>.md) and that the trailing bead reference in the bullet text also matches the same bead ID
-      source: copilot:PR#143
+      check: Verify the changelog fragment filename matches the current PR's bead ID (changelog.d/<bead-id>.md) and that the trailing bead reference in the bullet text also matches the same bead ID. Also verify the fragment file ends with a trailing blank line to maintain consistent formatting across all entries.
+      source: copilot:PR#143,PR#336
       added: "2026-03-09"
     - id: no-dead-db-columns
       category: other
@@ -897,11 +897,5 @@ rules:
       category: testing
       pattern: Adding backward-compatible unmarshalling or parsing logic that accepts legacy/alternative input formats
       check: Verify that unit tests exist covering the legacy/alternative input format, asserting that the parser correctly handles the old shape and produces the expected default values for any missing fields
-      source: copilot:PR#336
-      added: "2026-03-20"
-    - id: changelog-trailing-newline
-      category: style
-      pattern: Files in changelog.d/ directory
-      check: Verify that changelog fragment files end with a trailing blank line to maintain consistent formatting across all entries
       source: copilot:PR#336
       added: "2026-03-20"


### PR DESCRIPTION
## Warden Rule Learning

Learned **2** new review rule(s) from Copilot comments on PR #336.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*