### PR TITLE
Description viewer with glamour markdown rendering (Forge-1ndf)

### DIFF
--- a/changelog.d/Forge-1ndf.md
+++ b/changelog.d/Forge-1ndf.md
@@ -1,3 +1,3 @@
 category: Added
-- **Description viewer with glamour markdown rendering** - Press 'd' on a bead in the Queue or Needs Attention panel to open a scrollable overlay that renders the bead's description field as formatted markdown using glamour. Dismiss with Esc or 'q'. (Forge-1ndf)
+- **Description viewer with glamour markdown rendering** - Press `d` on a bead in the Queue or Needs Attention panel to open a scrollable overlay that renders the bead's description field as formatted markdown using glamour. Dismiss with `Esc` or `q`. (Forge-1ndf)
 


### PR DESCRIPTION
## Changes

- **Description viewer with glamour markdown rendering** - Press 'd' on a bead in the Queue or Needs Attention panel to open a scrollable overlay that renders the bead's description field as formatted markdown using glamour. Dismiss with Esc or 'q'. (Forge-1ndf)

## Original Issue (task): Description viewer with glamour markdown rendering

Implement a 'd' key handler that opens a description viewer overlay/pane, following the pattern in internal/hearth/description.go. Use the glamour library to render markdown. Add a DescriptionModel or overlay state to the main Model. Wire the 'd' keybinding in the Update() method to fetch and display the focused bead's description field. Dismiss with 'q' or 'Esc'. This sub-task depends on the responsive layout sub-task for sizing the overlay correctly.

---
Bead: Forge-1ndf | Branch: forge/Forge-1ndf
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)