### PR TITLE
Worktree cleanup deletes remote branch — breaks PR creation (Forge-0mmb)

### DIFF
--- a/changelog.d/Forge-0mmb.md
+++ b/changelog.d/Forge-0mmb.md
@@ -1,3 +1,3 @@
 category: Fixed
-- **Worktree cleanup no longer deletes remote branch** - Removed `git push origin --delete` from `worktree.Remove()` which was running after PR creation and deleting the remote branch the new PR depended on, causing all PRs to fail with "Head sha can't be blank". Remote branch cleanup is now delegated to GitHub's auto-delete-branch setting or Bellows after merge. (Forge-0mmb)
+- **Worktree cleanup no longer deletes remote branch** - Removed `git push origin --delete` from `(*worktree.Manager).Remove` which was running after PR creation and deleting the remote branch the new PR depended on, causing all PRs to fail with "Head sha can't be blank". Remote branch cleanup is now delegated to GitHub's auto-delete-branch setting or Bellows after merge. (Forge-0mmb)
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -283,7 +283,7 @@ func TestCreateWithOptions_ResetBranch(t *testing.T) {
 }
 
 // TestRemove_DoesNotDeleteRemoteBranch is a regression test for Forge-0mmb.
-// worktree.Remove() must NOT delete the remote branch — it is still needed by
+// Manager.Remove must NOT delete the remote branch — it is still needed by
 // the PR that was just created. Remote branch cleanup is handled by GitHub's
 // auto-delete setting or Bellows after merge.
 func TestRemove_DoesNotDeleteRemoteBranch(t *testing.T) {


### PR DESCRIPTION
## Changes

- **Worktree cleanup no longer deletes remote branch** - Removed `git push origin --delete` from `worktree.Remove()` which was running after PR creation and deleting the remote branch the new PR depended on, causing all PRs to fail with "Head sha can't be blank". Remote branch cleanup is now delegated to GitHub's auto-delete-branch setting or Bellows after merge. (Forge-0mmb)

## Original Issue (bug): Worktree cleanup deletes remote branch — breaks PR creation

PR #482 (Forge-x8g6) added 'git push origin --delete <branch>' to worktree.Remove(). This was meant to clean up remote branches after merge, but it's now deleting remote branches for ALL worktree cleanups — including after pipeline completion where the branch is needed for the just-created PR.

Since worktree.Remove is deferred in the daemon worker goroutine (line 892), the sequence is:
1. Pipeline: smith → temper → warden → git push branch to origin
2. Daemon: gh pr create (using the pushed branch)
3. Defer fires: worktree.Remove → git push origin --delete branch 💥

The remote branch deletion should ONLY happen when:
- The PR has been merged (branch is no longer needed)
- The PR creation failed and we're cleaning up

It should NOT happen on normal worktree cleanup after a successful pipeline + PR creation.

Fix: remove the 'git push origin --delete' from worktree.Remove entirely. Let GitHub's auto-delete-branch setting or Bellows handle remote branch cleanup after merge. The original issue (Forge-x8g6) was about gh pr merge failing on local branch delete — the fix should have been --delete-branch=false on gh pr merge, not adding remote branch deletion to worktree cleanup.

---
Bead: Forge-0mmb | Branch: forge/Forge-0mmb
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)