### PR TITLE
Smelter runs on every daemon startup — should skip if already ran today (Forge-nmsw)

### DIFF
--- a/changelog.d/Forge-nmsw.md
+++ b/changelog.d/Forge-nmsw.md
@@ -1,3 +1,3 @@
 category: Fixed
-- **Smelter skips redundant startup scan** - Vulncheck no longer re-scans on every daemon restart; if a scan already completed today (recorded in state.db), the startup scan is skipped and the next run follows the normal interval schedule. (Forge-nmsw)
+- **Vulncheck skips redundant startup scan** - Vulncheck no longer re-scans on every daemon restart; if a scan already completed today (recorded in state.db), the startup scan is skipped and the next run follows the normal interval schedule. (Forge-nmsw)
 

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1303,6 +1303,7 @@ const (
 	EventVulnScanStarted      EventType = "vuln_scan_started"
 	EventVulnScanDone         EventType = "vuln_scan_done"
 	EventVulnScanFailed       EventType = "vuln_scan_failed"
+	EventVulnScanCycleDone    EventType = "vuln_scan_cycle_done"
 	EventVulnBeadCreated      EventType = "vuln_bead_created"
 	EventWardenRerun          EventType = "warden_rerun"
 	EventApproveAsIs          EventType = "approve_as_is"
@@ -1394,6 +1395,35 @@ func (db *DB) HasEventForDate(eventType EventType, date string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// HasEventWithin reports whether any event of the given type was logged within
+// the past duration d from now. Any DB error is returned to the caller.
+func (db *DB) HasEventWithin(eventType EventType, d time.Duration) (bool, error) {
+	cutoff := time.Now().Add(-d).Format(dbTimeLayout)
+	var dummy int
+	err := db.conn.QueryRow(
+		`SELECT 1 FROM events WHERE type = ? AND timestamp >= ? LIMIT 1`,
+		string(eventType), cutoff,
+	).Scan(&dummy)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// LogEventAt records an event with an explicit timestamp. It is intended for
+// use in tests where deterministic timestamps are required.
+func (db *DB) LogEventAt(typ EventType, message, beadID, anvil string, at time.Time) error {
+	_, err := db.conn.Exec(
+		`INSERT INTO events (timestamp, type, message, bead_id, anvil)
+		 VALUES (?, ?, ?, ?, ?)`,
+		at.Format(dbTimeLayout), string(typ), message, beadID, anvil,
+	)
+	return err
 }
 
 // RecentEvents returns the most recent n events.

--- a/internal/vulncheck/vulncheck.go
+++ b/internal/vulncheck/vulncheck.go
@@ -510,12 +510,11 @@ func (s *Scanner) RunScheduled(ctx context.Context, interval time.Duration) {
 	case <-time.After(initialDelay):
 	}
 
-	// Skip the startup scan if one already completed today (e.g. after a
-	// daemon restart during development or config reload). The interval ticker
-	// below will fire on the normal schedule.
-	today := time.Now().Format("2006-01-02")
-	if s.shouldSkipStartupScan(today) {
-		s.logger.Info("vulncheck skipping startup scan — already ran today", "date", today)
+	// Skip the startup scan if a full cycle completed within the last 24 hours
+	// (e.g. after a daemon restart during development or config reload). The
+	// interval ticker below will fire on the normal schedule.
+	if s.shouldSkipStartupScan() {
+		s.logger.Info("vulncheck skipping startup scan — already ran within 24h")
 	} else {
 		s.runOnce(ctx)
 	}
@@ -534,16 +533,17 @@ func (s *Scanner) RunScheduled(ctx context.Context, interval time.Duration) {
 	}
 }
 
-// shouldSkipStartupScan returns true when a vuln scan already completed today,
-// meaning the startup scan can be safely skipped. Any DB error is logged and
-// treated as "do not skip" so we err on the side of scanning.
-func (s *Scanner) shouldSkipStartupScan(today string) bool {
-	ranToday, err := s.db.HasEventForDate(state.EventVulnScanDone, today)
+// shouldSkipStartupScan returns true when a full vuln scan cycle completed
+// within the last 24 hours, meaning the startup scan can be safely skipped.
+// Any DB error is logged and treated as "do not skip" so we err on the side
+// of scanning.
+func (s *Scanner) shouldSkipStartupScan() bool {
+	ranRecently, err := s.db.HasEventWithin(state.EventVulnScanCycleDone, 24*time.Hour)
 	if err != nil {
 		s.logger.Warn("vulncheck: could not check for prior scan, will run startup scan", "err", err)
 		return false
 	}
-	return ranToday
+	return ranRecently
 }
 
 // runOnce performs a single scan-and-create-beads cycle.
@@ -552,9 +552,12 @@ func (s *Scanner) runOnce(ctx context.Context) {
 	created, err := s.CreateBeads(ctx, results)
 	if err != nil {
 		s.logger.Error("vulncheck bead creation error", "error", err)
-		return
-	}
-	if created > 0 {
+	} else if created > 0 {
 		s.logger.Info("vulncheck created new beads", "count", created)
+	}
+	// Log a cycle-level completion event so the startup deduplication check
+	// knows a full cycle completed, regardless of per-anvil outcomes.
+	if logErr := s.db.LogEvent(state.EventVulnScanCycleDone, "vuln scan cycle complete", "", ""); logErr != nil {
+		s.logger.Warn("vulncheck: failed to log cycle completion", "err", logErr)
 	}
 }

--- a/internal/vulncheck/vulncheck_test.go
+++ b/internal/vulncheck/vulncheck_test.go
@@ -171,28 +171,25 @@ func TestShouldSkipStartupScan_NoEventLogged(t *testing.T) {
 	db := newTestDB(t)
 	s := &Scanner{logger: slog.Default(), db: db}
 
-	today := time.Now().Format("2006-01-02")
 	// No event logged yet — should not skip.
-	assert.False(t, s.shouldSkipStartupScan(today))
+	assert.False(t, s.shouldSkipStartupScan())
 }
 
-func TestShouldSkipStartupScan_AlreadyRanToday(t *testing.T) {
+func TestShouldSkipStartupScan_RecentCycle(t *testing.T) {
 	db := newTestDB(t)
 	s := &Scanner{logger: slog.Default(), db: db}
 
-	today := time.Now().Format("2006-01-02")
-	require.NoError(t, db.LogEvent(state.EventVulnScanDone, "scan complete", "", ""))
-
-	// Event exists for today — should skip.
-	assert.True(t, s.shouldSkipStartupScan(today))
+	// Cycle-done event logged just now — should skip.
+	require.NoError(t, db.LogEvent(state.EventVulnScanCycleDone, "cycle complete", "", ""))
+	assert.True(t, s.shouldSkipStartupScan())
 }
 
-func TestShouldSkipStartupScan_EventOnDifferentDay(t *testing.T) {
+func TestShouldSkipStartupScan_OldCycle(t *testing.T) {
 	db := newTestDB(t)
 	s := &Scanner{logger: slog.Default(), db: db}
 
-	// Log event for today but ask about tomorrow — should not skip.
-	require.NoError(t, db.LogEvent(state.EventVulnScanDone, "scan complete", "", ""))
-	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
-	assert.False(t, s.shouldSkipStartupScan(tomorrow))
+	// Cycle-done event logged more than 24 hours ago — should not skip.
+	old := time.Now().Add(-25 * time.Hour)
+	require.NoError(t, db.LogEventAt(state.EventVulnScanCycleDone, "cycle complete", "", "", old))
+	assert.False(t, s.shouldSkipStartupScan())
 }


### PR DESCRIPTION
## Changes

- **Smelter skips redundant startup scan** - Vulncheck no longer re-scans on every daemon restart; if a scan already completed today (recorded in state.db), the startup scan is skipped and the next run follows the normal interval schedule. (Forge-nmsw)

## Original Issue (task): Smelter runs on every daemon startup — should skip if already ran today

The Smelter (vulnerability scanner) runs immediately on every Forge daemon startup regardless of when it last ran. If the daemon is restarted multiple times in a day (e.g. during development or after config changes), Smelter runs each time unnecessarily.

It should persist the last run timestamp (e.g. in state.db) and skip the startup run if it already completed within the last 24 hours. The interval-based schedule should still work normally after that.

Source: https://github.com/Robin831/Forge/issues/450

---
Bead: Forge-nmsw | Branch: forge/Forge-nmsw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)