### PR TITLE
Rename cifix/reviewfix packages to quench/burnish (Forge-8tex)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ Forge is a **Go orchestrator daemon** that autonomously drives Claude Code agent
 | `internal/vulncheck` | Vulnerability scanning via `govulncheck` — creates prioritized beads |
 | `internal/wicket` | GitHub issue triage monitor — polls repos for new issues, AI-classifies them, and creates beads or requests clarification |
 | `internal/schematic` | Pre-analysis worker — decomposes complex beads or produces implementation plans |
-| `internal/cifix` | CI failure fix worker — spawns Smith with targeted fix prompt |
-| `internal/reviewfix` | Review comment fix worker — addresses PR review feedback |
+| `internal/quench` | CI failure fix worker — spawns Smith with targeted fix prompt |
+| `internal/burnish` | Review comment fix worker — addresses PR review feedback |
 | `internal/rebase` | Conflict rebase handling for merge conflicts |
 | `internal/poller` | Calls `bd ready` to get available beads from an anvil; detects Crucible candidates |
 | `internal/worktree` | Creates/removes `git worktree` branches for each bead |

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Forge/
 ├── internal/
 │   ├── bellows/          # PR monitoring (CI fix, review fix, rebase)
 │   ├── changelog/        # Changelog fragment parsing & assembly
-│   ├── cifix/            # CI failure fix worker
+│   ├── quench/           # CI failure fix worker (quench)
 │   ├── config/           # Viper-based configuration
 │   ├── cost/             # Token usage & USD cost tracking
 │   ├── crucible/         # Parent-child bead orchestration (epic branches)
@@ -259,7 +259,7 @@ Forge/
 │   ├── provider/         # AI provider fallback chain
 │   ├── rebase/           # Conflict rebase handling
 │   ├── retry/            # Exponential backoff & retry logic
-│   ├── reviewfix/        # Review comment fix worker
+│   ├── burnish/          # Review comment fix worker (burnish)
 │   ├── schematic/        # Pre-analysis worker (decompose complex beads)
 │   ├── shutdown/         # Graceful shutdown & orphan cleanup
 │   ├── smith/            # Claude Code worker spawning & lifecycle

--- a/changelog.d/Forge-8tex.md
+++ b/changelog.d/Forge-8tex.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Rename cifix/reviewfix packages to quench/burnish** - Renamed internal/cifix to internal/quench and internal/reviewfix to internal/burnish, aligning package names with the blacksmith metaphor used throughout the codebase. Config keys and DB columns remain unchanged for backward compatibility. (Forge-8tex)

