### PR TITLE
schematic: use json.Decoder to tolerate trailing noise in bd create --json output (Forge-byca)

### DIFF
--- a/changelog.d/Forge-byca.md
+++ b/changelog.d/Forge-byca.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Schematic tolerates trailing noise in bd output** - Use streaming JSON decoder instead of strict `json.Unmarshal` so that trailing diagnostics from `bd create --json` (e.g. orphan detection warnings) no longer break sub-bead ID parsing. Applied the same fix to depcheck and ledger packages. (Forge-byca)

--- a/internal/depcheck/depcheck.go
+++ b/internal/depcheck/depcheck.go
@@ -8,7 +8,6 @@ package depcheck
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os/exec"

--- a/internal/depcheck/depcheck.go
+++ b/internal/depcheck/depcheck.go
@@ -348,22 +348,12 @@ func (s *Scanner) createConsolidatedBead(ctx context.Context, allResults []*Chec
 	}
 
 	// Extract the bead ID from the JSON output for logging.
-	// bd create --json may emit extra lines (e.g. progress messages) before the JSON
-	// object, so fall back to scanning each line if a whole-output unmarshal fails.
+	// bd create --json may emit trailing diagnostics (e.g. orphan detection
+	// warnings) after the JSON object; use DecodeJSON to tolerate the noise.
 	var created struct {
 		ID string `json:"id"`
 	}
