### PR TITLE
Pipeline hooks: configurable shell commands at each stage (Forge-esii)

### DIFF
--- a/changelog.d/Forge-esii.md
+++ b/changelog.d/Forge-esii.md
@@ -1,0 +1,2 @@
+category: Added
+- **Pipeline hooks** - Configurable shell commands that run before/after each pipeline stage (schematic, smith, temper, warden). Hooks receive context via environment variables (FORGE_BEAD_ID, FORGE_WORKTREE_PATH, FORGE_BRANCH, FORGE_ANVIL_NAME, FORGE_ANVIL_PATH, FORGE_STAGE, FORGE_ITERATION). Before-hooks abort the pipeline on failure; after-hooks are best-effort. Configure per-anvil under `hooks` in forge.yaml. (Forge-esii)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,7 @@ anvils:
 | `FORGE_ANVIL_NAME` | Repository label |
 | `FORGE_ANVIL_PATH` | Absolute path to the main repository |
 | `FORGE_STAGE` | Current pipeline stage (`schematic`, `smith`, `temper`, `warden`) |
-| `FORGE_ITERATION` | Current Smith-Warden cycle number (1-based) |
+| `FORGE_ITERATION` | Current Smith-Warden cycle number (1-based) for `smith`/`warden` stages; `schematic` hooks currently receive `1` even though they run outside the Smith-Warden loop |
 
 **Use cases:** custom linters, Slack/Teams notifications, prompt context injection, metrics collection, pre-flight checks.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,7 +168,7 @@ anvils:
 
 ### Pipeline Hooks
 
