### PR TITLE
Ledger: enable mouse support for scroll and click (Forge-wxb9)

### DIFF
--- a/changelog.d/Forge-wxb9.md
+++ b/changelog.d/Forge-wxb9.md
@@ -1,2 +1,2 @@
 category: Added
-- **Ledger mouse scroll support** - Scroll wheel events now navigate the bead list, kanban lane, and hierarchy view in the Ledger TUI, matching the mouse-enabled startup already in place. (Forge-wxb9)
+- **Ledger mouse scroll support** - Scroll wheel events now navigate the bead list, kanban lane, and hierarchy view in the Ledger TUI, and add mouse-enabled startup to the Ledger interface. Pass `--no-mouse` to disable and restore normal terminal text selection. (Forge-wxb9)

--- a/cmd/forge/ledger.go
+++ b/cmd/forge/ledger.go
@@ -14,6 +14,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(ledgerCmd)
+	ledgerCmd.Flags().Bool("no-mouse", false, "disable mouse reporting (restores normal terminal text selection)")
 }
 
 var ledgerCmd = &cobra.Command{
@@ -44,8 +45,15 @@ var ledgerCmd = &cobra.Command{
 		}
 
 		model := ledger.NewModel(anvils, cfg.Anvils, db)
-		// tea.WithMouseCellMotion enables mouse scroll events for the bead list and kanban lanes.
-		p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
+		noMouse, _ := cmd.Flags().GetBool("no-mouse")
+		// tea.WithMouseCellMotion enables mouse events (scroll wheel, clicks) throughout
+		// the Ledger TUI, including list, kanban, hierarchy, and help overlay.
+		// Pass --no-mouse to disable and restore normal terminal text selection.
+		opts := []tea.ProgramOption{tea.WithAltScreen()}
+		if !noMouse {
+			opts = append(opts, tea.WithMouseCellMotion())
+		}
+		p := tea.NewProgram(model, opts...)
 		if _, err := p.Run(); err != nil {
 			fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)
 			return err

--- a/internal/ledger/help_test.go
+++ b/internal/ledger/help_test.go
@@ -6,6 +6,14 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+func sendMouseWheel(m *Model, button tea.MouseButton) *Model {
+	result, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: button})
+	if next, ok := result.(*Model); ok {
+		return next
+	}
+	return m
+}
+
 // newTestModel returns a minimal Model suitable for Update-level tests.
 func newTestModel() *Model {
 	m := &Model{
@@ -85,5 +93,128 @@ func TestHelpOverlayConsumesKeys(t *testing.T) {
 	m = sendKey(m, "q")
 	if !m.helpSt.show {
 		t.Error("`q` should not close the help overlay; only `?` and `esc` should")
+	}
+}
+
+// TestMouseWheelScrollsList verifies that wheel down/up moves the list cursor.
+func TestMouseWheelScrollsList(t *testing.T) {
+	m := newTestModel()
+	m.view = ViewList
+	m.beads = []Bead{
+		{ID: "a", Title: "A", Status: "open", Anvil: "test"},
+		{ID: "b", Title: "B", Status: "open", Anvil: "test"},
+		{ID: "c", Title: "C", Status: "open", Anvil: "test"},
+	}
+
+	initial := m.list.vp.Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelDown)
+	if m.list.vp.Selected() <= initial {
+		t.Error("wheel down should advance the list cursor")
+	}
+
+	after := m.list.vp.Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelUp)
+	if m.list.vp.Selected() >= after {
+		t.Error("wheel up should retreat the list cursor")
+	}
+}
+
+// TestMouseWheelScrollsKanban verifies that wheel down/up moves the kanban lane cursor.
+func TestMouseWheelScrollsKanban(t *testing.T) {
+	m := newTestModel()
+	m.view = ViewKanban
+	m.beads = []Bead{
+		{ID: "a", Title: "A", Status: "open", Anvil: "test"},
+		{ID: "b", Title: "B", Status: "open", Anvil: "test"},
+	}
+	m.refreshKanbanLanes()
+
+	lane := m.kanban.activeLane
+	initial := m.kanban.laneVP[lane].Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelDown)
+	if m.kanban.laneVP[lane].Selected() <= initial {
+		t.Error("wheel down should advance the kanban lane cursor")
+	}
+
+	after := m.kanban.laneVP[lane].Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelUp)
+	if m.kanban.laneVP[lane].Selected() >= after {
+		t.Error("wheel up should retreat the kanban lane cursor")
+	}
+}
+
+// TestMouseWheelScrollsHierarchy verifies that wheel down/up moves the hierarchy cursor.
+func TestMouseWheelScrollsHierarchy(t *testing.T) {
+	m := newTestModel()
+	m.view = ViewHierarchy
+	m.beads = []Bead{
+		{ID: "a", Title: "A", Status: "open", Anvil: "test"},
+		{ID: "b", Title: "B", Status: "open", Anvil: "test"},
+		{ID: "c", Title: "C", Status: "open", Anvil: "test"},
+	}
+	m.refreshHierarchy()
+
+	initial := m.hierarchy.vp.Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelDown)
+	if m.hierarchy.vp.Selected() <= initial {
+		t.Error("wheel down should advance the hierarchy cursor")
+	}
+
+	after := m.hierarchy.vp.Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelUp)
+	if m.hierarchy.vp.Selected() >= after {
+		t.Error("wheel up should retreat the hierarchy cursor")
+	}
+}
+
+// TestMouseWheelHelpOverlayDoesNotMoveList verifies that when the help overlay
+// is visible, wheel events scroll the help viewport but do NOT change the
+// underlying list/kanban/hierarchy selection.
+func TestMouseWheelHelpOverlayDoesNotMoveList(t *testing.T) {
+	m := newTestModel()
+	m.view = ViewList
+	m.beads = []Bead{
+		{ID: "a", Title: "A", Status: "open", Anvil: "test"},
+		{ID: "b", Title: "B", Status: "open", Anvil: "test"},
+		{ID: "c", Title: "C", Status: "open", Anvil: "test"},
+	}
+	m.refreshHierarchy()
+
+	// Open the help overlay.
+	m = sendKey(m, "?")
+	if !m.helpSt.show {
+		t.Fatal("help overlay must be open")
+	}
+
+	before := m.list.vp.Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelDown)
+	if m.list.vp.Selected() != before {
+		t.Error("wheel down with help overlay open should not move the list cursor")
+	}
+
+	m = sendMouseWheel(m, tea.MouseButtonWheelUp)
+	if m.list.vp.Selected() != before {
+		t.Error("wheel up with help overlay open should not move the list cursor")
+	}
+}
+
+// TestMouseWheelIgnoredWhenOverlayActive verifies that wheel events are ignored
+// while an overlay (AI, update, sort form) is active, preventing selection
+// changes behind the overlay.
+func TestMouseWheelIgnoredWhenOverlayActive(t *testing.T) {
+	m := newTestModel()
+	m.view = ViewList
+	m.beads = []Bead{
+		{ID: "a", Title: "A", Status: "open", Anvil: "test"},
+		{ID: "b", Title: "B", Status: "open", Anvil: "test"},
+	}
+
+	// Simulate an active AI overlay.
+	m.aiOverlay = aiOverlaySpinner
+
+	before := m.list.vp.Selected()
+	m = sendMouseWheel(m, tea.MouseButtonWheelDown)
+	if m.list.vp.Selected() != before {
+		t.Error("wheel down should be ignored when an overlay is active")
 	}
 }

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -491,6 +491,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Action != tea.MouseActionPress {
 			break
 		}
+		// Don't let scroll events mutate underlying state while a blocking overlay
+		// (form, update overlay, AI overlay, or sort selector) is active.
+		overlayActive := m.activeForm != nil ||
+			m.showUpdateOverlay ||
+			m.aiOverlay != aiOverlayNone ||
+			m.list.sortForm != nil
+		if overlayActive {
+			break
+		}
 		switch msg.Button {
 		case tea.MouseButtonWheelDown:
 			if m.helpSt.show {


### PR DESCRIPTION
## Summary
- Adds `tea.WithMouseCellMotion()` to `cmd/forge/ledger.go` startup so bubbletea delivers mouse events to the model
- Handles `tea.MouseMsg` in `ledger.go` Update — wheel down/up moves the cursor in list, kanban lane, and hierarchy views
- Mouse scroll in the help overlay scrolls the help viewport independently

## Test plan
- [ ] `forge ledger` — scroll wheel moves selection in list view
- [ ] Switch to kanban (`V`) — scroll wheel moves active lane cursor
- [ ] Switch to hierarchy — scroll wheel navigates tree
- [ ] Open help (`?`) — scroll wheel scrolls help text, not the list behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)