-	if err := json.Unmarshal(output, &created); err != nil || created.ID == "" {
-		for _, line := range strings.Split(string(output), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
-				continue
-			}
-			if err2 := json.Unmarshal([]byte(line), &created); err2 == nil && created.ID != "" {
-				break
-			}
-		}
-	}
+	_ = executil.DecodeJSON(output, &created)
 	if created.ID != "" {
 		log.Printf("[depcheck] %s: created consolidated bead %s", anvilName, created.ID)
 		_ = s.db.LogEvent(state.EventDepcheckBeadCreated,

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -15,7 +15,8 @@ import (
 func DecodeJSON(data []byte, v any) error {
 	// Fast path: output starts with JSON (tolerates trailing noise).
 	dec := json.NewDecoder(bytes.NewReader(data))
-	if err := dec.Decode(v); err == nil {
+	fastErr := dec.Decode(v)
+	if fastErr == nil {
 		return nil
 	}
 
@@ -24,10 +25,12 @@ func DecodeJSON(data []byte, v any) error {
 		dec = json.NewDecoder(bytes.NewReader(data[idx:]))
 		if err := dec.Decode(v); err == nil {
 			return nil
+		} else {
+			return fmt.Errorf("decoding JSON from subprocess output: %w", err)
 		}
 	}
 
-	return fmt.Errorf("no valid JSON value found in %d bytes of output", len(data))
+	return fmt.Errorf("decoding JSON from subprocess output: %w", fastErr)
 }
 
 // HideWindow configures cmd to not create a visible console window.

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -1,7 +1,34 @@
 // Package executil provides helpers for spawning subprocesses.
 package executil
 
-import "os/exec"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// DecodeJSON decodes one JSON value from subprocess output that may contain
+// leading or trailing non-JSON noise (log lines, diagnostics, etc.).
+// It uses json.NewDecoder which tolerates trailing data after the JSON value,
+// and falls back to scanning for the first '{' or '[' to handle leading noise.
+func DecodeJSON(data []byte, v any) error {
+	// Fast path: output starts with JSON (tolerates trailing noise).
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(v); err == nil {
+		return nil
+	}
+
+	// Slow path: skip leading noise by finding the first JSON delimiter.
+	if idx := bytes.IndexAny(data, "{["); idx > 0 {
+		dec = json.NewDecoder(bytes.NewReader(data[idx:]))
+		if err := dec.Decode(v); err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no valid JSON value found in %d bytes of output", len(data))
+}
 
 // HideWindow configures cmd to not create a visible console window.
 // On Windows this sets CREATE_NO_WINDOW. On other platforms it is a no-op.

--- a/internal/executil/executil_test.go
+++ b/internal/executil/executil_test.go
@@ -51,9 +51,9 @@ func TestDecodeJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:   "JSON array",
-			input:  "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
-			wantID: "",
+			name:    "JSON array into struct",
+			input:   "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
+			wantErr: true,
 		},
 	}
 

--- a/internal/executil/executil_test.go
+++ b/internal/executil/executil_test.go
@@ -1,0 +1,96 @@
+package executil
+
+import (
+	"testing"
+)
+
+func TestDecodeJSON(t *testing.T) {
+	type obj struct {
+		ID string `json:"id"`
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		wantID  string
+		wantErr bool
+	}{
+		{
+			name:   "clean JSON",
+			input:  `{"id":"abc"}`,
+			wantID: "abc",
+		},
+		{
+			name:   "trailing newline",
+			input:  "{\"id\":\"abc\"}\n",
+			wantID: "abc",
+		},
+		{
+			name:   "trailing log lines",
+			input:  "{\"id\":\"abc\"}\n2026/04/10 16:03:42.874951 orphan detection: found 975 orphaned child issue(s)\n  Fhi.Metadata-014f [closed] Warm up\n",
+			wantID: "abc",
+		},
+		{
+			name:   "leading log line then JSON",
+			input:  "some warning\n{\"id\":\"def\"}\n",
+			wantID: "def",
+		},
+		{
+			name:   "leading and trailing noise",
+			input:  "log line 1\n{\"id\":\"ghi\"}\nlog line 2\n",
+			wantID: "ghi",
+		},
+		{
+			name:    "no JSON at all",
+			input:   "just some text\nno json here\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:   "JSON array",
+			input:  "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
+			wantID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got obj
+			err := DecodeJSON([]byte(tt.input), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", got.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestDecodeJSON_Array(t *testing.T) {
+	type item struct {
+		Name string `json:"name"`
+	}
+
+	input := `[{"name":"first"},{"name":"second"}]` + "\n2026/04/10 orphan warning\n"
+	var got []item
+	if err := DecodeJSON([]byte(input), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2", len(got))
+	}
+	if got[0].Name != "first" {
+		t.Errorf("got[0].Name = %q, want %q", got[0].Name, "first")
+	}
+}

--- a/internal/ledger/actions.go
+++ b/internal/ledger/actions.go
@@ -2,11 +2,12 @@ package ledger
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Robin831/Forge/internal/executil"
 )
 
 // Action result messages returned by bead CRUD commands.
@@ -222,16 +223,17 @@ func RemoveDepCmd(anvilPath, beadID, depID string) tea.Cmd {
 
 // extractIDFromJSON does a best-effort extraction of the "id" field from
 // bd create --json output. The output may be a JSON array (e.g. [{"id":...}])
-// or a plain object. Returns empty string on failure.
+// or a plain object, and may contain trailing diagnostics (e.g. orphan
+// detection warnings). Returns empty string on failure.
 func extractIDFromJSON(data []byte) string {
 	// Try as array first — bd --json typically wraps results in an array.
 	var arr []Bead
-	if err := json.Unmarshal(data, &arr); err == nil && len(arr) > 0 {
+	if err := executil.DecodeJSON(data, &arr); err == nil && len(arr) > 0 {
 		return arr[0].ID
 	}
 	// Fall back to single object.
 	var b Bead
-	if err := json.Unmarshal(data, &b); err != nil {
+	if err := executil.DecodeJSON(data, &b); err != nil {
 		return ""
 	}
 	return b.ID

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -452,23 +452,16 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 			return subBeads, fmt.Errorf("creating sub-bead %q: %w: %s", task.Title, err, out)
 		}
 
-		// Extract ID from JSON output
+		// Extract ID from JSON output. bd may emit trailing diagnostics
+		// (e.g. orphan detection warnings) after the JSON object, so use a
+		// streaming decoder that tolerates trailing data.
 		var created struct {
 			ID string `json:"id"`
 		}
-		if err := json.Unmarshal(out, &created); err != nil {
-			// Try to find the ID in the output
-			lines := strings.Split(string(out), "\n")
-			for _, line := range lines {
-				if err2 := json.Unmarshal([]byte(line), &created); err2 == nil && created.ID != "" {
-					break
-				}
-			}
-			if created.ID == "" {
-				log.Printf("[schematic:%s] Partial decomposition failure after creating %d sub-beads: could not parse ID", parent.ID, len(subBeads))
-				resetParent()
-				return subBeads, fmt.Errorf("parsing sub-bead ID from output: %w: %s", err, out)
-			}
+		if err := executil.DecodeJSON(out, &created); err != nil || created.ID == "" {
+			log.Printf("[schematic:%s] Partial decomposition failure after creating %d sub-beads: could not parse ID", parent.ID, len(subBeads))
+			resetParent()
+			return subBeads, fmt.Errorf("parsing sub-bead ID from output: %w: %s", err, out)
 		}
 
 		subBeads = append(subBeads, SubBead{ID: created.ID, Title: task.Title})
@@ -592,7 +585,8 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 func parseDepsFromShow(jsonOutput string) (upstreamIDs, downstreamIDs []string) {
 	// bd show --json returns an array with one element.
 	var items []json.RawMessage
-	if err := json.Unmarshal([]byte(jsonOutput), &items); err != nil || len(items) == 0 {
+	// bd show --json may emit trailing diagnostics; use DecodeJSON to tolerate noise.
+	if err := executil.DecodeJSON([]byte(jsonOutput), &items); err != nil || len(items) == 0 {
 		// Try parsing as a single object.
 		items = []json.RawMessage{json.RawMessage(jsonOutput)}
 	}
@@ -605,7 +599,7 @@ func parseDepsFromShow(jsonOutput string) (upstreamIDs, downstreamIDs []string) 
 			ID string `json:"id"`
 		} `json:"dependents"`
 	}
-	if err := json.Unmarshal(items[0], &parsed); err != nil {
+	if err := executil.DecodeJSON(items[0], &parsed); err != nil {
 		return nil, nil
 	}
 

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -458,10 +458,15 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 		var created struct {
 			ID string `json:"id"`
 		}
-		if err := executil.DecodeJSON(out, &created); err != nil || created.ID == "" {
+		if err := executil.DecodeJSON(out, &created); err != nil {
 			log.Printf("[schematic:%s] Partial decomposition failure after creating %d sub-beads: could not parse ID", parent.ID, len(subBeads))
 			resetParent()
 			return subBeads, fmt.Errorf("parsing sub-bead ID from output: %w: %s", err, out)
+		}
+		if created.ID == "" {
+			log.Printf("[schematic:%s] Partial decomposition failure after creating %d sub-beads: could not parse ID", parent.ID, len(subBeads))
+			resetParent()
+			return subBeads, fmt.Errorf("parsing sub-bead ID from output: missing id in bd create JSON: %s", out)
 		}
 
 		subBeads = append(subBeads, SubBead{ID: created.ID, Title: task.Title})


### PR DESCRIPTION
## Changes

- **Schematic tolerates trailing noise in bd output** - Use streaming JSON decoder instead of strict `json.Unmarshal` so that trailing diagnostics from `bd create --json` (e.g. orphan detection warnings) no longer break sub-bead ID parsing. Applied the same fix to depcheck and ledger packages. (Forge-byca)

## Original Issue (task): schematic: use json.Decoder to tolerate trailing noise in bd create --json output

## Problem

`internal/schematic/schematic.go:459` uses `json.Unmarshal(out, &created)` to parse the result of `bd create --json`. This rejects any trailing data after the JSON value, so if `bd` (or any subprocess we shell out to) writes log lines or diagnostics to stdout alongside the JSON, decomposition fails with:

```
parsing sub-bead ID from output: invalid character '/' after top-level value: ...
```

There is a fallback that splits the output by newlines and tries to parse each line as JSON, but that only works if the JSON itself is single-line AND at least one full log line isn't itself valid JSON. In practice it doesn't save us.

## Real-world trigger

Observed today on the munin anvil with two beads (`Fhi.Metadata-fcbo`, `Fhi.Metadata-urcm`). The munin bd database had ~975 orphaned child beads (children whose parent no longer exists). `bd create` runs orphan detection on every invocation and emits:

```
{"id":"Fhi.Metadata-xyz",...}
2026/04/10 16:03:42.874951 orphan detection: found 975 orphaned child issue(s) whose parent no longer exists:
  Fhi.Metadata-014f [closed] Warm up explorer read model on API startup
  ... 974 more lines ...
```

All to stdout. Forge's parser chokes on the first `/` in the timestamp. Every decomposition on this anvil is now DOA until one of:
1. bd stops writing diagnostics to stdout (upstream fix needed)
2. The orphans get cleaned up (avoids the warning but doesn't fix the underlying fragility)
3. Forge tolerates trailing junk in the JSON output

Only option 3 is in our control and future-proofs us against any bd chattiness.

## Proposed fix

Replace `json.Unmarshal` at `schematic.go:459` with a streaming decoder:

```go
dec := json.NewDecoder(bytes.NewReader(out))
if err := dec.Decode(&created); err != nil {
    // existing fallback or a smarter first-'{' scan
}
```

`json.Decoder.Decode` consumes one JSON value from the stream and is happy to leave trailing bytes behind. Pairs well with a ''find first `{`'' scan as the fallback: find the first byte that looks like the start of a JSON object, decode from there, ignore anything after.

The same brittleness likely applies anywhere else in schematic/other packages that unmarshal the output of shell commands — worth an audit.

## Impact

- High severity on affected anvils: every decomposition fails, beads pile up in Needs Attention.
- Stuck beads require manual cleanup (close parent, inspect partial children, clear forge state).
- The orphaned-children problem is also masked by this: the warning is actionable but ends up swallowed as a parser error.

## Related

Robin831/Forge#506 — other schematic brittleness around `bd dep add` non-zero exit when the dep was actually added. Same general theme: be defensive about bd's stdout.

Source: https://github.com/Robin831/Forge/issues/508

---
Bead: Forge-byca | Branch: forge/Forge-byca
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)