--- a/cmd/listprs/main.go
+++ b/cmd/listprs/main.go
@@ -25,11 +25,11 @@ func main() {
 	defer rows.Close()
 	found := false
 	for rows.Next() {
-		var id, number, cifix, revfix, cipassing int
+		var id, number, quenchCount, burnishCount, cipassing int
 		var anvil, beadID, branch, status string
-		_ = rows.Scan(&id, &number, &anvil, &beadID, &branch, &status, &cifix, &revfix, &cipassing)
+		_ = rows.Scan(&id, &number, &anvil, &beadID, &branch, &status, &quenchCount, &burnishCount, &cipassing)
 		fmt.Printf("PR #%-4d  dbid=%-4d  anvil=%-14s  bead=%-12s  status=%-12s  ci_fix=%-2d  rev_fix=%-2d  ci_passing=%d\n",
-			number, id, anvil, beadID, status, cifix, revfix, cipassing)
+			number, id, anvil, beadID, status, quenchCount, burnishCount, cipassing)
 		found = true
 	}
 	if !found {

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Reference documentation for configuring and operating Forge.
 | [CLI Reference](cli.md) | All CLI commands with flags and examples |
 | [Providers](providers.md) | Provider chain syntax, model fallback, and rate limiting |
 | [Prompt Customization](prompt-customization.md) | Per-anvil `.forge/prompt.tmpl` templates |
-| [Reviewfix Loop](reviewfix.md) | Automatic PR review comment handling and CI fix cycles |
+| [Burnish (Review Fix) Loop](reviewfix.md) | Automatic PR review comment handling and CI fix cycles |
 | [Remote Access](remote-access.md) | Remote Hearth TUI and Claude CLI via VS Code Tunnels |
 
 ## Quick Links

--- a/docs/plans/copilot-request-reduction.md
+++ b/docs/plans/copilot-request-reduction.md
@@ -174,7 +174,7 @@ settings:
 
 **Impact: Save 1-3 requests per failed PR**
 
-When a PR has multiple CI failures or review comments, batch them into a single Smith invocation instead of spawning separate cifix/reviewfix workers per issue.
+When a PR has multiple CI failures or review comments, batch them into a single Smith invocation instead of spawning separate quench/burnish workers per issue.
 
 **Implementation** in `internal/quench/quench.go` and `internal/burnish/burnish.go`:
 

--- a/docs/plans/copilot-request-reduction.md
+++ b/docs/plans/copilot-request-reduction.md
@@ -176,7 +176,7 @@ settings:
 
 When a PR has multiple CI failures or review comments, batch them into a single Smith invocation instead of spawning separate cifix/reviewfix workers per issue.
 
-**Implementation** in `internal/cifix/cifix.go` and `internal/reviewfix/reviewfix.go`:
+**Implementation** in `internal/quench/quench.go` and `internal/burnish/burnish.go`:
 
 ```go
 // Instead of one Fix() call per failed check:
@@ -274,7 +274,7 @@ settings:
 | `internal/prompt/prompt.go` | Self-review checklist injection for combined mode |
 | `internal/warden/warden.go` | Accept model override parameter |
 | `internal/schematic/schematic.go` | Accept model override parameter |
-| `internal/cifix/cifix.go` | Batch fix mode |
-| `internal/reviewfix/reviewfix.go` | Batch fix mode |
+| `internal/quench/quench.go` | Batch fix mode |
+| `internal/burnish/burnish.go` | Batch fix mode |
 | `internal/cost/premium.go` | No changes needed (multipliers already correct) |
 | `docs/configuration.md` | Document new settings |

--- a/docs/reviewfix.md
+++ b/docs/reviewfix.md
@@ -1,4 +1,4 @@
-# Reviewfix Loop and Re-Review Mechanism
+# Burnish (Review Fix) Loop and Re-Review Mechanism
 
 The Forge automatically responds to PR review comments from GitHub Copilot (and
 other reviewers) by spawning a Smith agent to address them, then requesting a
@@ -9,7 +9,7 @@ fresh review once the fixes are pushed.
 ```
 Bellows detects "changes requested" or unresolved threads
     ↓
-reviewfix.Fix() fetches review comments via GraphQL
+burnish.Fix() fetches review comments via GraphQL
     ↓
 Smith spawned with targeted fix prompt
     ↓
@@ -33,7 +33,7 @@ Bellows (`internal/bellows`) polls all open PRs on a configurable interval
 - A review transitions to `CHANGES_REQUESTED`, or
 - The count of unresolved review threads increases from zero.
 
-The daemon's event handler for `EventReviewChanges` calls `reviewfix.Fix()`.
+The daemon's event handler for `EventReviewChanges` calls `burnish.Fix()`.
 
 ## Re-Review Request
 
@@ -74,7 +74,7 @@ settings:
 ```
 
 To use a different reviewer (e.g. a human or another bot), supply
-`FixParams.Reviewer` directly when calling `reviewfix.Fix()`.
+`FixParams.Reviewer` directly when calling `burnish.Fix()`.
 
 ## State Events
 

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -330,7 +330,7 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 		}
 		// Seed unresolved threads/conflicts as false when no fix has been
 		// attempted yet, so the first poll detects a false→true transition
-		// and triggers a reviewfix/rebase worker. Without this, PRs that
+		// and triggers a burnish/rebase worker. Without this, PRs that
 		// already had issues when assigned to bellows would never fire.
 		threadsSeed := pr.HasUnresolvedThreads
 		if threadsSeed && pr.Status != state.PRNeedsFix && pr.ReviewFixCount == 0 {
@@ -377,7 +377,7 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 
 	// External PRs (not created by Forge) are tracked for display in the
 	// Hearth PR panel. Unless explicitly assigned to bellows, they must not
-	// trigger lifecycle workers (cifix, reviewfix, rebase). Persist their
+	// trigger lifecycle workers (quench, burnish, rebase). Persist their
 	// mergeability state and return early.
 	if strings.HasPrefix(pr.BeadID, "ext-") && !pr.BellowsManaged {
 		m.wasUnmanaged[key] = true
@@ -477,7 +477,7 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 		_ = m.db.LogEvent(state.EventCIFailed, fmt.Sprintf("PR #%d CI checks failed", pr.Number), pr.BeadID, pr.Anvil)
 		_ = m.db.LogEvent(state.EventPRNeedsFix, fmt.Sprintf("PR #%d CI failed", pr.Number), pr.BeadID, pr.Anvil)
 	} else if !newSnap.CIPassing && !newSnap.CIInProgress && !lastSnap.CIPassing {
-		// CI is still failing with no transition. Check if a previous cifix
+		// CI is still failing with no transition. Check if a previous quench
 		// attempt completed (PR status reset to open) and retries remain.
 		// This catches the gap where NotifyCIFixCompleted() clears the fix
 		// state but bellows never re-emits EventCIFailed because it only

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -420,7 +420,7 @@ func TestCheckAll_WorkerRowNotDuplicatedOnRepeatPolls(t *testing.T) {
 }
 
 // TestCIFixRetryLogic verifies the secondary CI failure detection that
-// re-emits EventCIFailed when a previous cifix attempt completed but CI
+// re-emits EventCIFailed when a previous quench attempt completed but CI
 // is still failing. This is the core fix for the retry gap.
 func TestCIFixRetryLogic(t *testing.T) {
 	tests := []struct {

--- a/internal/burnish/burnish.go
+++ b/internal/burnish/burnish.go
@@ -1,9 +1,9 @@
-// Package reviewfix spawns a Smith worker to address PR review comments.
+// Package burnish spawns a Smith worker to address PR review comments.
 //
-// When Bellows detects "changes requested" on a PR, reviewfix fetches the
+// When Bellows detects "changes requested" on a PR, burnish fetches the
 // review comments via the VCS provider, constructs a targeted fix prompt,
 // and spawns Smith to address them. It then pushes the fixes to the PR branch.
-package reviewfix
+package burnish
 
 import (
 	"context"
@@ -116,7 +116,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	prompt := buildBatchReviewPrompt(p.PRNumber, p.Branch, p.BeadID, actionable)
 
 	if p.DB != nil {
-		_ = p.DB.LogEvent(state.EventReviewFixStarted,
+		_ = p.DB.LogEvent(state.EventBurnishStarted,
 			fmt.Sprintf("PR #%d: batch fix for %d comments", p.PRNumber, len(actionable)),
 			p.BeadID, p.AnvilName)
 	}
@@ -164,7 +164,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	if smithResult == nil {
 		result.Error = fmt.Errorf("batch review fix: no smith result (no providers available)")
 		if p.DB != nil {
-			_ = p.DB.LogEvent(state.EventReviewFixFailed,
+			_ = p.DB.LogEvent(state.EventBurnishFailed,
 				fmt.Sprintf("PR #%d batch fix: no smith result", p.PRNumber),
 				p.BeadID, p.AnvilName)
 		}
@@ -175,7 +175,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	if smithResult.RateLimited {
 		result.Error = fmt.Errorf("all providers (%d) are rate limited", len(providers))
 		if p.DB != nil {
-			_ = p.DB.LogEvent(state.EventReviewFixFailed,
+			_ = p.DB.LogEvent(state.EventBurnishFailed,
 				fmt.Sprintf("PR #%d batch fix: all providers rate limited", p.PRNumber),
 				p.BeadID, p.AnvilName)
 		}
@@ -186,7 +186,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	if smithResult.ExitCode != 0 {
 		result.Error = fmt.Errorf("batch review fix failed (exit %d)", smithResult.ExitCode)
 		if p.DB != nil {
-			_ = p.DB.LogEvent(state.EventReviewFixFailed,
+			_ = p.DB.LogEvent(state.EventBurnishFailed,
 				fmt.Sprintf("PR #%d: batch Smith exit %d", p.PRNumber, smithResult.ExitCode),
 				p.BeadID, p.AnvilName)
 		}
@@ -218,7 +218,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	}
 
 	if p.DB != nil {
-		_ = p.DB.LogEvent(state.EventReviewFixSuccess,
+		_ = p.DB.LogEvent(state.EventBurnishSuccess,
 			fmt.Sprintf("PR #%d: batch addressed %d comments", p.PRNumber, len(actionable)),
 			p.BeadID, p.AnvilName)
 	}
@@ -327,7 +327,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		prompt := buildReviewFixPrompt(p, actionable)
 
 		// Step 3: Spawn Smith (with provider fallback on rate limit)
-		_ = p.DB.LogEvent(state.EventReviewFixStarted,
+		_ = p.DB.LogEvent(state.EventBurnishStarted,
 			fmt.Sprintf("PR #%d: attempt %d, %d comments (provider: %s)", p.PRNumber, attempt, len(actionable), providers[activeProviderIdx].Label()),
 			p.BeadID, p.AnvilName)
 
@@ -338,7 +338,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			if pi > activeProviderIdx {
 				log.Printf("[burnish] PR #%d: Provider %s rate limited, retrying with %s",
 					p.PRNumber, providers[pi-1].Label(), pv.Label())
-				_ = p.DB.LogEvent(state.EventReviewFixSmithError,
+				_ = p.DB.LogEvent(state.EventBurnishSmithError,
 					fmt.Sprintf("PR #%d attempt %d: %s rate limited, falling back to %s",
 						p.PRNumber, attempt, providers[pi-1].Label(), pv.Label()),
 					p.BeadID, p.AnvilName)
@@ -346,7 +346,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			process, err := smith.SpawnWithProvider(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
 			if err != nil {
 				result.Error = fmt.Errorf("spawning smith (%s) for review fix: %w", pv.Label(), err)
-				_ = p.DB.LogEvent(state.EventReviewFixFailed, result.Error.Error(), p.BeadID, p.AnvilName)
+				_ = p.DB.LogEvent(state.EventBurnishFailed, result.Error.Error(), p.BeadID, p.AnvilName)
 				result.Duration = time.Since(start)
 				return result
 			}
@@ -385,10 +385,10 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		// If all providers are rate-limited, abort rather than burning more attempts.
 		if smithResult.RateLimited {
 			log.Printf("[burnish] PR #%d: All providers rate limited on attempt %d", p.PRNumber, attempt)
-			_ = p.DB.LogEvent(state.EventReviewFixFailed,
+			_ = p.DB.LogEvent(state.EventBurnishFailed,
 				fmt.Sprintf("PR #%d attempt %d: all providers rate limited", p.PRNumber, attempt),
 				p.BeadID, p.AnvilName)
-			_ = p.DB.LogEvent(state.EventReviewFixSmithError,
+			_ = p.DB.LogEvent(state.EventBurnishSmithError,
 				fmt.Sprintf("PR #%d attempt %d: rate_limited (all %d providers exhausted)", p.PRNumber, attempt, len(providers)),
 				p.BeadID, p.AnvilName)
 			result.Error = fmt.Errorf("all providers (%d) are rate limited", len(providers))
@@ -399,7 +399,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		if smithResult.ExitCode != 0 {
 			log.Printf("[burnish] PR #%d: Smith fix attempt %d failed (exit %d, subtype=%s)",
 				p.PRNumber, attempt, smithResult.ExitCode, smithResult.ResultSubtype)
-			_ = p.DB.LogEvent(state.EventReviewFixFailed,
+			_ = p.DB.LogEvent(state.EventBurnishFailed,
 				fmt.Sprintf("PR #%d: Smith exit %d on attempt %d", p.PRNumber, smithResult.ExitCode, attempt),
 				p.BeadID, p.AnvilName)
 			// Log error detail for root-cause debugging.
@@ -411,7 +411,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 				}
 			}
 			if errDetail != "" {
-				_ = p.DB.LogEvent(state.EventReviewFixSmithError,
+				_ = p.DB.LogEvent(state.EventBurnishSmithError,
 					fmt.Sprintf("PR #%d attempt %d: %s", p.PRNumber, attempt, errDetail),
 					p.BeadID, p.AnvilName)
 			}
@@ -432,7 +432,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			}
 			if err := p.VCS.ResolveThread(ctx, p.WorktreePath, comment.ThreadID); err != nil {
 				log.Printf("[burnish] PR #%d: Warning: failed to resolve thread %s: %v", p.PRNumber, comment.ThreadID, err)
-				_ = p.DB.LogEvent(state.EventReviewFixFailed,
+				_ = p.DB.LogEvent(state.EventBurnishFailed,
 					fmt.Sprintf("PR #%d: resolve thread %s failed: %v", p.PRNumber, comment.ThreadID, err),
 					p.BeadID, p.AnvilName)
 			} else {
@@ -452,7 +452,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			log.Printf("[burnish] PR #%d: Resolved %d/%d threads on GitHub", p.PRNumber, resolvedCount, len(actionable))
 		}
 
-		_ = p.DB.LogEvent(state.EventReviewFixSuccess,
+		_ = p.DB.LogEvent(state.EventBurnishSuccess,
 			fmt.Sprintf("PR #%d: Addressed %d comments on attempt %d", p.PRNumber, len(actionable), attempt),
 			p.BeadID, p.AnvilName)
 
@@ -461,7 +461,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 	}
 
 	result.Error = fmt.Errorf("could not address review comments after %d attempts", p.MaxAttempts)
-	_ = p.DB.LogEvent(state.EventReviewFixFailed,
+	_ = p.DB.LogEvent(state.EventBurnishFailed,
 		fmt.Sprintf("PR #%d: Exhausted %d fix attempts for %d comments", p.PRNumber, p.MaxAttempts, len(actionable)),
 		p.BeadID, p.AnvilName)
 	result.Duration = time.Since(start)

--- a/internal/burnish/burnish_test.go
+++ b/internal/burnish/burnish_test.go
@@ -1,4 +1,4 @@
-package reviewfix
+package burnish
 
 import (
 	"context"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,7 +207,7 @@ type SettingsConfig struct {
 	// SmithProviders is the ordered list of AI providers used specifically for
 	// dispatch pipeline (Smith + Warden + Schematic). When empty, Providers is
 	// used as fallback. This lets smiths run a more capable model (e.g.
-	// claude/claude-opus-4-6) while lifecycle workers (cifix, reviewfix) use a
+	// claude/claude-opus-4-6) while lifecycle workers (quench, burnish) use a
 	// lighter model. Accepts the same "kind/model" format as Providers.
 	//
 	// Deprecated: Use StageProviders for per-stage configuration. SmithProviders
@@ -215,7 +215,7 @@ type SettingsConfig struct {
 	// corresponding StageProviders key is not set.
 	SmithProviders []string `mapstructure:"smith_providers" yaml:"smith_providers,omitempty"`
 	// StageProviders maps pipeline stage names to their own provider chains.
-	// Supported keys: "smith", "warden", "schematic", "cifix", "reviewfix".
+	// Supported keys: "smith", "warden", "schematic", "cifix" (quench), "reviewfix" (burnish).
 	// Each value uses the same "kind/model" format as Providers. When a stage
 	// key is missing, the fallback chain is:
 	//   stage_providers[stage] → smith_providers (smith/warden/schematic only) → providers → defaults

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/Robin831/Forge/internal/adventurer"
 	"github.com/Robin831/Forge/internal/bellows"
-	"github.com/Robin831/Forge/internal/cifix"
+	"github.com/Robin831/Forge/internal/quench"
 	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/crucible"
 	"github.com/Robin831/Forge/internal/depcheck"
@@ -50,7 +50,7 @@ import (
 	"github.com/Robin831/Forge/internal/prompt"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/rebase"
-	"github.com/Robin831/Forge/internal/reviewfix"
+	"github.com/Robin831/Forge/internal/burnish"
 	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/schematic"
 	"github.com/Robin831/Forge/internal/shutdown"
@@ -389,9 +389,9 @@ func (d *Daemon) vcsForAnvil(anvil string) vcs.Provider {
 	return github.New(d.db)
 }
 
-// cifixLearnConfig builds a warden.LearnConfig for the CI-fix path that routes
-// learned rules into the pending_warden_rules table when smelter is enabled.
-func (d *Daemon) cifixLearnConfig(anvilName string) *warden.LearnConfig {
+// quenchLearnConfig builds a warden.LearnConfig for the quench (CI-fix) path
+// that routes learned rules into the pending_warden_rules table when smelter is enabled.
+func (d *Daemon) quenchLearnConfig(anvilName string) *warden.LearnConfig {
 	return &warden.LearnConfig{
 		SmelterEnabled: d.cfg.Load().Settings.IsSmelterEnabled(),
 		AnvilName:      anvilName,
@@ -894,8 +894,8 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 		workerID := fmt.Sprintf("%s-%s-%d", req.Anvil, req.BeadID, time.Now().UnixNano())
 
 		// Derive a timeout context for the lifecycle worker so it cannot hang
-		// indefinitely. Use SmithTimeout as the budget since these workers (cifix,
-		// reviewfix, rebase) each spawn a Claude session of comparable length.
+		// indefinitely. Use SmithTimeout as the budget since these workers (quench,
+		// burnish, rebase) each spawn a Claude session of comparable length.
 		// Mirror the pipeline defaulting: treat SmithTimeout <= 0 as "use 30m"
 		// so lifecycle workers always have a deadline unless explicitly configured.
 		workerTimeout := d.cfg.Load().Settings.SmithTimeout
@@ -933,10 +933,10 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 				StaleTimeout: workerTimeout / 2,
 			})
 			cfg := d.config()
-			cifixProviders := d.filterCopilotIfLimited(provider.FromConfig(config.ProvidersForStageWithAnvil(cfg.Settings, &anvilCfg, "cifix")))
+			quenchProviders := d.filterCopilotIfLimited(provider.FromConfig(config.ProvidersForStageWithAnvil(cfg.Settings, &anvilCfg, "cifix")))
 			// Use batch mode when copilot_batch_ci_fixes is enabled and the primary provider is Copilot.
-			var res *cifix.FixResult
-			useBatch := cfg.Settings.CopilotBatchCIFixes && len(cifixProviders) > 0 && cifixProviders[0].Kind == provider.Copilot
+			var res *quench.FixResult
+			useBatch := cfg.Settings.CopilotBatchCIFixes && len(quenchProviders) > 0 && quenchProviders[0].Kind == provider.Copilot
 			if useBatch {
 				anvilVCS := d.vcsForAnvil(req.Anvil)
 				_, failingChecks, fetchErr := anvilVCS.FetchPRChecks(workerCtx, wt.Path, req.PRNumber)
@@ -950,7 +950,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 						useBatch = false
 					}
 					if useBatch {
-						res = cifix.BatchFix(workerCtx, cifix.BatchFixParams{
+						res = quench.BatchFix(workerCtx, quench.BatchFixParams{
 						WorktreePath:  wt.Path,
 						BeadID:        req.BeadID,
 						AnvilName:     req.Anvil,
@@ -959,7 +959,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 						DB:            d.db,
 						WorkerID:      workerID,
 						ExtraFlags:    cfg.Settings.ClaudeFlags,
-						Providers:     cifixProviders,
+						Providers:     quenchProviders,
 						FailingChecks: failingChecks,
 						CILogs:        ciLogs,
 						})
@@ -967,8 +967,8 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 				}
 			}
 			if !useBatch {
-				cifixDetectOpts := temper.DetectOptionsFromAnvilFlag(anvilCfg.GolangciLint)
-				res = cifix.Fix(workerCtx, cifix.FixParams{
+				quenchDetectOpts := temper.DetectOptionsFromAnvilFlag(anvilCfg.GolangciLint)
+				res = quench.Fix(workerCtx, quench.FixParams{
 					WorktreePath:    wt.Path,
 					BeadID:          req.BeadID,
 					AnvilName:       req.Anvil,
@@ -979,11 +979,11 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 					WorkerID:        workerID,
 					ExtraFlags:      cfg.Settings.ClaudeFlags,
 					TemperConfig:    d.resolveTemperConfig(anvilCfg),
-					DetectOptions:   cifixDetectOpts,
+					DetectOptions:   quenchDetectOpts,
 					GoRaceDetection: d.resolveGoRaceDetection(anvilCfg),
-					Providers:       cifixProviders,
+					Providers:       quenchProviders,
 					VCS:             d.vcsForAnvil(req.Anvil),
-					LearnConfig:     d.cifixLearnConfig(req.Anvil),
+					LearnConfig:     d.quenchLearnConfig(req.Anvil),
 				})
 			}
 			status := state.WorkerDone
@@ -1003,7 +1003,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 				// Reset the snapshot only; do not trigger an immediate Refresh()
 				// here because CI checks may still be pending. An immediate poll
 				// would see "not yet passing" and could emit EventCIFailed while
-				// checks are still running, burning through cifix retries before
+				// checks are still running, burning through quench retries before
 				// CI has a chance to complete. The regular poll interval is
 				// sufficient to re-detect failure once CI settles.
 				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
@@ -1023,19 +1023,19 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 				StartedAt:    time.Now(),
 				StaleTimeout: workerTimeout / 2,
 			})
-			reviewCfg := d.cfg.Load()
-			reviewProviders := d.filterCopilotIfLimited(provider.FromConfig(config.ProvidersForStageWithAnvil(reviewCfg.Settings, &anvilCfg, "reviewfix")))
+			burnishCfg := d.cfg.Load()
+			burnishProviders := d.filterCopilotIfLimited(provider.FromConfig(config.ProvidersForStageWithAnvil(burnishCfg.Settings, &anvilCfg, "reviewfix")))
 			// Use batch mode when copilot_batch_review_fixes is enabled and the primary provider is Copilot.
-			var res *reviewfix.FixResult
-			useReviewBatch := reviewCfg.Settings.CopilotBatchReviewFixes && len(reviewProviders) > 0 && reviewProviders[0].Kind == provider.Copilot
-			if useReviewBatch {
+			var res *burnish.FixResult
+			useBurnishBatch := burnishCfg.Settings.CopilotBatchReviewFixes && len(burnishProviders) > 0 && burnishProviders[0].Kind == provider.Copilot
+			if useBurnishBatch {
 				anvilVCS := d.vcsForAnvil(req.Anvil)
 				comments, fetchErr := anvilVCS.FetchReviewComments(workerCtx, wt.Path, req.PRNumber)
 				if fetchErr != nil {
 					d.logger.Warn("failed to fetch review comments for batch fix, falling back to single fix", "pr", req.PRNumber, "error", fetchErr)
-					useReviewBatch = false
+					useBurnishBatch = false
 				} else {
-					res = reviewfix.BatchFix(workerCtx, reviewfix.BatchFixParams{
+					res = burnish.BatchFix(workerCtx, burnish.BatchFixParams{
 						WorktreePath: wt.Path,
 						BeadID:       req.BeadID,
 						AnvilName:    req.Anvil,
@@ -1043,15 +1043,15 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 						Branch:       req.Branch,
 						DB:           d.db,
 						WorkerID:     workerID,
-						ExtraFlags:   reviewCfg.Settings.ClaudeFlags,
-						Providers:    reviewProviders,
+						ExtraFlags:   burnishCfg.Settings.ClaudeFlags,
+						Providers:    burnishProviders,
 						Comments:     comments,
 						VCS:          anvilVCS,
 					})
 				}
 			}
-			if !useReviewBatch {
-				res = reviewfix.Fix(workerCtx, reviewfix.FixParams{
+			if !useBurnishBatch {
+				res = burnish.Fix(workerCtx, burnish.FixParams{
 					WorktreePath: wt.Path,
 					BeadID:       req.BeadID,
 					AnvilName:    req.Anvil,
@@ -1060,9 +1060,9 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 					Branch:       req.Branch,
 					DB:           d.db,
 					WorkerID:     workerID,
-					MaxAttempts:  reviewCfg.Settings.MaxReviewAttempts,
-					ExtraFlags:   reviewCfg.Settings.ClaudeFlags,
-					Providers:    reviewProviders,
+					MaxAttempts:  burnishCfg.Settings.MaxReviewAttempts,
+					ExtraFlags:   burnishCfg.Settings.ClaudeFlags,
+					Providers:    burnishProviders,
 					VCS:          d.vcsForAnvil(req.Anvil),
 				})
 			}
@@ -1081,7 +1081,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 				// fresh CI state. The review fix pushed new commits which
 				// trigger a new CI run — without resetting, bellows sees
 				// CIPassing false→false (no transition) and never emits
-				// EventCIFailed, preventing a cifix worker from spawning.
+				// EventCIFailed, preventing a quench worker from spawning.
 				if d.bellowsMonitor != nil {
 					d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
 				}
@@ -3933,7 +3933,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				IsManual: true,
 			}
 			go d.handleLifecycleAction(d.runCtx, req)
-			_ = d.db.LogEvent(state.EventCIFixStarted, fmt.Sprintf("PR #%d CI fix triggered by user", pa.PRNumber), pa.BeadID, pa.Anvil)
+			_ = d.db.LogEvent(state.EventQuenchStarted, fmt.Sprintf("PR #%d CI fix triggered by user", pa.PRNumber), pa.BeadID, pa.Anvil)
 			d.logger.Info("CI fix triggered by user via pr_action", "pr", pa.PRNumber, "anvil", pa.Anvil)
 
 		case "burnish", "reviewfix":
@@ -3950,7 +3950,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				IsManual: true,
 			}
 			go d.handleLifecycleAction(d.runCtx, req)
-			_ = d.db.LogEvent(state.EventReviewFixStarted, fmt.Sprintf("PR #%d review fix triggered by user", pa.PRNumber), pa.BeadID, pa.Anvil)
+			_ = d.db.LogEvent(state.EventBurnishStarted, fmt.Sprintf("PR #%d review fix triggered by user", pa.PRNumber), pa.BeadID, pa.Anvil)
 			d.logger.Info("review fix triggered by user via pr_action", "pr", pa.PRNumber, "anvil", pa.Anvil)
 
 		case "rebase":

--- a/internal/hearth/data.go
+++ b/internal/hearth/data.go
@@ -202,9 +202,9 @@ func inferWorkerType(id string, status state.WorkerStatus) string {
 		return "warden"
 	case len(id) > 7 && id[:7] == "temper-":
 		return "temper"
-	case len(id) > 6 && id[:6] == "cifix-":
+	case len(id) > 7 && id[:7] == "quench-":
 		return "quench"
-	case len(id) > 10 && id[:10] == "reviewfix-":
+	case len(id) > 8 && id[:8] == "burnish-":
 		return "burnish"
 	case len(id) > 7 && id[:7] == "rebase-":
 		return "rebase"

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -146,8 +146,8 @@ type PRActionMenuChoice int
 const (
 	PRActionOpenBrowser      PRActionMenuChoice = iota // Open in GitHub
 	PRActionMerge                                      // Merge the PR
-	PRActionFixCI                                      // Trigger cifix worker
-	PRActionFixComments                                // Trigger reviewfix worker
+	PRActionFixCI                                      // Trigger quench worker
+	PRActionFixComments                                // Trigger burnish worker
 	PRActionResolveConflicts                           // Trigger rebase worker
 	PRActionClosePR                                    // Close the PR
 	PRActionAssignBellows                              // Assign bellows to monitor & autofix
@@ -2834,13 +2834,13 @@ func (m *Model) buildPRActionForm(item *PRItem, choice *PRActionMenuChoice) *huh
 	if !item.IsConflicting {
 		opts = append(opts, huh.NewOption("Merge            — Merge this pull request", PRActionMerge))
 	}
-	// Lifecycle actions (cifix, reviewfix, rebase) only for forge-managed or bellows-assigned PRs
+	// Lifecycle actions (quench, burnish, rebase) only for forge-managed or bellows-assigned PRs
 	if item.BellowsManaged {
 		if !item.CIPassing {
-			opts = append(opts, huh.NewOption("Fix CI           — Run cifix worker", PRActionFixCI))
+			opts = append(opts, huh.NewOption("Fix CI           — Run quench worker", PRActionFixCI))
 		}
 		if item.HasUnresolvedThreads {
-			opts = append(opts, huh.NewOption("Fix comments     — Run reviewfix worker", PRActionFixComments))
+			opts = append(opts, huh.NewOption("Fix comments     — Run burnish worker", PRActionFixComments))
 		}
 		if item.IsConflicting {
 			opts = append(opts, huh.NewOption("Fix conflict     — Run rebase worker", PRActionResolveConflicts))

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -580,7 +580,7 @@ func TestManager_AnvilCollision(t *testing.T) {
 // fix cycle" guard.
 //
 // This covers the real-world scenario where:
-//  1. First wave: reviewer requests changes → reviewfix dispatched (ReviewNeedsFix=true)
+//  1. First wave: reviewer requests changes → burnish dispatched (ReviewNeedsFix=true)
 //  2. Second wave arrives WHILE fix is running → "already in fix cycle" (expected)
 //  3. Fix worker pushes changes → NotifyReviewFixCompleted clears ReviewNeedsFix
 //  4. Reviewer re-examines the push, still requests changes → new EventReviewChanges
@@ -951,7 +951,7 @@ func TestCIFixRetryFlowToExhaustion(t *testing.T) {
 		if st.CIFixCount != i {
 			t.Fatalf("cycle %d: expected CIFixCount=%d, got %d", i, i, st.CIFixCount)
 		}
-		// Simulate cifix worker completing (CI still broken).
+		// Simulate quench worker completing (CI still broken).
 		m.NotifyCIFixCompleted("test-anvil", 700)
 	}
 

--- a/internal/quench/quench.go
+++ b/internal/quench/quench.go
@@ -1,11 +1,11 @@
-// Package cifix spawns a Smith worker to fix CI failures on a PR branch.
+// Package quench spawns a Smith worker to fix CI failures on a PR branch.
 //
-// When Bellows detects CI failures, cifix checks out the existing PR branch,
+// When Bellows detects CI failures, quench checks out the existing PR branch,
 // fetches failing check details via the VCS provider, runs Temper to reproduce
 // local failures, then spawns Smith with a targeted fix prompt. For CI checks
 // that Temper cannot reproduce (e.g. changelog-check), Smith receives the
 // failing check names and CI logs directly.
-package cifix
+package quench
 
 import (
 	"context"
@@ -55,7 +55,7 @@ type FixParams struct {
 	// DetectOptions controls optional steps during Temper auto-detection.
 	// When TemperConfig is nil, these options are forwarded to
 	// temper.DefaultConfig so that per-anvil settings (e.g. DisableGolangciLint)
-	// are respected by the cifix worker.
+	// are respected by the quench worker.
 	DetectOptions *temper.DetectOptions
 	// GoRaceDetection enables a separate 'go test -race' step in Temper.
 	// Only used during auto-detection (when TemperConfig is nil).
@@ -131,7 +131,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	prompt := buildBatchCIPrompt(p)
 
 	if p.DB != nil {
-		_ = p.DB.LogEvent(state.EventCIFixStarted,
+		_ = p.DB.LogEvent(state.EventQuenchStarted,
 			fmt.Sprintf("PR #%d: batch fix for %d failing checks", p.PRNumber, len(p.FailingChecks)),
 			p.BeadID, p.AnvilName)
 	}
@@ -179,7 +179,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	if smithResult == nil {
 		result.Error = fmt.Errorf("batch CI fix: no smith result (no providers available)")
 		if p.DB != nil {
-			_ = p.DB.LogEvent(state.EventCIFixFailed,
+			_ = p.DB.LogEvent(state.EventQuenchFailed,
 				fmt.Sprintf("PR #%d batch fix: no smith result", p.PRNumber),
 				p.BeadID, p.AnvilName)
 		}
@@ -190,7 +190,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	if smithResult.RateLimited {
 		result.Error = fmt.Errorf("all providers (%d) are rate limited", len(providers))
 		if p.DB != nil {
-			_ = p.DB.LogEvent(state.EventCIFixFailed,
+			_ = p.DB.LogEvent(state.EventQuenchFailed,
 				fmt.Sprintf("PR #%d batch fix: all providers rate limited", p.PRNumber),
 				p.BeadID, p.AnvilName)
 		}
@@ -201,7 +201,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	if smithResult.ExitCode != 0 {
 		result.Error = fmt.Errorf("batch CI fix failed (exit %d)", smithResult.ExitCode)
 		if p.DB != nil {
-			_ = p.DB.LogEvent(state.EventCIFixFailed,
+			_ = p.DB.LogEvent(state.EventQuenchFailed,
 				fmt.Sprintf("PR #%d: batch Smith exit %d", p.PRNumber, smithResult.ExitCode),
 				p.BeadID, p.AnvilName)
 		}
@@ -212,7 +212,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	log.Printf("[quench] PR #%d: batch CI fix applied for %d checks", p.PRNumber, len(p.FailingChecks))
 	result.Fixed = true
 	if p.DB != nil {
-		_ = p.DB.LogEvent(state.EventCIFixSuccess,
+		_ = p.DB.LogEvent(state.EventQuenchSuccess,
 			fmt.Sprintf("PR #%d: batch fix applied for %d checks", p.PRNumber, len(p.FailingChecks)),
 			p.BeadID, p.AnvilName)
 	}
@@ -257,7 +257,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 	result := &FixResult{}
 
 	if p.VCS == nil {
-		result.Error = fmt.Errorf("cifix: VCS provider is required but was not set")
+		result.Error = fmt.Errorf("quench: VCS provider is required but was not set")
 		result.Duration = time.Since(start)
 		return result
 	}
@@ -333,7 +333,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		if failedStep == "" && len(failingChecks) > 0 {
 			failedStep = "github:" + failingChecks[0].Name
 		}
-		_ = p.DB.LogEvent(state.EventCIFixStarted,
+		_ = p.DB.LogEvent(state.EventQuenchStarted,
 			fmt.Sprintf("PR #%d: attempt %d, failed step: %s", p.PRNumber, attempt, failedStep),
 			p.BeadID, p.AnvilName)
 
@@ -392,7 +392,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 
 		if smithResult.RateLimited {
 			log.Printf("[quench] PR #%d: All providers rate limited on attempt %d", p.PRNumber, attempt)
-			_ = p.DB.LogEvent(state.EventCIFixFailed,
+			_ = p.DB.LogEvent(state.EventQuenchFailed,
 				fmt.Sprintf("PR #%d attempt %d: all providers rate limited", p.PRNumber, attempt),
 				p.BeadID, p.AnvilName)
 			result.Error = fmt.Errorf("all providers (%d) are rate limited", len(providers))
@@ -402,7 +402,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 
 		if smithResult.ExitCode != 0 {
 			log.Printf("[quench] PR #%d: Smith fix attempt %d failed (exit %d)", p.PRNumber, attempt, smithResult.ExitCode)
-			_ = p.DB.LogEvent(state.EventCIFixFailed,
+			_ = p.DB.LogEvent(state.EventQuenchFailed,
 				fmt.Sprintf("PR #%d: Smith exit %d on attempt %d", p.PRNumber, smithResult.ExitCode, attempt),
 				p.BeadID, p.AnvilName)
 			continue
@@ -415,7 +415,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		if verifyResult.Passed {
 			log.Printf("[quench] PR #%d: Fixed on attempt %d (local verification passed)", p.PRNumber, attempt)
 			result.Fixed = true
-			_ = p.DB.LogEvent(state.EventCIFixSuccess,
+			_ = p.DB.LogEvent(state.EventQuenchSuccess,
 				fmt.Sprintf("PR #%d: Fixed on attempt %d", p.PRNumber, attempt),
 				p.BeadID, p.AnvilName)
 			result.Duration = time.Since(start)
@@ -451,7 +451,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 	}
 
 	result.Error = fmt.Errorf("could not fix CI after %d attempts", MaxAttempts)
-	_ = p.DB.LogEvent(state.EventCIFixFailed,
+	_ = p.DB.LogEvent(state.EventQuenchFailed,
 		fmt.Sprintf("PR #%d: Exhausted %d fix attempts", p.PRNumber, MaxAttempts),
 		p.BeadID, p.AnvilName)
 	result.Duration = time.Since(start)

--- a/internal/quench/quench_test.go
+++ b/internal/quench/quench_test.go
@@ -1,4 +1,4 @@
-package cifix
+package quench
 
 import (
 	"context"

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -450,7 +450,7 @@ type Worker struct {
 	Status      WorkerStatus
 	Phase       string // active component: smith|temper|warden|bellows|idle
 	Title       string // bead title for display in hearth
-	PRNumber    int    // PR number for bellows-triggered workers (cifix/reviewfix/rebase)
+	PRNumber    int    // PR number for bellows-triggered workers (quench/burnish/rebase)
 	StartedAt   time.Time
 	CompletedAt *time.Time
 	LogPath     string
@@ -596,7 +596,7 @@ func (db *DB) StalledWorkers(staleThreshold time.Duration) ([]Worker, error) {
 		}
 	}
 
-	// Check lifecycle workers (quench/cifix/burnish/reviewfix/rebase) that carry a
+	// Check lifecycle workers (quench/burnish/rebase) that carry a
 	// per-worker stale timeout. These phases are excluded from the global check
 	// above but should still surface as stalled when they stop producing log output
 	// within their own per-worker threshold (set at worker registration time).
@@ -666,7 +666,7 @@ func (db *DB) MarkWorkerStalled(id string) error {
 
 // ActiveDispatchWorkers returns active workers that are running primary dispatch
 // pipeline phases (smith, temper, warden). Bellows (PR monitoring) and lifecycle
-// workers (cifix, reviewfix, rebase) are excluded so they don't consume dispatch capacity slots.
+// workers (quench, burnish, rebase) are excluded so they don't consume dispatch capacity slots.
 // Stalled workers are included so they continue to count against capacity and
 // prevent the daemon from over-subscribing while stalled processes are still running.
 func (db *DB) ActiveDispatchWorkers() ([]Worker, error) {
@@ -677,7 +677,7 @@ func (db *DB) ActiveDispatchWorkers() ([]Worker, error) {
 }
 
 // ActiveDispatchWorkersByAnvil returns active dispatch workers for a given anvil,
-// excluding bellows and lifecycle workers (cifix, reviewfix, rebase).
+// excluding bellows and lifecycle workers (quench, burnish, rebase).
 // Stalled workers are included so they continue to count against per-anvil capacity.
 func (db *DB) ActiveDispatchWorkersByAnvil(anvil string) ([]Worker, error) {
 	return db.queryWorkers(`SELECT id, bead_id, anvil, branch, pid, status, phase, title, pr_number, started_at, completed_at, log_path
@@ -877,7 +877,7 @@ type PR struct {
 	HasPendingReviews    bool
 	HasApproval          bool
 	Title                string
-	BellowsManaged       bool // true = bellows runs lifecycle workers (cifix, reviewfix, rebase)
+	BellowsManaged       bool // true = bellows runs lifecycle workers (quench, burnish, rebase)
 }
 
 // IsExternal returns true if this PR was discovered via GitHub reconciliation
@@ -1148,7 +1148,7 @@ func (db *DB) UpdatePRMergeability(id int, ciPassing, isConflicting, hasUnresolv
 }
 
 // UpdatePRBellowsManaged sets the bellows_managed flag for a PR.
-// When true, bellows will run lifecycle workers (cifix, reviewfix, rebase) for this PR.
+// When true, bellows will run lifecycle workers (quench, burnish, rebase) for this PR.
 func (db *DB) UpdatePRBellowsManaged(id int, managed bool) error {
 	_, err := db.conn.Exec(`UPDATE prs SET bellows_managed = ? WHERE id = ?`, boolToInt(managed), id)
 	return err
@@ -1341,15 +1341,15 @@ const (
 	EventTemperFailed         EventType = "temper_failed"
 	EventBellowsStarted       EventType = "bellows_started"
 	EventCIFailed             EventType = "ci_failed"
-	EventCIFixStarted         EventType = "ci_fix_started"
-	EventCIFixSuccess         EventType = "ci_fix_success"
-	EventCIFixFailed          EventType = "ci_fix_failed"
+	EventQuenchStarted        EventType = "ci_fix_started"
+	EventQuenchSuccess        EventType = "ci_fix_success"
+	EventQuenchFailed         EventType = "ci_fix_failed"
 	EventReviewChanges        EventType = "review_changes"
-	EventReviewFixStarted     EventType = "review_fix_started"
-	EventReviewFixSuccess     EventType = "review_fix_success"
-	EventReviewFixFailed      EventType = "review_fix_failed"
+	EventBurnishStarted       EventType = "review_fix_started"
+	EventBurnishSuccess       EventType = "review_fix_success"
+	EventBurnishFailed        EventType = "review_fix_failed"
 	EventReviewThreadResolved EventType = "review_thread_resolved"
-	EventReviewFixSmithError  EventType = "review_fix_smith_error"
+	EventBurnishSmithError    EventType = "review_fix_smith_error"
 	EventPRCreated            EventType = "pr_created"
 	EventPRMerged             EventType = "pr_merged"
 	EventPRClosed             EventType = "pr_closed"

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -897,18 +897,18 @@ func TestDB_StalledWorkers_ExcludesLongRunningPhases(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Cifix worker — should be excluded
+	// Quench worker — should be excluded
 	if err := db.InsertWorker(&Worker{
-		ID: "w-cifix", BeadID: "BD-3", Anvil: "anvil-1",
+		ID: "w-quench", BeadID: "BD-3", Anvil: "anvil-1",
 		Status: WorkerRunning, Phase: "quench",
 		StartedAt: time.Now().Add(-25 * time.Minute),
 		LogPath:   makeStaleLog("quench.log"),
 	}); err != nil {
 		t.Fatal(err)
 	}
-	// Reviewfix worker — should be excluded
+	// Burnish worker — should be excluded
 	if err := db.InsertWorker(&Worker{
-		ID: "w-reviewfix", BeadID: "BD-4", Anvil: "anvil-1",
+		ID: "w-burnish", BeadID: "BD-4", Anvil: "anvil-1",
 		Status: WorkerRunning, Phase: "burnish",
 		StartedAt: time.Now().Add(-25 * time.Minute),
 		LogPath:   makeStaleLog("burnish.log"),

--- a/internal/warden/learn.go
+++ b/internal/warden/learn.go
@@ -372,7 +372,7 @@ func LearnFromCIFix(ctx context.Context, anvilPath, repoDir string, failingLogs 
 		lc = cfg[0]
 	}
 
-	source := fmt.Sprintf("cifix:PR#%d", prNumber)
+	source := fmt.Sprintf("quench:PR#%d", prNumber)
 	changed := false
 	var pendingRules []Rule
 

--- a/internal/warden/learn_quench_test.go
+++ b/internal/warden/learn_quench_test.go
@@ -101,7 +101,7 @@ func TestLearnFromCIFix_SkipExisting(t *testing.T) {
 				Category: "ui",
 				Pattern:  "calling setState inside useEffect",
 				Check:    "don't call setState unconditionally in useEffect",
-				Source:   SourceList{"cifix:PR#1"},
+				Source:   SourceList{"quench:PR#1"},
 				Added:    "2025-01-01",
 			},
 		},
@@ -166,7 +166,7 @@ func TestLearnFromCIFix_DistillsNewRule(t *testing.T) {
 	if r.ID != "react-hooks-exhaustive-deps" {
 		t.Errorf("unexpected rule ID %q", r.ID)
 	}
-	wantSource := fmt.Sprintf("cifix:PR#%d", 99)
+	wantSource := fmt.Sprintf("quench:PR#%d", 99)
 	if r.Source.String() != wantSource {
 		t.Errorf("expected source %q, got %q", wantSource, r.Source)
 	}
@@ -273,7 +273,7 @@ func TestLearnFromCIFix_SmelterEnabled(t *testing.T) {
 	if insertedAnvil != "test-anvil" {
 		t.Errorf("expected insertedAnvil %q, got %q", "test-anvil", insertedAnvil)
 	}
-	wantSource := "cifix:PR#77"
+	wantSource := "quench:PR#77"
 	if insertedSource != wantSource {
 		t.Errorf("expected insertedSource %q, got %q", wantSource, insertedSource)
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -235,7 +235,7 @@ func ActiveCount(db *state.DB, anvilName string) (int, error) {
 }
 
 // DispatchActiveCount returns the number of active dispatch pipeline workers for
-// an anvil, excluding lifecycle workers (cifix, reviewfix). This is the correct
+// an anvil, excluding lifecycle workers (quench, burnish). This is the correct
 // value to compare against max_smiths.
 func DispatchActiveCount(db *state.DB, anvilName string) (int, error) {
 	workers, err := db.ActiveDispatchWorkersByAnvil(anvilName)
@@ -247,7 +247,7 @@ func DispatchActiveCount(db *state.DB, anvilName string) (int, error) {
 
 // CanSpawn checks if a new worker can be spawned for the given anvil,
 // respecting the max_smiths limit. Only dispatch pipeline workers count;
-// lifecycle workers (cifix, reviewfix) are excluded.
+// lifecycle workers (quench, burnish) are excluded.
 func CanSpawn(db *state.DB, anvilName string, maxSmiths int) (bool, error) {
 	active, err := DispatchActiveCount(db, anvilName)
 	if err != nil {
@@ -266,7 +266,7 @@ func TotalActiveCount(db *state.DB) (int, error) {
 }
 
 // DispatchTotalActiveCount returns the total number of active dispatch pipeline
-// workers across all anvils, excluding lifecycle workers (cifix, reviewfix).
+// workers across all anvils, excluding lifecycle workers (quench, burnish).
 // This is the correct value to compare against max_total_smiths.
 func DispatchTotalActiveCount(db *state.DB) (int, error) {
 	workers, err := db.ActiveDispatchWorkers()
@@ -278,7 +278,7 @@ func DispatchTotalActiveCount(db *state.DB) (int, error) {
 
 // CanSpawnGlobal checks if a new worker can be spawned globally,
 // respecting the max_total_smiths limit. Only dispatch pipeline workers count;
-// lifecycle workers (cifix, reviewfix) are excluded.
+// lifecycle workers (quench, burnish) are excluded.
 func CanSpawnGlobal(db *state.DB, maxTotal int) (bool, error) {
 	total, err := DispatchTotalActiveCount(db)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Renamed `internal/cifix/` → `internal/quench/` and `internal/reviewfix/` → `internal/burnish/`
- Updated all import paths across 23 files
- Go identifiers renamed to match (e.g. `cifixLearnConfig` → `quenchLearnConfig`)
- DB columns (`ci_fix_count`, `review_fix_count`) and config keys (`"cifix"`, `"reviewfix"`) preserved unchanged for backward compatibility
- Documentation updated (CLAUDE.md, README.md, docs/)

Bead: Forge-8tex

🤖 Generated with [Claude Code](https://claude.com/claude-code)