### PR TITLE
forge: learn 2 warden rule(s) from PR #364 [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -1217,7 +1217,7 @@ rules:
         Adding a new warden rule entry that shares the same category, pattern intent, or check guidance as an existing rule (including semantic overlap in pattern or check wording)
       check: >-
         Before inserting a new warden rule, scan existing rules for semantic overlap. If a match exists, consolidate by appending the new source (e.g. PR number) to the existing rule's source list and merging any unique wording into the existing rule's pattern/check instead of creating a separate entry.
-      source: ['copilot:PR#349', 'copilot:PR#359', 'copilot:PR#360', 'copilot:PR#361']
+      source: ['copilot:PR#349', 'copilot:PR#359', 'copilot:PR#360', 'copilot:PR#361', 'copilot:PR#364']
       added: "2026-03-20"
     - id: sourcelist-yaml-flow-sequence
       category: style
@@ -1304,20 +1304,4 @@ rules:
       check: >-
         Verify that completion or summary events are emitted even when the effective result count is zero (e.g., all duplicates, all filtered). Silent early returns on zero-result paths make successful queue draining invisible in the event log and break observability contracts.
       source: copilot:PR#362
-      added: "2026-03-20"
-    - id: warden-rule-dedup
-      category: other
-      pattern: >-
-        Adding a new warden rule to .forge/warden-rules.yaml that overlaps with an existing rule's scope
-      check: >-
-        Before adding a new warden rule, check existing rules for overlapping coverage. If a similar rule exists, consolidate by updating the existing rule's pattern/check and appending the new source to its source field instead of creating a duplicate entry.
-      source: copilot:PR#364
-      added: "2026-03-20"
-    - id: consolidate-overlapping-warden-rules
-      category: style
-      pattern: >-
-        New warden rule being added to .forge/warden-rules.yaml that overlaps with an existing rule's scope
-      check: >-
-        Verify the new rule does not duplicate or overlap with an existing rule. If it does, consolidate by appending the new source to the existing rule's source field (as a YAML flow sequence) instead of creating a separate entry.
-      source: copilot:PR#364
       added: "2026-03-20"


### PR DESCRIPTION
## Warden Rule Learning

Learned **2** new review rule(s) from Copilot comments on PR #364.

These rules will be applied by Warden during future code reviews.
Review the rules in `.forge/warden-rules.yaml` and merge if they look correct.

---
*Generated by [The Forge](https://github.com/Robin831/Forge) auto-learn*