### PR TITLE
vulncheck: modernize string/slice patterns flagged by linter (Forge-q66l)

### DIFF
--- a/changelog.d/Forge-q66l.md
+++ b/changelog.d/Forge-q66l.md
@@ -1,0 +1,2 @@
+category: Changed
+- **vulncheck: modernize string/slice patterns** - Replace `bytes.Split`+range with `bytes.SplitSeq` iterator and manual duplicate-check loop with `slices.Contains` in the govulncheck JSON parser. (Forge-q66l)

--- a/internal/vulncheck/vulncheck.go
+++ b/internal/vulncheck/vulncheck.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -248,8 +249,7 @@ func parseGovulncheckJSON(data []byte) ([]ParsedVuln, error) {
 	osvMap := make(map[string]*osvEntry)
 	findingOSVs := make(map[string]bool) // OSV IDs that have actual findings (called vulns)
 
-	lines := bytes.Split(data, []byte("\n"))
-	for _, line := range lines {
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
@@ -297,17 +297,8 @@ func parseGovulncheckJSON(data []byte) ([]ParsedVuln, error) {
 				v.CVEs = append(v.CVEs, alias)
 			}
 		}
-		if strings.HasPrefix(osv.ID, "CVE-") {
-			seen := false
-			for _, c := range v.CVEs {
-				if c == osv.ID {
-					seen = true
-					break
-				}
-			}
-			if !seen {
-				v.CVEs = append(v.CVEs, osv.ID)
-			}
+		if strings.HasPrefix(osv.ID, "CVE-") && !slices.Contains(v.CVEs, osv.ID) {
+			v.CVEs = append(v.CVEs, osv.ID)
 		}
 
 		// Extract affected packages, fix versions, and symbols


### PR DESCRIPTION
## Changes

- **vulncheck: modernize string/slice patterns** - Replace `bytes.Split`+range with `bytes.SplitSeq` iterator and manual duplicate-check loop with `slices.Contains` in the govulncheck JSON parser. (Forge-q66l)

## Original Issue (task): vulncheck: modernize string/slice patterns flagged by linter

internal/vulncheck/vulncheck.go has two pre-existing linter hints: line 251 (strings.SplitSeq more efficient than Split+range) and line 302 (slices.Contains simpler than manual loop). Discovered while fixing Forge-nmsw.

---
Bead: Forge-q66l | Branch: forge/Forge-q66l
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)