-Configure shell commands that run before or after each pipeline stage. Hooks are executed via `sh -c` with the worktree as the working directory and receive pipeline context as environment variables.
+Configure shell commands that run before or after each pipeline stage. Hooks are executed via a platform-appropriate shell (`sh -c` on Unix, `cmd /c` on Windows) with the worktree as the working directory and receive pipeline context as environment variables. Each hook has a 60-second timeout.
 
 ```yaml
 anvils:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,9 @@ anvils:
     golangci_lint: null            # null/omit = auto-detect (runs only if binary found on PATH); false = disable
     go_race_detection: false       # Per-anvil race detector override
     depcheck_enabled: true         # Set to false to skip depcheck for this anvil
+    hooks:                         # Pipeline stage hooks (optional)
+      after_smith: './scripts/post-smith.sh'
+      before_temper: './scripts/pre-temper.sh'
 
   my-frontend:
     path: /path/to/repos/my-frontend
@@ -136,6 +139,7 @@ Each key under `anvils` is the anvil name. The name is used in CLI output, logs,
 | `wicket_triage_prompt` | string | | Optional prompt suffix appended to the default Wicket triage system prompt, allowing project-specific context or constraints to be injected. |
 | `wicket_ignore_users` | []string | `[]` | GitHub logins to skip entirely when triaging issues for this anvil. In addition to this list, a built-in set of well-known bot accounts (dependabot[bot], renovate[bot], github-actions[bot], etc.) is always ignored. Comparison is case-insensitive. |
 | `smith` | object\|null | null | Smith configuration for this anvil. Currently supports `deny_patterns` for file and command restrictions. See [Smith Deny Patterns](#smith-deny-patterns) below. |
+| `hooks` | object\|null | null | Shell commands to run before/after each pipeline stage. See [Pipeline Hooks](#pipeline-hooks) below. |
 
 ### Smith Deny Patterns
 
@@ -161,6 +165,55 @@ anvils:
 |-------|------|---------|-------------|
 | `smith.deny_patterns.files` | []string | `[]` | Glob patterns matched against file paths in the Smith diff. Patterns without `/` also match the basename (e.g. `*.env` matches `config/.env`). Patterns with `/` match path suffixes (e.g. `.forge/*` matches `src/.forge/config.yaml`). Uses `path.Match` syntax (platform-independent, always forward-slash). |
 | `smith.deny_patterns.commands` | []string | `[]` | Glob patterns matched against bash commands executed by Smith. Extracted from stream-json tool_use events. `*` matches any sequence of characters including `/`, so patterns like `rm -rf /*` and `git push --force*` work as expected. |
+
+### Pipeline Hooks
+
+Configure shell commands that run before or after each pipeline stage. Hooks are executed via `sh -c` with the worktree as the working directory and receive pipeline context as environment variables.
+
+```yaml
+anvils:
+  myrepo:
+    path: /path/to/repo
+    hooks:
+      before_smith: './scripts/pre-smith.sh'
+      after_smith: './scripts/post-smith.sh'
+      before_temper: './scripts/pre-temper.sh'
+      after_temper: './scripts/notify.sh'
+      before_warden: './scripts/pre-warden.sh'
+      after_warden: './scripts/post-warden.sh'
+      before_schematic: 'echo "Starting schematic"'
+      after_schematic: 'echo "Schematic done"'
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hooks.before_schematic` | string | | Runs before the Schematic pre-analysis stage. |
+| `hooks.after_schematic` | string | | Runs after the Schematic pre-analysis stage. |
+| `hooks.before_smith` | string | | Runs before each Smith iteration. |
+| `hooks.after_smith` | string | | Runs after each Smith iteration. |
+| `hooks.before_temper` | string | | Runs before each Temper verification. |
+| `hooks.after_temper` | string | | Runs after each Temper verification. |
+| `hooks.before_warden` | string | | Runs before each Warden review. |
+| `hooks.after_warden` | string | | Runs after each Warden review. |
+
+**Hook behavior:**
+- **Before hooks** abort the pipeline on non-zero exit. Use them to enforce preconditions (e.g., required files, environment validation).
+- **After hooks** are best-effort — failures are logged but do not abort the pipeline. Use them for notifications, metrics, or cleanup.
+- Hooks run in the worktree directory, so relative paths resolve against the worktree.
+
+**Environment variables** available to all hooks:
+
+| Variable | Description |
+|----------|-------------|
+| `FORGE_BEAD_ID` | Unique bead identifier |
+| `FORGE_WORKTREE_PATH` | Absolute path to the worker's worktree |
+| `FORGE_BRANCH` | Git branch name |
+| `FORGE_ANVIL_NAME` | Repository label |
+| `FORGE_ANVIL_PATH` | Absolute path to the main repository |
+| `FORGE_STAGE` | Current pipeline stage (`schematic`, `smith`, `temper`, `warden`) |
+| `FORGE_ITERATION` | Current Smith-Warden cycle number (1-based) |
+
+**Use cases:** custom linters, Slack/Teams notifications, prompt context injection, metrics collection, pre-flight checks.
 
 ### Auto-Dispatch Modes
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,7 +152,8 @@ type DenyPatternsConfig struct {
 }
 
 // HooksConfig defines optional shell commands that run before/after each
-// pipeline stage. Each field is a shell command string executed via "sh -c".
+// pipeline stage. Each field is a shell command string executed via a
+// platform-appropriate shell (sh -c on Unix, cmd /c on Windows).
 // Commands receive pipeline context as environment variables.
 type HooksConfig struct {
 	BeforeSchematic string `mapstructure:"before_schematic" yaml:"before_schematic,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,14 @@ type AnvilConfig struct {
 	// Smith holds optional Smith configuration for this anvil, including
 	// deny patterns for files and commands.
 	Smith *SmithConfig `mapstructure:"smith" yaml:"smith,omitempty"`
+
+	// Hooks defines optional shell commands to run before/after each
+	// pipeline stage. Commands receive context as environment variables
+	// (FORGE_BEAD_ID, FORGE_WORKTREE_PATH, FORGE_BRANCH, FORGE_ANVIL_NAME,
+	// FORGE_ANVIL_PATH, FORGE_STAGE, FORGE_ITERATION). A non-zero exit
+	// from a "before" hook aborts the stage; "after" hook failures are
+	// logged but do not abort the pipeline.
+	Hooks *HooksConfig `mapstructure:"hooks" yaml:"hooks,omitempty"`
 }
 
 // SmithConfig holds per-anvil Smith configuration.
@@ -141,6 +149,20 @@ type DenyPatternsConfig struct {
 	// Commands is a list of glob patterns matched against bash commands
 	// executed by Smith. Examples: "rm -rf /", "git push --force*".
 	Commands []string `mapstructure:"commands" yaml:"commands,omitempty"`
+}
+
+// HooksConfig defines optional shell commands that run before/after each
+// pipeline stage. Each field is a shell command string executed via "sh -c".
+// Commands receive pipeline context as environment variables.
+type HooksConfig struct {
+	BeforeSchematic string `mapstructure:"before_schematic" yaml:"before_schematic,omitempty"`
+	AfterSchematic  string `mapstructure:"after_schematic" yaml:"after_schematic,omitempty"`
+	BeforeSmith     string `mapstructure:"before_smith" yaml:"before_smith,omitempty"`
+	AfterSmith      string `mapstructure:"after_smith" yaml:"after_smith,omitempty"`
+	BeforeTemper    string `mapstructure:"before_temper" yaml:"before_temper,omitempty"`
+	AfterTemper     string `mapstructure:"after_temper" yaml:"after_temper,omitempty"`
+	BeforeWarden    string `mapstructure:"before_warden" yaml:"before_warden,omitempty"`
+	AfterWarden     string `mapstructure:"after_warden" yaml:"after_warden,omitempty"`
 }
 
 // TemperCommandsConfig holds custom build/test/lint commands for an anvil.

--- a/internal/pipeline/hooks.go
+++ b/internal/pipeline/hooks.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/executil"
 )
+
+// hookTimeout is the maximum time a single hook command is allowed to run.
+const hookTimeout = 60 * time.Second
 
 // hookEnv holds the environment variables passed to pipeline hook commands.
 type hookEnv struct {
@@ -36,17 +43,44 @@ func (h hookEnv) environ() []string {
 	}
 }
 
+// filterForgeEnv returns a copy of environ with any existing FORGE_* variables
+// removed so that hook-specific values are not shadowed or duplicated.
+func filterForgeEnv(environ []string) []string {
+	filtered := make([]string, 0, len(environ))
+	for _, e := range environ {
+		if !strings.HasPrefix(e, "FORGE_") {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// shellArgs returns the platform-appropriate shell and flag for executing a
+// command string. On Windows it uses "cmd /c"; elsewhere "sh -c".
+func shellArgs() (string, string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", "/c"
+	}
+	return "sh", "-c"
+}
+
 // runHook executes a shell command with the given hook environment. It returns
-// nil when cmd is empty (no hook configured). The command is run via "sh -c"
-// with the worktree as the working directory.
+// nil when cmd is empty (no hook configured). The command is run via a
+// platform-appropriate shell (sh -c on Unix, cmd /c on Windows) with the
+// worktree as the working directory. A dedicated timeout of hookTimeout is
+// applied to prevent hooks from blocking the pipeline indefinitely.
 func runHook(ctx context.Context, workerID, hookName, cmd string, env hookEnv) error {
 	if cmd == "" {
 		return nil
 	}
+	hookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
+	defer cancel()
+
 	log.Printf("[pipeline:%s] Running hook %s: %s", workerID, hookName, cmd)
-	c := executil.HideWindow(exec.CommandContext(ctx, "sh", "-c", cmd))
+	shell, flag := shellArgs()
+	c := executil.HideWindow(exec.CommandContext(hookCtx, shell, flag, cmd))
 	c.Dir = env.WorktreePath
-	c.Env = append(c.Environ(), env.environ()...)
+	c.Env = append(filterForgeEnv(os.Environ()), env.environ()...)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		log.Printf("[pipeline:%s] Hook %s failed: %v\n%s", workerID, hookName, err, out)

--- a/internal/pipeline/hooks.go
+++ b/internal/pipeline/hooks.go
@@ -76,19 +76,19 @@ func runHook(ctx context.Context, workerID, hookName, cmd string, env hookEnv) e
 	hookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
 	defer cancel()
 
-	log.Printf("[pipeline:%s] Running hook %s: %s", workerID, hookName, cmd)
+	log.Printf("[pipeline:%s] Running hook %s", workerID, hookName)
 	shell, flag := shellArgs()
 	c := executil.HideWindow(exec.CommandContext(hookCtx, shell, flag, cmd))
 	c.Dir = env.WorktreePath
 	c.Env = append(filterForgeEnv(os.Environ()), env.environ()...)
 	out, err := c.CombinedOutput()
 	if err != nil {
-		log.Printf("[pipeline:%s] Hook %s failed: %v\n%s", workerID, hookName, err, out)
+		// Log only the exit status, not the command or raw output, to avoid
+		// leaking secrets that may be embedded in hook commands or output.
+		log.Printf("[pipeline:%s] Hook %s failed: %v (output omitted)", workerID, hookName, err)
 		return fmt.Errorf("hook %s failed: %w", hookName, err)
 	}
-	if len(out) > 0 {
-		log.Printf("[pipeline:%s] Hook %s output: %s", workerID, hookName, out)
-	}
+	log.Printf("[pipeline:%s] Hook %s completed (%d bytes output)", workerID, hookName, len(out))
 	return nil
 }
 

--- a/internal/pipeline/hooks.go
+++ b/internal/pipeline/hooks.go
@@ -1,0 +1,87 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/executil"
+)
+
+// hookEnv holds the environment variables passed to pipeline hook commands.
+type hookEnv struct {
+	BeadID       string
+	WorktreePath string
+	Branch       string
+	AnvilName    string
+	AnvilPath    string
+	Stage        string
+	Iteration    int
+}
+
+// environ returns the hook context as a slice of KEY=VALUE strings suitable
+// for appending to exec.Cmd.Env.
+func (h hookEnv) environ() []string {
+	return []string{
+		"FORGE_BEAD_ID=" + h.BeadID,
+		"FORGE_WORKTREE_PATH=" + h.WorktreePath,
+		"FORGE_BRANCH=" + h.Branch,
+		"FORGE_ANVIL_NAME=" + h.AnvilName,
+		"FORGE_ANVIL_PATH=" + h.AnvilPath,
+		"FORGE_STAGE=" + h.Stage,
+		"FORGE_ITERATION=" + strconv.Itoa(h.Iteration),
+	}
+}
+
+// runHook executes a shell command with the given hook environment. It returns
+// nil when cmd is empty (no hook configured). The command is run via "sh -c"
+// with the worktree as the working directory.
+func runHook(ctx context.Context, workerID, hookName, cmd string, env hookEnv) error {
+	if cmd == "" {
+		return nil
+	}
+	log.Printf("[pipeline:%s] Running hook %s: %s", workerID, hookName, cmd)
+	c := executil.HideWindow(exec.CommandContext(ctx, "sh", "-c", cmd))
+	c.Dir = env.WorktreePath
+	c.Env = append(c.Environ(), env.environ()...)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		log.Printf("[pipeline:%s] Hook %s failed: %v\n%s", workerID, hookName, err, out)
+		return fmt.Errorf("hook %s failed: %w", hookName, err)
+	}
+	if len(out) > 0 {
+		log.Printf("[pipeline:%s] Hook %s output: %s", workerID, hookName, out)
+	}
+	return nil
+}
+
+// hookCmd resolves the command string for a named hook from the anvil config.
+// Returns "" when hooks are not configured or the named hook is not set.
+func hookCmd(hooks *config.HooksConfig, name string) string {
+	if hooks == nil {
+		return ""
+	}
+	switch name {
+	case "before_schematic":
+		return hooks.BeforeSchematic
+	case "after_schematic":
+		return hooks.AfterSchematic
+	case "before_smith":
+		return hooks.BeforeSmith
+	case "after_smith":
+		return hooks.AfterSmith
+	case "before_temper":
+		return hooks.BeforeTemper
+	case "after_temper":
+		return hooks.AfterTemper
+	case "before_warden":
+		return hooks.BeforeWarden
+	case "after_warden":
+		return hooks.AfterWarden
+	default:
+		return ""
+	}
+}

--- a/internal/pipeline/hooks_test.go
+++ b/internal/pipeline/hooks_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
+	"os/exec"
 	"testing"
 
 	"github.com/Robin831/Forge/internal/config"
@@ -17,10 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func skipIfNoSh(t *testing.T) {
+func skipIfNoShell(t *testing.T) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("hooks require sh -c which is not available on Windows")
+	shell, _ := shellArgs()
+	if _, err := exec.LookPath(shell); err != nil {
+		t.Skipf("hooks require %s which is not available", shell)
 	}
 }
 
@@ -30,7 +31,7 @@ func TestRunHook_Empty_NoOp(t *testing.T) {
 }
 
 func TestRunHook_Success(t *testing.T) {
-	skipIfNoSh(t)
+	skipIfNoShell(t)
 	dir := t.TempDir()
 	env := hookEnv{
 		BeadID:       "bead-1",
@@ -52,7 +53,7 @@ func TestRunHook_Success(t *testing.T) {
 }
 
 func TestRunHook_Failure(t *testing.T) {
-	skipIfNoSh(t)
+	skipIfNoShell(t)
 	env := hookEnv{WorktreePath: t.TempDir()}
 	err := runHook(context.Background(), "w1", "before_temper", "exit 1", env)
 	assert.Error(t, err)
@@ -105,10 +106,28 @@ func TestHookEnv_Environ(t *testing.T) {
 	assert.Contains(t, vars, "FORGE_ITERATION=3")
 }
 
+func TestFilterForgeEnv(t *testing.T) {
+	input := []string{
+		"HOME=/home/user",
+		"FORGE_BEAD_ID=old-bead",
+		"PATH=/usr/bin",
+		"FORGE_STAGE=smith",
+		"GOPATH=/go",
+	}
+	got := filterForgeEnv(input)
+	assert.Equal(t, []string{"HOME=/home/user", "PATH=/usr/bin", "GOPATH=/go"}, got)
+}
+
+func TestShellArgs(t *testing.T) {
+	shell, flag := shellArgs()
+	assert.NotEmpty(t, shell)
+	assert.NotEmpty(t, flag)
+}
+
 // TestBeforeSmithHook_Abort verifies that a failing before_smith hook aborts
 // the pipeline with an error.
 func TestBeforeSmithHook_Abort(t *testing.T) {
-	skipIfNoSh(t)
+	skipIfNoShell(t)
 	db := newTestDB(t)
 	params, _, _ := baseParams(t, db)
 	params.AnvilConfig.Hooks = &config.HooksConfig{
@@ -127,7 +146,7 @@ func TestBeforeSmithHook_Abort(t *testing.T) {
 // TestAfterSmithHook_NoAbort verifies that a failing after_smith hook does not
 // abort the pipeline (after hooks are best-effort).
 func TestAfterSmithHook_NoAbort(t *testing.T) {
-	skipIfNoSh(t)
+	skipIfNoShell(t)
 	db := newTestDB(t)
 	params, _, _ := baseParams(t, db)
 	params.AnvilConfig.Hooks = &config.HooksConfig{
@@ -144,7 +163,7 @@ func TestAfterSmithHook_NoAbort(t *testing.T) {
 // TestBeforeTemperHook_ReceivesEnv verifies that a before_temper hook receives
 // the correct environment variables and can create files in the worktree.
 func TestBeforeTemperHook_ReceivesEnv(t *testing.T) {
-	skipIfNoSh(t)
+	skipIfNoShell(t)
 	db := newTestDB(t)
 	params, _, _ := baseParams(t, db)
 
@@ -174,7 +193,7 @@ func TestBeforeTemperHook_ReceivesEnv(t *testing.T) {
 // TestHooks_SuccessfulPipeline verifies that all hooks run during a successful
 // pipeline pass without interfering.
 func TestHooks_SuccessfulPipeline(t *testing.T) {
-	skipIfNoSh(t)
+	skipIfNoShell(t)
 	db := newTestDB(t)
 	params, _, _ := baseParams(t, db)
 

--- a/internal/pipeline/hooks_test.go
+++ b/internal/pipeline/hooks_test.go
@@ -1,0 +1,212 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/provider"
+	"github.com/Robin831/Forge/internal/smith"
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/Robin831/Forge/internal/temper"
+	"github.com/Robin831/Forge/internal/warden"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func skipIfNoSh(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("hooks require sh -c which is not available on Windows")
+	}
+}
+
+func TestRunHook_Empty_NoOp(t *testing.T) {
+	err := runHook(context.Background(), "w1", "before_smith", "", hookEnv{})
+	assert.NoError(t, err)
+}
+
+func TestRunHook_Success(t *testing.T) {
+	skipIfNoSh(t)
+	dir := t.TempDir()
+	env := hookEnv{
+		BeadID:       "bead-1",
+		WorktreePath: dir,
+		Branch:       "forge/bead-1",
+		AnvilName:    "myrepo",
+		AnvilPath:    "/tmp/myrepo",
+		Stage:        "smith",
+		Iteration:    2,
+	}
+	marker := filepath.Join(dir, "hook-ran.txt")
+	cmd := "echo $FORGE_BEAD_ID $FORGE_STAGE $FORGE_ITERATION > " + marker
+	err := runHook(context.Background(), "w1", "before_smith", cmd, env)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "bead-1 smith 2")
+}
+
+func TestRunHook_Failure(t *testing.T) {
+	skipIfNoSh(t)
+	env := hookEnv{WorktreePath: t.TempDir()}
+	err := runHook(context.Background(), "w1", "before_temper", "exit 1", env)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook before_temper failed")
+}
+
+func TestHookCmd_NilHooks(t *testing.T) {
+	assert.Equal(t, "", hookCmd(nil, "before_smith"))
+}
+
+func TestHookCmd_AllStages(t *testing.T) {
+	h := &config.HooksConfig{
+		BeforeSchematic: "a",
+		AfterSchematic:  "b",
+		BeforeSmith:     "c",
+		AfterSmith:      "d",
+		BeforeTemper:    "e",
+		AfterTemper:     "f",
+		BeforeWarden:    "g",
+		AfterWarden:     "h",
+	}
+	assert.Equal(t, "a", hookCmd(h, "before_schematic"))
+	assert.Equal(t, "b", hookCmd(h, "after_schematic"))
+	assert.Equal(t, "c", hookCmd(h, "before_smith"))
+	assert.Equal(t, "d", hookCmd(h, "after_smith"))
+	assert.Equal(t, "e", hookCmd(h, "before_temper"))
+	assert.Equal(t, "f", hookCmd(h, "after_temper"))
+	assert.Equal(t, "g", hookCmd(h, "before_warden"))
+	assert.Equal(t, "h", hookCmd(h, "after_warden"))
+	assert.Equal(t, "", hookCmd(h, "unknown"))
+}
+
+func TestHookEnv_Environ(t *testing.T) {
+	env := hookEnv{
+		BeadID:       "test-bead",
+		WorktreePath: "/tmp/wt",
+		Branch:       "forge/test-bead",
+		AnvilName:    "repo",
+		AnvilPath:    "/src/repo",
+		Stage:        "temper",
+		Iteration:    3,
+	}
+	vars := env.environ()
+	assert.Contains(t, vars, "FORGE_BEAD_ID=test-bead")
+	assert.Contains(t, vars, "FORGE_WORKTREE_PATH=/tmp/wt")
+	assert.Contains(t, vars, "FORGE_BRANCH=forge/test-bead")
+	assert.Contains(t, vars, "FORGE_ANVIL_NAME=repo")
+	assert.Contains(t, vars, "FORGE_ANVIL_PATH=/src/repo")
+	assert.Contains(t, vars, "FORGE_STAGE=temper")
+	assert.Contains(t, vars, "FORGE_ITERATION=3")
+}
+
+// TestBeforeSmithHook_Abort verifies that a failing before_smith hook aborts
+// the pipeline with an error.
+func TestBeforeSmithHook_Abort(t *testing.T) {
+	skipIfNoSh(t)
+	db := newTestDB(t)
+	params, _, _ := baseParams(t, db)
+	params.AnvilConfig.Hooks = &config.HooksConfig{
+		BeforeSmith: "exit 1",
+	}
+	params.WardenReviewer = func(_ context.Context, _, _, _, _, _ string, _ *state.DB, _ string, _ ...provider.Provider) (*warden.ReviewResult, error) {
+		return &warden.ReviewResult{Verdict: warden.VerdictApprove}, nil
+	}
+
+	outcome := Run(context.Background(), params)
+	assert.False(t, outcome.Success)
+	assert.Error(t, outcome.Error)
+	assert.Contains(t, outcome.Error.Error(), "before_smith hook")
+}
+
+// TestAfterSmithHook_NoAbort verifies that a failing after_smith hook does not
+// abort the pipeline (after hooks are best-effort).
+func TestAfterSmithHook_NoAbort(t *testing.T) {
+	skipIfNoSh(t)
+	db := newTestDB(t)
+	params, _, _ := baseParams(t, db)
+	params.AnvilConfig.Hooks = &config.HooksConfig{
+		AfterSmith: "exit 1",
+	}
+	params.WardenReviewer = func(_ context.Context, _, _, _, _, _ string, _ *state.DB, _ string, _ ...provider.Provider) (*warden.ReviewResult, error) {
+		return &warden.ReviewResult{Verdict: warden.VerdictApprove, Summary: "lgtm"}, nil
+	}
+
+	outcome := Run(context.Background(), params)
+	assert.True(t, outcome.Success)
+}
+
+// TestBeforeTemperHook_ReceivesEnv verifies that a before_temper hook receives
+// the correct environment variables and can create files in the worktree.
+func TestBeforeTemperHook_ReceivesEnv(t *testing.T) {
+	skipIfNoSh(t)
+	db := newTestDB(t)
+	params, _, _ := baseParams(t, db)
+
+	// Use a hook that writes env vars to a file so we can verify them.
+	params.AnvilConfig.Hooks = &config.HooksConfig{
+		BeforeTemper: `echo "$FORGE_BEAD_ID|$FORGE_STAGE|$FORGE_ANVIL_NAME" > hook-env.txt`,
+	}
+
+	// Capture the worktree path from the temper runner so we can read the file.
+	var wtPath string
+	params.TemperRunner = func(_ context.Context, wt string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		wtPath = wt
+		return &temper.Result{Passed: true}
+	}
+	params.WardenReviewer = func(_ context.Context, _, _, _, _, _ string, _ *state.DB, _ string, _ ...provider.Provider) (*warden.ReviewResult, error) {
+		return &warden.ReviewResult{Verdict: warden.VerdictApprove, Summary: "ok"}, nil
+	}
+
+	outcome := Run(context.Background(), params)
+	require.True(t, outcome.Success)
+
+	data, err := os.ReadFile(filepath.Join(wtPath, "hook-env.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "test-bead|temper|test-anvil")
+}
+
+// TestHooks_SuccessfulPipeline verifies that all hooks run during a successful
+// pipeline pass without interfering.
+func TestHooks_SuccessfulPipeline(t *testing.T) {
+	skipIfNoSh(t)
+	db := newTestDB(t)
+	params, _, _ := baseParams(t, db)
+
+	params.AnvilConfig.Hooks = &config.HooksConfig{
+		BeforeSmith:  "echo before_smith >> hook-log.txt",
+		AfterSmith:   "echo after_smith >> hook-log.txt",
+		BeforeTemper: "echo before_temper >> hook-log.txt",
+		AfterTemper:  "echo after_temper >> hook-log.txt",
+		BeforeWarden: "echo before_warden >> hook-log.txt",
+		AfterWarden:  "echo after_warden >> hook-log.txt",
+	}
+
+	var wtPath string
+	origSmith := params.SmithRunner
+	params.SmithRunner = func(ctx context.Context, wt, promptText, logDir string, pv provider.Provider, flags []string) (*smith.Process, error) {
+		wtPath = wt
+		return origSmith(ctx, wt, promptText, logDir, pv, flags)
+	}
+	params.WardenReviewer = func(_ context.Context, _, _, _, _, _ string, _ *state.DB, _ string, _ ...provider.Provider) (*warden.ReviewResult, error) {
+		return &warden.ReviewResult{Verdict: warden.VerdictApprove, Summary: "lgtm"}, nil
+	}
+
+	outcome := Run(context.Background(), params)
+	require.True(t, outcome.Success)
+
+	data, err := os.ReadFile(filepath.Join(wtPath, "hook-log.txt"))
+	require.NoError(t, err)
+	lines := string(data)
+	assert.Contains(t, lines, "before_smith")
+	assert.Contains(t, lines, "after_smith")
+	assert.Contains(t, lines, "before_temper")
+	assert.Contains(t, lines, "after_temper")
+	assert.Contains(t, lines, "before_warden")
+	assert.Contains(t, lines, "after_warden")
+}

--- a/internal/pipeline/hooks_test.go
+++ b/internal/pipeline/hooks_test.go
@@ -3,8 +3,9 @@ package pipeline
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Robin831/Forge/internal/config"
@@ -25,6 +26,15 @@ func skipIfNoShell(t *testing.T) {
 	}
 }
 
+// skipIfWindows skips tests that use POSIX shell syntax ($VAR, >>, redirection)
+// which is not compatible with cmd /c on Windows.
+func skipIfWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX shell syntax not supported by cmd /c on Windows")
+	}
+}
+
 func TestRunHook_Empty_NoOp(t *testing.T) {
 	err := runHook(context.Background(), "w1", "before_smith", "", hookEnv{})
 	assert.NoError(t, err)
@@ -32,6 +42,7 @@ func TestRunHook_Empty_NoOp(t *testing.T) {
 
 func TestRunHook_Success(t *testing.T) {
 	skipIfNoShell(t)
+	skipIfWindows(t) // uses POSIX $VAR expansion and > redirection
 	dir := t.TempDir()
 	env := hookEnv{
 		BeadID:       "bead-1",
@@ -164,6 +175,7 @@ func TestAfterSmithHook_NoAbort(t *testing.T) {
 // the correct environment variables and can create files in the worktree.
 func TestBeforeTemperHook_ReceivesEnv(t *testing.T) {
 	skipIfNoShell(t)
+	skipIfWindows(t) // uses POSIX $VAR expansion and > redirection
 	db := newTestDB(t)
 	params, _, _ := baseParams(t, db)
 
@@ -194,6 +206,7 @@ func TestBeforeTemperHook_ReceivesEnv(t *testing.T) {
 // pipeline pass without interfering.
 func TestHooks_SuccessfulPipeline(t *testing.T) {
 	skipIfNoShell(t)
+	skipIfWindows(t) // uses POSIX >> append redirection
 	db := newTestDB(t)
 	params, _, _ := baseParams(t, db)
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -824,7 +824,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 
 			// after_schematic hook (best-effort — failures are logged but do not abort)
 			if err := runHook(ctx, workerID, "after_schematic", hookCmd(p.AnvilConfig.Hooks, "after_schematic"), hEnv); err != nil {
-				_ = p.DB.LogEvent(state.EventSchematicDone, fmt.Sprintf("after_schematic hook failed: %v", err), p.Bead.ID, p.AnvilName)
+				_ = p.DB.LogEvent(state.EventHookFailed, fmt.Sprintf("after_schematic hook failed: %v", err), p.Bead.ID, p.AnvilName)
 			}
 		} else {
 			log.Printf("[pipeline:%s] %s", workerID, skipReason)
@@ -1105,7 +1105,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 
 		// after_smith hook (best-effort — failures are logged but do not abort)
 		if err := runHook(ctx, workerID, "after_smith", hookCmd(p.AnvilConfig.Hooks, "after_smith"), hEnv); err != nil {
-			_ = p.DB.LogEvent(state.EventSmithDone, fmt.Sprintf("after_smith hook failed: %v", err), p.Bead.ID, p.AnvilName)
+			_ = p.DB.LogEvent(state.EventHookFailed, fmt.Sprintf("after_smith hook failed: %v", err), p.Bead.ID, p.AnvilName)
 		}
 
 		// Step 2.5: Check deny patterns (post-Smith diff validation)
@@ -1226,7 +1226,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 
 		// after_temper hook (best-effort)
 		if err := runHook(ctx, workerID, "after_temper", hookCmd(p.AnvilConfig.Hooks, "after_temper"), hEnv); err != nil {
-			_ = p.DB.LogEvent(state.EventSmithDone, fmt.Sprintf("after_temper hook failed: %v", err), p.Bead.ID, p.AnvilName)
+			_ = p.DB.LogEvent(state.EventHookFailed, fmt.Sprintf("after_temper hook failed: %v", err), p.Bead.ID, p.AnvilName)
 		}
 
 		if !temperResult.Passed {
@@ -1371,7 +1371,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 
 		// after_warden hook (best-effort)
 		if err := runHook(ctx, workerID, "after_warden", hookCmd(p.AnvilConfig.Hooks, "after_warden"), hEnv); err != nil {
-			_ = p.DB.LogEvent(state.EventWardenPass, fmt.Sprintf("after_warden hook failed: %v", err), p.Bead.ID, p.AnvilName)
+			_ = p.DB.LogEvent(state.EventHookFailed, fmt.Sprintf("after_warden hook failed: %v", err), p.Bead.ID, p.AnvilName)
 		}
 
 		switch reviewResult.Verdict {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1104,6 +1104,10 @@ func Run(ctx context.Context, p Params) *Outcome {
 		} // end else (smith phase)
 
 		// after_smith hook (best-effort — failures are logged but do not abort)
+		// Ensure Smith-stage hook metadata is populated even when Smith was
+		// intentionally skipped on the first iteration.
+		hEnv.Stage = "smith"
+		hEnv.Iteration = iteration
 		if err := runHook(ctx, workerID, "after_smith", hookCmd(p.AnvilConfig.Hooks, "after_smith"), hEnv); err != nil {
 			_ = p.DB.LogEvent(state.EventHookFailed, fmt.Sprintf("after_smith hook failed: %v", err), p.Bead.ID, p.AnvilName)
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -662,6 +662,16 @@ func Run(ctx context.Context, p Params) *Outcome {
 		}
 	}
 
+	// Build hook environment for pipeline stage hooks.
+	hEnv := hookEnv{
+		BeadID:       p.Bead.ID,
+		WorktreePath: wt.Path,
+		Branch:       wt.Branch,
+		AnvilName:    p.AnvilName,
+		AnvilPath:    p.AnvilConfig.Path,
+		Iteration:    1,
+	}
+
 	// Run Schematic pre-worker (optional — skipped when SkipSmith is set)
 	if !p.SkipSmith && p.SchematicConfig != nil {
 		runSchematic := p.SchematicRunner
@@ -688,6 +698,16 @@ func Run(ctx context.Context, p Params) *Outcome {
 
 		runSchemBool, skipReason := shouldRunSchematic(schemCfg, p.Bead, providers)
 		if runSchemBool {
+			// before_schematic hook
+			hEnv.Stage = "schematic"
+			if err := runHook(ctx, workerID, "before_schematic", hookCmd(p.AnvilConfig.Hooks, "before_schematic"), hEnv); err != nil {
+				outcome.Error = fmt.Errorf("before_schematic hook: %w", err)
+				outcome.Duration = time.Since(start)
+				_ = p.DB.UpdateWorkerStatus(workerID, state.WorkerFailed)
+				markIngotFailed()
+				return outcome
+			}
+
 			log.Printf("[pipeline:%s] Running Schematic pre-analysis", workerID)
 			_ = p.DB.UpdateWorkerPhase(workerID, "schematic")
 			_ = p.DB.LogEvent(state.EventSchematicStarted, "Analysing bead scope", p.Bead.ID, p.AnvilName)
@@ -801,6 +821,11 @@ func Run(ctx context.Context, p Params) *Outcome {
 				log.Printf("[pipeline:%s] Schematic skipped: %s", workerID, sResult.Reason)
 				_ = p.DB.LogEvent(state.EventSchematicSkipped, sResult.Reason, p.Bead.ID, p.AnvilName)
 			}
+
+			// after_schematic hook (best-effort — failures are logged but do not abort)
+			if err := runHook(ctx, workerID, "after_schematic", hookCmd(p.AnvilConfig.Hooks, "after_schematic"), hEnv); err != nil {
+				_ = p.DB.LogEvent(state.EventSchematicDone, fmt.Sprintf("after_schematic hook failed: %v", err), p.Bead.ID, p.AnvilName)
+			}
 		} else {
 			log.Printf("[pipeline:%s] %s", workerID, skipReason)
 		}
@@ -861,6 +886,17 @@ func Run(ctx context.Context, p Params) *Outcome {
 			log.Printf("[pipeline:%s] Skipping smith (already completed externally)", workerID)
 			_ = p.DB.UpdateWorkerPhase(workerID, "temper")
 		} else {
+
+		// before_smith hook
+		hEnv.Stage = "smith"
+		hEnv.Iteration = iteration
+		if err := runHook(ctx, workerID, "before_smith", hookCmd(p.AnvilConfig.Hooks, "before_smith"), hEnv); err != nil {
+			outcome.Error = fmt.Errorf("before_smith hook: %w", err)
+			outcome.Duration = time.Since(start)
+			_ = p.DB.UpdateWorkerStatus(workerID, state.WorkerFailed)
+			markIngotFailed()
+			return outcome
+		}
 
 		// Run Smith (with provider fallback on rate limit)
 		log.Printf("[pipeline:%s] Running Smith (provider: %s)", workerID, providers[activeProviderIdx].Label())
@@ -1067,6 +1103,11 @@ func Run(ctx context.Context, p Params) *Outcome {
 		}
 		} // end else (smith phase)
 
+		// after_smith hook (best-effort — failures are logged but do not abort)
+		if err := runHook(ctx, workerID, "after_smith", hookCmd(p.AnvilConfig.Hooks, "after_smith"), hEnv); err != nil {
+			_ = p.DB.LogEvent(state.EventSmithDone, fmt.Sprintf("after_smith hook failed: %v", err), p.Bead.ID, p.AnvilName)
+		}
+
 		// Step 2.5: Check deny patterns (post-Smith diff validation)
 		if p.AnvilConfig.Smith != nil && p.AnvilConfig.Smith.DenyPatterns != nil {
 			smithRawOutput := ""
@@ -1156,6 +1197,17 @@ func Run(ctx context.Context, p Params) *Outcome {
 			}
 		}
 
+		// before_temper hook
+		hEnv.Stage = "temper"
+		hEnv.Iteration = iteration
+		if err := runHook(ctx, workerID, "before_temper", hookCmd(p.AnvilConfig.Hooks, "before_temper"), hEnv); err != nil {
+			outcome.Error = fmt.Errorf("before_temper hook: %w", err)
+			outcome.Duration = time.Since(start)
+			_ = p.DB.UpdateWorkerStatus(workerID, state.WorkerFailed)
+			markIngotFailed()
+			return outcome
+		}
+
 		// Step 3: Run Temper (build/test)
 		log.Printf("[pipeline:%s] Running Temper verification", workerID)
 		_ = p.DB.UpdateWorkerPhase(workerID, "temper")
@@ -1171,6 +1223,11 @@ func Run(ctx context.Context, p Params) *Outcome {
 		temperResult := runTemper(ctx, wt.Path, *temperCfg, p.DB, p.Bead.ID, p.AnvilName)
 		outcome.TemperResult = temperResult
 		recordIngotTemperResults(p.DB, workerID, p.Bead.ID, p.AnvilName, temperResult, ingotRec)
+
+		// after_temper hook (best-effort)
+		if err := runHook(ctx, workerID, "after_temper", hookCmd(p.AnvilConfig.Hooks, "after_temper"), hEnv); err != nil {
+			_ = p.DB.LogEvent(state.EventSmithDone, fmt.Sprintf("after_temper hook failed: %v", err), p.Bead.ID, p.AnvilName)
+		}
 
 		if !temperResult.Passed {
 			log.Printf("[pipeline:%s] Temper failed at step: %s", workerID, temperResult.FailedStep)
@@ -1198,6 +1255,17 @@ func Run(ctx context.Context, p Params) *Outcome {
 			_ = p.DB.UpdateWorkerStatus(workerID, state.WorkerFailed)
 			markIngotFailed()
 			outcome.Duration = time.Since(start)
+			return outcome
+		}
+
+		// before_warden hook
+		hEnv.Stage = "warden"
+		hEnv.Iteration = iteration
+		if err := runHook(ctx, workerID, "before_warden", hookCmd(p.AnvilConfig.Hooks, "before_warden"), hEnv); err != nil {
+			outcome.Error = fmt.Errorf("before_warden hook: %w", err)
+			outcome.Duration = time.Since(start)
+			_ = p.DB.UpdateWorkerStatus(workerID, state.WorkerFailed)
+			markIngotFailed()
 			return outcome
 		}
 
@@ -1300,6 +1368,11 @@ func Run(ctx context.Context, p Params) *Outcome {
 			}
 		}
 		outcome.ReviewResult = reviewResult
+
+		// after_warden hook (best-effort)
+		if err := runHook(ctx, workerID, "after_warden", hookCmd(p.AnvilConfig.Hooks, "after_warden"), hEnv); err != nil {
+			_ = p.DB.LogEvent(state.EventWardenPass, fmt.Sprintf("after_warden hook failed: %v", err), p.Bead.ID, p.AnvilName)
+		}
 
 		switch reviewResult.Verdict {
 		case warden.VerdictApprove:

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1439,6 +1439,9 @@ const (
 	EventWicketPRLinked         EventType = "wicket_pr_linked"
 	EventWicketIssueClosed      EventType = "wicket_issue_closed"
 	EventWicketIssueStaleClose  EventType = "wicket_issue_stale_close"
+
+	// Pipeline hook events.
+	EventHookFailed EventType = "hook_failed"
 )
 
 // Event represents a logged event.


### PR DESCRIPTION
## Changes

- **Pipeline hooks** - Configurable shell commands that run before/after each pipeline stage (schematic, smith, temper, warden). Hooks receive context via environment variables (FORGE_BEAD_ID, FORGE_WORKTREE_PATH, FORGE_BRANCH, FORGE_ANVIL_NAME, FORGE_ANVIL_PATH, FORGE_STAGE, FORGE_ITERATION). Before-hooks abort the pipeline on failure; after-hooks are best-effort. Configure per-anvil under `hooks` in forge.yaml. (Forge-esii)

## Original Issue (task): Pipeline hooks: configurable shell commands at each stage

Add before/after shell command hooks for each pipeline stage in forge.yaml. Hooks receive context (bead ID, worktree path, branch, anvil name) as environment variables.

Example config:
anvils:
  myrepo:
    hooks:
      after_smith: './scripts/post-smith.sh'
      before_temper: './scripts/pre-temper.sh'
      after_warden: './scripts/notify.sh'

Use cases: custom linters, Slack notifications, prompt context injection, metrics collection. Inspired by OpenCode's plugin hook system but implemented as simple shell commands. See docs/research/opencode-patterns.md section 2.

---
Bead: Forge-esii | Branch: forge/Forge-esii
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)