### PR TITLE
schematic: tolerate bd dep add exiting non-zero when dependency was actually added (Forge-30a5)

### DIFF
--- a/changelog.d/Forge-30a5.md
+++ b/changelog.d/Forge-30a5.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Schematic tolerates bd dep add non-zero exit** - When `bd dep add` exits non-zero but stdout confirms the dependency was added, treat it as success instead of marking the bead as needing clarification. (Forge-30a5)

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -484,12 +484,17 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 			prev := subBeads[len(subBeads)-2]
 			depCtx, depCancel := context.WithTimeout(ctx, 15*time.Second)
 			depOut, depErr := run(depCtx, anvilPath, "dep", "add", created.ID, prev.ID)
+			depCtxErr := depCtx.Err() // capture before Cancel clears it
 			depCancel()
 			if depErr != nil {
 				// bd dep add can exit non-zero even when the dependency was
 				// successfully added (stdout contains "✓ Added dependency").
-				// Treat that as success to avoid torpedoing a good decomposition.
-				if strings.Contains(string(depOut), "Added dependency") {
+				// Only treat it as success for exit-status-1 failures when the
+				// context had not been canceled/expired at call time (to avoid
+				// masking timeouts or other execution failures).
+				exitErr, isExitErr := depErr.(*exec.ExitError)
+				if isExitErr && exitErr.ExitCode() == 1 && depCtxErr == nil &&
+					strings.Contains(string(depOut), "Added dependency") {
 					log.Printf("[schematic:%s] bd dep add exited non-zero but dependency was added (%s -> %s), ignoring exit code: %v",
 						parent.ID, created.ID, prev.ID, depErr)
 				} else {

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -486,11 +486,19 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 			depOut, depErr := run(depCtx, anvilPath, "dep", "add", created.ID, prev.ID)
 			depCancel()
 			if depErr != nil {
-				log.Printf("[schematic:%s] Failed to add sequential dep %s -> %s: %v: %s",
-					parent.ID, created.ID, prev.ID, depErr, depOut)
-				resetParent()
-				return subBeads, fmt.Errorf("adding sequential dependency %s -> %s: %w: %s",
-					created.ID, prev.ID, depErr, depOut)
+				// bd dep add can exit non-zero even when the dependency was
+				// successfully added (stdout contains "✓ Added dependency").
+				// Treat that as success to avoid torpedoing a good decomposition.
+				if strings.Contains(string(depOut), "Added dependency") {
+					log.Printf("[schematic:%s] bd dep add exited non-zero but dependency was added (%s -> %s), ignoring exit code: %v",
+						parent.ID, created.ID, prev.ID, depErr)
+				} else {
+					log.Printf("[schematic:%s] Failed to add sequential dep %s -> %s: %v: %s",
+						parent.ID, created.ID, prev.ID, depErr, depOut)
+					resetParent()
+					return subBeads, fmt.Errorf("adding sequential dependency %s -> %s: %w: %s",
+						created.ID, prev.ID, depErr, depOut)
+				}
 			}
 		}
 	}

--- a/internal/schematic/schematic_test.go
+++ b/internal/schematic/schematic_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"sync"
 	"testing"
 
@@ -11,6 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// exitError1 returns a real *exec.ExitError with exit code 1 by running "false".
+func exitError1(t *testing.T) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("false").Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	return exitErr
+}
 
 func TestShouldRun_DisabledConfig(t *testing.T) {
 	cfg := Config{Enabled: false, WordThreshold: 10}
@@ -311,6 +323,7 @@ func TestCreateSubBeads_DepAddFailureIsFatal(t *testing.T) {
 }
 
 func TestCreateSubBeads_DepAddNonZeroButAdded(t *testing.T) {
+	depErr := exitError1(t) // real *exec.ExitError with exit code 1
 	var idCounter int
 	var mu sync.Mutex
 	fake := &fakeRunner{
@@ -324,7 +337,7 @@ func TestCreateSubBeads_DepAddNonZeroButAdded(t *testing.T) {
 			}
 			if len(args) > 0 && args[0] == "dep" {
 				// bd dep add exits non-zero but stdout confirms the dep was added.
-				return []byte("✓ Added dependency: test-2 depends on test-1 (blocks)"), fmt.Errorf("exit status 1")
+				return []byte("✓ Added dependency: test-2 depends on test-1 (blocks)"), depErr
 			}
 			return []byte("ok"), nil
 		},

--- a/internal/schematic/schematic_test.go
+++ b/internal/schematic/schematic_test.go
@@ -310,6 +310,38 @@ func TestCreateSubBeads_DepAddFailureIsFatal(t *testing.T) {
 	assert.NotEmpty(t, subs, "partial sub-beads should be returned even on dep add failure")
 }
 
+func TestCreateSubBeads_DepAddNonZeroButAdded(t *testing.T) {
+	var idCounter int
+	var mu sync.Mutex
+	fake := &fakeRunner{
+		response: func(args []string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "create" {
+				mu.Lock()
+				idCounter++
+				id := fmt.Sprintf("test-%d", idCounter)
+				mu.Unlock()
+				return []byte(fmt.Sprintf(`{"id":%q}`, id)), nil
+			}
+			if len(args) > 0 && args[0] == "dep" {
+				// bd dep add exits non-zero but stdout confirms the dep was added.
+				return []byte("✓ Added dependency: test-2 depends on test-1 (blocks)"), fmt.Errorf("exit status 1")
+			}
+			return []byte("ok"), nil
+		},
+	}
+
+	parent := poller.Bead{ID: "parent-1", Title: "Feature", Priority: 2}
+	tasks := []subTaskVerdict{
+		{Title: "Task A", Description: "Desc A"},
+		{Title: "Task B", Description: "Desc B"},
+	}
+
+	subs, err := createSubBeads(context.Background(), parent, tasks, "/tmp", fake.run)
+	// Should succeed because the output confirms the dependency was added.
+	require.NoError(t, err, "dep add with success marker in output should not be fatal")
+	assert.Len(t, subs, 2)
+}
+
 func TestCreateSubBeads_SingleTaskNoDep(t *testing.T) {
 	fake := newFakeRunner()
 	parent := poller.Bead{ID: "parent-1", Title: "Simple task", Priority: 1}


### PR DESCRIPTION
## Changes

- **Schematic tolerates bd dep add non-zero exit** - When `bd dep add` exits non-zero but stdout confirms the dependency was added, treat it as success instead of marking the bead as needing clarification. (Forge-30a5)

## Original Issue (task): schematic: tolerate bd dep add exiting non-zero when dependency was actually added

## Problem

`internal/schematic/schematic.go:488` treats any non-zero exit from `bd dep add` as fatal and calls `resetParent()`, flipping the bead to `ActionClarify`. However, `bd dep add` can exit with status 1 even when the dependency has been successfully added — its stdout shows `✓ Added dependency: ...`.

The result is that an otherwise-successful decomposition is marked as `needs clarification`, leaving the parent bead stuck in the forge queue's Needs Attention column even though the sub-beads and sequential dependency chain are all correctly in place on the anvil.

## Repro (real incident)

Bead `Fhi.Metadata-jp8d` on the munin anvil, 2026-04-10:

```
dispatch_failed: Automatic decomposition failed, bead requires manual review:
adding sequential dependency Fhi.Metadata-9k38 -> Fhi.Metadata-56js:
exit status 1: ✓ Added dependency: Fhi.Metadata-9k38 (...) depends on
Fhi.Metadata-56js (...) (blocks)
```

Post-incident verification on the anvil:
- `Fhi.Metadata-jp8d` — depends on both `56js` and `9k38` ✓
- `Fhi.Metadata-56js` — no deps, ready ✓
- `Fhi.Metadata-9k38` — depends on `56js` ✓ (the "failed" dep is present)

The decomposition was fully intact; only the forge state had `clarification_needed=1`.

## Proposed fix

In `internal/schematic/schematic.go` around line 486, after `bd dep add` returns non-zero:

1. Check whether the stdout contains `✓ Added dependency` and treat that as success.
2. Or, more robustly: re-query the dependency via `bd show` on the child and verify the link is present. Treat "already present" as success (idempotent).

Either approach avoids torching a good decomposition over a flaky exit code.

## Impact

- Low severity but annoying: the bead sits in Needs Attention until a human manually `forge queue unclarify`s it.
- The children are left without `forgeReady`, so they don't get picked up either — the whole decomposed tree stalls.

## Notes

Root cause of `bd`'s non-zero exit is unknown and may also warrant investigation in the beads project, but forge should be defensive regardless.

Source: https://github.com/Robin831/Forge/issues/506

---
Bead: Forge-30a5 | Branch: forge/Forge-30a5
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)