### PR TITLE
bd subprocess timeouts too short for anvils with remote Dolt / auto GitHub sync (Forge-u21i)

### DIFF
--- a/changelog.d/Forge-u21i.md
+++ b/changelog.d/Forge-u21i.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bump bd subprocess timeouts to 60s** - All bd subprocess invocations now use a centralized 60-second timeout (up from 10-30s) via `executil.DefaultBdTimeout`, preventing premature kills on anvils with remote Dolt or GitHub auto-sync where bd writes routinely take 20-30 seconds. (Forge-u21i)

--- a/internal/crucible/crucible.go
+++ b/internal/crucible/crucible.go
@@ -646,7 +646,7 @@ type bdShowBead struct {
 // bd show returns dependents as an array of objects with dependency_type,
 // not a flat "blocks" array, so we extract blocks from the dependents.
 func FetchBead(ctx context.Context, beadID, dir string) (poller.Bead, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "show", beadID, "--json"))
@@ -764,7 +764,7 @@ func (p *Params) claimBead(ctx context.Context, beadID, dir string) error {
 	if p.BeadClaimer != nil {
 		return p.BeadClaimer(ctx, beadID, dir)
 	}
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "update", beadID, "--status=in_progress", "--json"))
@@ -781,7 +781,7 @@ func (p *Params) closeBead(ctx context.Context, beadID, dir string) error {
 	if p.BeadCloser != nil {
 		return p.BeadCloser(ctx, beadID, dir)
 	}
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "close", beadID, "--force", "--reason=Crucible child completed", "--json"))
@@ -798,7 +798,7 @@ func (p *Params) resetBead(ctx context.Context, beadID, dir string) error {
 	if p.BeadResetter != nil {
 		return p.BeadResetter(ctx, beadID, dir)
 	}
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "update", beadID, "--status=open", "--json"))

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2390,7 +2390,9 @@ func (d *Daemon) insertPendingWorker(beadID, anvilName, title string) string {
 
 // claimBead marks a bead as in_progress via bd update --claim.
 func (d *Daemon) claimBead(ctx context.Context, beadID, anvilPath string) error {
-	cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "update", beadID, "--status=in_progress", "--json"))
+	tctx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(tctx, "bd", "update", beadID, "--status=in_progress", "--json"))
 	cmd.Dir = anvilPath
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -326,7 +326,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 	d.costLimitLoggedDate.Store("")
 	d.cfg.Store(cfg)
 	d.labelAdder = func(anvilPath, beadID, tag string) error {
-		ctx, cancel := context.WithTimeout(d.runCtx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 		defer cancel()
 		cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "update", beadID, "--add-label", tag))
 		cmd.Dir = anvilPath
@@ -339,7 +339,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 	d.beadShower = func(anvilPath, beadID string) ([]byte, string, error) {
 		// Use context.Background() so the bd show call succeeds even during
 		// graceful shutdown (d.runCtx may already be cancelled at that point).
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 		cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "show", beadID, "--json"))
 		cmd.Dir = anvilPath
@@ -351,7 +351,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 	d.parentCloser = func(anvilPath, beadID, reason string) error {
 		// Use context.Background() so the bd close call succeeds even during
 		// graceful shutdown (d.runCtx may already be cancelled at that point).
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 		cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "close", beadID,
 			"--force", "--reason="+reason, "--json"))
@@ -1192,7 +1192,7 @@ func (d *Daemon) handleBeadCloseOnMerge(ctx context.Context, event bellows.PREve
 	if !ok || anvilCfg.Path == "" {
 		return
 	}
-	closeCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	closeCtx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 	defer cancel()
 	if err := d.closeBead(closeCtx, event.BeadID, anvilCfg.Path, fmt.Sprintf("PR #%d merged", event.PRNumber)); err != nil {
 		d.logger.Warn("failed to close bead after PR merge", "bead", event.BeadID, "pr", event.PRNumber, "error", err)
@@ -1270,7 +1270,7 @@ func (d *Daemon) reconcileMergedBeads(ctx context.Context) {
 			continue
 		}
 
-		closeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		closeCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 		err := d.closeBead(closeCtx, pr.BeadID, anvilCfg.Path,
 			fmt.Sprintf("PR #%d merged (startup reconciliation)", pr.Number))
 		cancel()
@@ -2200,7 +2200,7 @@ normalPipeline:
 			// Smith determined no changes are needed — close the bead with the
 			// reason instead of marking it as failed or needs_human.
 			d.logger.Info("no changes needed — closing bead", "bead", bead.ID, "reason", outcome.NoChangesReason)
-			closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 			defer closeCancel()
 			d.applyNoChangesNeededOutcome(closeCtx, bead, anvilCfg.Path, outcome.NoChangesReason)
 			return
@@ -2807,7 +2807,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 
 			// Reset bead status to open and clear assignee so the poller
 			// can rediscover it as a crucible candidate.
-			resetCtx, resetCancel := context.WithTimeout(d.runCtx, 15*time.Second)
+			resetCtx, resetCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 			defer resetCancel()
 			statusCmd := executil.HideWindow(exec.CommandContext(resetCtx, "bd", "update", ca.ParentID, "--status=open", "--assignee=", "--json"))
 			statusCmd.Dir = anvilCfg.Path
@@ -2837,7 +2837,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				return ipc.Response{Type: "error", Payload: msg}
 			}
 
-			closeCtx, closeCancel := context.WithTimeout(d.runCtx, 15*time.Second)
+			closeCtx, closeCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 			defer closeCancel()
 			closeCmd := executil.HideWindow(exec.CommandContext(closeCtx, "bd", "close", ca.ParentID, "--reason=stopped from Hearth", "--json"))
 			closeCmd.Dir = anvilCfg.Path
@@ -3140,7 +3140,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			return ipc.Response{Type: "error", Payload: msg}
 		}
 
-		notesCtx, notesCancel := context.WithTimeout(d.runCtx, 30*time.Second)
+		notesCtx, notesCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 		defer notesCancel()
 
 		// bd update does not support reading notes from a file or stdin, so we must
@@ -3184,7 +3184,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("anvil %q has no auto_dispatch_tag configured", tp.Anvil)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		tagCtx, tagCancel := context.WithTimeout(d.runCtx, 30*time.Second)
+		tagCtx, tagCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 		defer tagCancel()
 		tagCmd := executil.HideWindow(exec.CommandContext(tagCtx, "bd", "update", tp.BeadID, "--add-label", tag))
 		tagCmd.Dir = anvilCfg.Path
@@ -3224,7 +3224,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("anvil %q has no path configured", cp.Anvil)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		closeCtx, closeCancel := context.WithTimeout(d.runCtx, 30*time.Second)
+		closeCtx, closeCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 		defer closeCancel()
 		closeCmd := executil.HideWindow(exec.CommandContext(closeCtx, "bd", "close", cp.BeadID))
 		closeCmd.Dir = anvilCfg.Path
@@ -3302,7 +3302,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		d.activeBeads.Delete(sp.BeadID)
 
 		// Release bead back to open so it's visible but not dispatched.
-		releaseCtx, releaseCancel := context.WithTimeout(d.runCtx, 30*time.Second)
+		releaseCtx, releaseCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 		defer releaseCancel()
 		releaseCmd := executil.HideWindow(exec.CommandContext(releaseCtx, "bd", "update", sp.BeadID, "--status=open", "--assignee=", "--json"))
 		releaseCmd.Dir = anvilCfg.Path
@@ -3403,7 +3403,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			// re-dispatch it. The pipeline sets status=in_progress on claim,
 			// and bd ready only returns open beads.
 			if anvilCfg, ok := d.cfg.Load().Anvils[rp.Anvil]; ok && anvilCfg.Path != "" {
-				resetCtx, resetCancel := context.WithTimeout(d.runCtx, 15*time.Second)
+				resetCtx, resetCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 				defer resetCancel()
 				statusCmd := executil.HideWindow(exec.CommandContext(resetCtx, "bd", "update", rp.BeadID, "--status=open", "--assignee=", "--json"))
 				statusCmd.Dir = anvilCfg.Path
@@ -3432,7 +3432,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		// re-dispatch it. The pipeline sets status=in_progress on claim,
 		// and bd ready only returns open beads.
 		if anvilCfg, ok := d.cfg.Load().Anvils[rp.Anvil]; ok && anvilCfg.Path != "" {
-			resetCtx, resetCancel := context.WithTimeout(d.runCtx, 15*time.Second)
+			resetCtx, resetCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 			defer resetCancel()
 			statusCmd := executil.HideWindow(exec.CommandContext(resetCtx, "bd", "update", rp.BeadID, "--status=open", "--assignee=", "--json"))
 			statusCmd.Dir = anvilCfg.Path
@@ -3781,7 +3781,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		// Refresh() fires, so we call closeBead directly here instead.
 		if beadID != "" && !strings.HasPrefix(beadID, "ext-") {
 			go func() {
-				closeCtx, closeCancel := context.WithTimeout(d.runCtx, 15*time.Second)
+				closeCtx, closeCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 				defer closeCancel()
 				if err := d.closeBead(closeCtx, beadID, anvilCfg.Path, fmt.Sprintf("PR #%d merged", mergeNumber)); err != nil {
 					d.logger.Warn("failed to close bead after merge", "bead", beadID, "pr", mergeNumber, "error", err)
@@ -3826,7 +3826,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			// Use context.Background() so this bd close call is not interrupted
 			// if the daemon is concurrently shutting down. The user explicitly
 			// chose to close this orphan, and the operation must complete.
-			closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			closeCtx, closeCancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 			defer closeCancel()
 			closeCmd := executil.HideWindow(exec.CommandContext(closeCtx, "bd", "close", rp.BeadID))
 			closeCmd.Dir = anvilCfg.Path
@@ -3843,7 +3843,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			// Use context.Background() so this bd close call is not interrupted
 			// if the daemon is concurrently shutting down. The user explicitly
 			// chose to discard this orphan, and the operation must complete.
-			discardCtx, discardCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			discardCtx, discardCancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 			defer discardCancel()
 			discardCmd := executil.HideWindow(exec.CommandContext(discardCtx, "bd", "close", rp.BeadID, `--reason=Discarded by user during orphan recovery`))
 			discardCmd.Dir = anvilCfg.Path

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -6,7 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"time"
 )
+
+// DefaultBdTimeout is the default timeout for bd subprocess invocations.
+// bd operations on anvils with remote Dolt (e.g. via kubectl port-forward)
+// and GitHub auto-sync can routinely take 20-30 seconds per write, so the
+// timeout must be generous enough to accommodate that latency.
+const DefaultBdTimeout = 60 * time.Second
 
 // DecodeJSON decodes one JSON value from subprocess output that may contain
 // leading or trailing non-JSON noise (log lines, diagnostics, etc.).

--- a/internal/ledger/actions.go
+++ b/internal/ledger/actions.go
@@ -3,7 +3,6 @@ package ledger
 import (
 	"context"
 	"fmt"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 

--- a/internal/ledger/actions.go
+++ b/internal/ledger/actions.go
@@ -30,7 +30,7 @@ type ActionErrorMsg struct{ Err error }
 // NewBeadCmd creates a new bead via bd create.
 func NewBeadCmd(anvilPath, title, description, issueType string, priority int) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{
@@ -55,7 +55,7 @@ func NewBeadCmd(anvilPath, title, description, issueType string, priority int) t
 // EditBeadCmd updates a bead's title and description.
 func EditBeadCmd(anvilPath, beadID, title, description string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"update", beadID, "--title", title, "--description", description}
@@ -70,7 +70,7 @@ func EditBeadCmd(anvilPath, beadID, title, description string) tea.Cmd {
 // CloseBeadCmd closes a bead with an optional reason.
 func CloseBeadCmd(anvilPath, beadID, reason string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"close", beadID, "--json"}
@@ -88,7 +88,7 @@ func CloseBeadCmd(anvilPath, beadID, reason string) tea.Cmd {
 // ReopenBeadCmd reopens a closed bead.
 func ReopenBeadCmd(anvilPath, beadID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"update", beadID, "--status=open"}
@@ -103,7 +103,7 @@ func ReopenBeadCmd(anvilPath, beadID string) tea.Cmd {
 // UpdateLabelCmd adds or removes a label from a bead.
 func UpdateLabelCmd(anvilPath, beadID, label string, remove bool) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		flag := "--add-label"
@@ -122,7 +122,7 @@ func UpdateLabelCmd(anvilPath, beadID, label string, remove bool) tea.Cmd {
 // UpdatePriorityCmd changes a bead's priority.
 func UpdatePriorityCmd(anvilPath, beadID string, priority int) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"update", beadID, "--priority", fmt.Sprintf("%d", priority)}
@@ -137,7 +137,7 @@ func UpdatePriorityCmd(anvilPath, beadID string, priority int) tea.Cmd {
 // AppendNotesCmd appends text to a bead's notes field.
 func AppendNotesCmd(anvilPath, beadID, notes string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"update", beadID, "--append-notes", notes}
@@ -152,7 +152,7 @@ func AppendNotesCmd(anvilPath, beadID, notes string) tea.Cmd {
 // UpdateNotesCmd replaces a bead's notes field.
 func UpdateNotesCmd(anvilPath, beadID, notes string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"update", beadID, "--notes", notes}
@@ -167,7 +167,7 @@ func UpdateNotesCmd(anvilPath, beadID, notes string) tea.Cmd {
 // UpdateAssigneeCmd assigns or unassigns a bead.
 func UpdateAssigneeCmd(anvilPath, beadID, assignee string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		args := []string{"update", beadID, "--assignee=" + assignee}
@@ -195,7 +195,7 @@ type DepRemovedMsg struct {
 // After this, beadID depends on depID (depID blocks beadID).
 func AddDepCmd(anvilPath, beadID, depID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		_, err := bdExec(ctx, anvilPath, "dep", "add", beadID, depID)
@@ -210,7 +210,7 @@ func AddDepCmd(anvilPath, beadID, depID string) tea.Cmd {
 // This removes the relationship where beadID depends on depID.
 func RemoveDepCmd(anvilPath, beadID, depID string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer cancel()
 
 		_, err := bdExec(ctx, anvilPath, "dep", "remove", beadID, depID)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -396,7 +396,7 @@ func (p *Params) schematicProviders(providers []provider.Provider) []provider.Pr
 // versa). A future cleanup could factor this into a shared executil helper used
 // by both call sites.
 func releaseBead(beadID, anvilPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 	defer cancel()
 	// Clear both status and assignee so the poller can re-dispatch the bead.
 	// The poller filters out any bead with a non-empty assignee (poller.go),

--- a/internal/poller/crucible.go
+++ b/internal/poller/crucible.go
@@ -82,7 +82,7 @@ type bdShowResponse struct {
 
 // lookupBlocks fetches a bead's details and extracts the IDs of beads it blocks.
 func lookupBlocks(ctx context.Context, beadID, anvilPath string) []string {
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "show", beadID, "--json"))

--- a/internal/poller/crucible.go
+++ b/internal/poller/crucible.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os/exec"
 	"sync"
-	"time"
 
 	"github.com/Robin831/Forge/internal/executil"
 )

--- a/internal/poller/epicbranch.go
+++ b/internal/poller/epicbranch.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/Robin831/Forge/internal/executil"
 )

--- a/internal/poller/epicbranch.go
+++ b/internal/poller/epicbranch.go
@@ -97,7 +97,7 @@ type parentBeadResponse struct {
 // (e.g. task blocks task) never generate a feature branch — only intentional
 // epic parents do.
 func lookupEpicBranch(ctx context.Context, parentID, anvilPath string) string {
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "show", parentID, "--json"))

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -169,7 +169,7 @@ func (p *BeadPoller) Poll(ctx context.Context) ([]Bead, []AnvilResult) {
 // pollAnvil runs 'bd ready --json' in an anvil directory and parses the output.
 func pollAnvil(ctx context.Context, name string, anvil config.AnvilConfig) ([]Bead, error) {
 	// Build command with timeout
-	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "ready", "--json"))
@@ -339,7 +339,7 @@ func (p *BeadPoller) PollInProgress(ctx context.Context) ([]Bead, []AnvilResult)
 
 // pollInProgressAnvil runs 'bd list --status=in_progress --json' in one anvil directory.
 func pollInProgressAnvil(ctx context.Context, name string, anvil config.AnvilConfig) ([]Bead, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "list", "--status=in_progress", "--json"))

--- a/internal/questgiver/questgiver.go
+++ b/internal/questgiver/questgiver.go
@@ -194,7 +194,7 @@ func isDuplicate(ctx context.Context, anvilPath, questName string) bool {
 	prefix := "E2E failure: " + questName
 
 	for _, status := range []string{"open", "in_progress"} {
-		cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 		cmd := executil.HideWindow(exec.CommandContext(cmdCtx,
 			"bd", "list", "--status="+status, "--limit", "0", "--json"))
 		cmd.Dir = anvilPath
@@ -244,7 +244,7 @@ func (m *Monitor) createBead(ctx context.Context, anvilName, anvilPath string, q
 		quest.Name, result.FailedStep, stepAction, result.ErrorMessage, quest.FilePath, quest.Name,
 	)
 
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx,

--- a/internal/schematic/schematic.go
+++ b/internal/schematic/schematic.go
@@ -417,7 +417,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 	}
 
 	resetParent := func() {
-		rCtx, rCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		rCtx, rCancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 		defer rCancel()
 		if out, err := run(rCtx, anvilPath, "update", parent.ID, "--status=open", "--json"); err != nil {
 			log.Printf("[schematic:%s] Warning: failed to reset parent to open: %v: %s", parent.ID, err, out)
@@ -435,7 +435,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 
 		// Create sub-bead with blocks dependency so the parent is blocked
 		// until all sub-beads are closed.
-		createCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		createCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 		out, err := run(createCtx, anvilPath,
 			"create",
 			"--title="+task.Title,
@@ -480,7 +480,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 		// can surface the issue to operators via ActionClarify.
 		if len(subBeads) >= 2 {
 			prev := subBeads[len(subBeads)-2]
-			depCtx, depCancel := context.WithTimeout(ctx, 15*time.Second)
+			depCtx, depCancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 			depOut, depErr := run(depCtx, anvilPath, "dep", "add", created.ID, prev.ID)
 			depCtxErr := depCtx.Err() // capture before Cancel clears it
 			depCancel()
@@ -523,7 +523,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 
 		// Re-fetch parent to get accurate dependency data from bd.
 		var upstreamIDs, downstreamIDs []string
-		showCtx, showCancel := context.WithTimeout(ctx, 30*time.Second)
+		showCtx, showCancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 		showOut, showErr := run(showCtx, anvilPath, "show", parent.ID, "--json")
 		showCancel()
 		if showErr == nil {
@@ -537,7 +537,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 
 		// Transfer parent's upstream dependencies to B1 (first sub-bead).
 		for _, depID := range upstreamIDs {
-			xCtx, xCancel := context.WithTimeout(ctx, 15*time.Second)
+			xCtx, xCancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 			xOut, xErr := run(xCtx, anvilPath, "dep", "add", first.ID, depID)
 			xCancel()
 			if xErr != nil {
@@ -548,7 +548,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 
 		// Transfer parent's downstream blocks to B3 (last sub-bead).
 		for _, blockedID := range downstreamIDs {
-			xCtx, xCancel := context.WithTimeout(ctx, 15*time.Second)
+			xCtx, xCancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 			xOut, xErr := run(xCtx, anvilPath, "dep", "add", blockedID, last.ID)
 			xCancel()
 			if xErr != nil {
@@ -571,7 +571,7 @@ func createSubBeads(ctx context.Context, parent poller.Bead, tasks []subTaskVerd
 		subIDs[i] = sb.ID
 	}
 	closeReason := fmt.Sprintf("Decomposed into %d sub-beads: %s", len(subBeads), strings.Join(subIDs, ", "))
-	closeCtx, closeCancel := context.WithTimeout(ctx, 15*time.Second)
+	closeCtx, closeCancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer closeCancel()
 	closeOut, closeErr := run(closeCtx, anvilPath, "close", parent.ID, "--force", "--reason", closeReason)
 	if closeErr != nil {

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -413,7 +413,7 @@ type inProgressBead struct {
 // last-updated timestamps and most-recent worker branch so callers can filter
 // by age and display the branch in dialogs.
 func (m *Manager) listInProgressBeads(anvilName, anvilPath string) ([]inProgressBead, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "list", "--status=in_progress", "--json"))

--- a/internal/vulncheck/vulncheck.go
+++ b/internal/vulncheck/vulncheck.go
@@ -391,7 +391,9 @@ func (s *Scanner) beadExists(ctx context.Context, anvilPath, vulnID string) (boo
 
 // createBead calls `bd create` to make a new issue.
 func (s *Scanner) createBead(ctx context.Context, anvilPath, title, description string, priority int) error {
-	cmd := exec.CommandContext(ctx, "bd", "create",
+	tctx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(tctx, "bd", "create",
 		"--title", title,
 		"--description", description,
 		"--type", "bug",

--- a/internal/vulncheck/vulncheck.go
+++ b/internal/vulncheck/vulncheck.go
@@ -370,7 +370,7 @@ func (s *Scanner) CreateBeads(ctx context.Context, results []ScanResult) (int, e
 // It restricts the search to open beads so that a resolved vulnerability whose bead
 // was closed does not suppress a new bead if the vulnerability reappears.
 func (s *Scanner) beadExists(ctx context.Context, anvilPath, vulnID string) (bool, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(cmdCtx, "bd", "list", "--status=open", "--json")

--- a/internal/wicket/triage.go
+++ b/internal/wicket/triage.go
@@ -58,7 +58,7 @@ func defaultBDListRunner(ctx context.Context, args []string, anvilPath string) (
 // A 30-second timeout is applied to prevent a hung beads DB from stalling the
 // scan loop indefinitely.
 func fetchBeadSummaries(ctx context.Context, status string, limit int, anvilPath string) []BeadSummary {
-	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	tctx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	args := []string{"--status", status, "--json"}
@@ -578,7 +578,7 @@ func RunTriageWithComments(ctx context.Context, issue Issue, comments []Comment,
 
 		// Fetch all paths in parallel with a shared 30-second deadline so
 		// slow paths cannot stall the triage loop indefinitely.
-		fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		fetchCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 		defer cancel()
 
 		type pathResult struct {

--- a/internal/wicket/triage.go
+++ b/internal/wicket/triage.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/provider"

--- a/internal/wicket/triage.go
+++ b/internal/wicket/triage.go
@@ -54,7 +54,7 @@ func defaultBDListRunner(ctx context.Context, args []string, anvilPath string) (
 // fetchBeadSummaries calls bd list with the given status filter and returns
 // parsed bead summaries. A limit of 0 means no limit. anvilPath sets the
 // working directory for the bd command so the correct .beads/ config is used.
-// A 30-second timeout is applied to prevent a hung beads DB from stalling the
+// A 60-second timeout is applied to prevent a hung beads DB from stalling the
 // scan loop indefinitely.
 func fetchBeadSummaries(ctx context.Context, status string, limit int, anvilPath string) []BeadSummary {
 	tctx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
@@ -575,8 +575,9 @@ func RunTriageWithComments(ctx context.Context, issue Issue, comments []Comment,
 			closedQuota = 1
 		}
 
-		// Fetch all paths in parallel with a shared 30-second deadline so
-		// slow paths cannot stall the triage loop indefinitely.
+		// Fetch all paths in parallel with a shared timeout derived from
+		// executil.DefaultBdTimeout so slow paths cannot stall the triage loop
+		// indefinitely.
 		fetchCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 		defer cancel()
 


### PR DESCRIPTION
## Changes

- **Bump bd subprocess timeouts to 60s** - All bd subprocess invocations now use a centralized 60-second timeout (up from 10-30s) via `executil.DefaultBdTimeout`, preventing premature kills on anvils with remote Dolt or GitHub auto-sync where bd writes routinely take 20-30 seconds. (Forge-u21i)

## Original Issue (task): bd subprocess timeouts too short for anvils with remote Dolt / auto GitHub sync

## Problem

Forge wraps every `bd` invocation in a short `context.WithTimeout`. On anvils where `bd` takes longer than a couple of seconds per write, those timeouts kick in mid-PostRun and `exec.CommandContext` kills the bd subprocess. On Windows, `Process.Kill` maps to `TerminateProcess(handle, 1)` — so the killed subprocess reports **exit code 1**, which forge treats as a bd error.

Observed on the munin anvil:

| Operation | bd actual wall time | forge timeout | result |
|---|---:|---:|---|
| `bd close --json` | ~19.9s | **15s** (`closeBead`) | killed every call |
| `bd create --json` with auto-sync | ~29s | **30s** (`schematic.createSubBeads`) | killed most calls |
| `bd create --json` without auto-sync | ~19.2s | 30s | survives |

Munin's bd is slow because Dolt lives in a k8s pod and is reached via `kubectl port-forward`, which adds hop latency to every Dolt query. On top of that we have `github.sync.auto = true` so every write does a REST round-trip to GitHub plus a second Dolt write to store the external_ref. Neither of those is going away — the port-forward is structural and auto-sync is required for our GitHub issue workflow to function.

So the baseline cost of a bd write is ~20s, and forge's timeouts are well below that for `bd close` and right at the edge for `bd create`.

### Visible symptoms

1. **`reconcileMergedBeads` fails for every merged-PR close**, every poll cycle, forever. The daemon log is filled with warnings like:

   ```
   level=WARN msg="reconcileMergedBeads: failed to close bead, will retry on next startup"
     bead=Fhi.Metadata-4hwm pr=1893
     error="bd close Fhi.Metadata-4hwm --json: exit status 1\n"
   ```

   Note the empty output after `exit status 1` — bd was killed before it could write anything. Across Fhi.Metadata and Heimdall anvils, dozens of beads show this pattern.

2. **Schematic decomposition fails intermittently** — when `bd create` finishes under 30s the JSON lands in the error message (so the parser sees valid JSON + exit 1), when it takes longer than 30s the create gets killed mid-flight. Either way the decomposition is marked `ActionClarify` and the parent bead gets stuck in Needs Attention.

3. Silent exit-1s are hard to diagnose because nothing shows up on stderr — `TerminateProcess` doesn't give bd a chance to print an error. I chased stderr contamination, JSON parser fragility, bd's internal `os.Exit(1)` paths, etc. before realising the killer was forge itself.

## Proposed fix

**Bump all `bd`-subprocess timeouts to a realistic floor**, and ideally make the floor configurable per-anvil so an on-prem anvil with a local Dolt can stay tight while a remote/pod-backed anvil gets more room.

Minimum concrete changes (all in forge):

1. `internal/daemon/daemon.go:2610` — `closeBead` uses `ctx` as-is; callers should pass a 60s (or longer) timeout. Audit every call site and bump their `context.WithTimeout(...)`.
2. `internal/daemon/daemon.go:1273` — `reconcileMergedBeads`'s per-bead `closeCtx` is 15s. Bump to 60s.
3. `internal/daemon/daemon.go:1195, 2203, 2840, 3227, 3784, 3829, 3884` — every `context.WithTimeout(..., 15*time.Second)` or `30*time.Second` around a bd subprocess call. Audit and bump each.
4. `internal/schematic/schematic.go:438` — `createCtx` 30s → 60s (or longer). This is the one that cost us an hour of debugging today.
5. `internal/schematic/schematic.go:483` — `depCtx` for `bd dep add` 15s → 60s.
6. `internal/schematic/schematic.go:526` — `showCtx` 30s → 60s (less urgent since show is read-only and usually fast, but consistency matters).
7. `internal/schematic/schematic.go:574` — final `closeCtx` 15s → 60s.
8. Any other `exec.CommandContext(ctx, \"bd\", ...)` call sites — there are likely more.

### Why not just \"make bd fast\"

Per-operation bd cost on munin:

- **Dolt server round-trip** via kubectl port-forward — structural, a few hundred ms per query, not going away
- **Compat migrations** — 15+ of them run on every `Open` in write mode (one of which, `orphan_detection`, was spamming stderr and causing separate problems fixed in Robin831/beads@94bd18ae)
- **GitHub auto-sync** — required for the product. Creates or updates the corresponding GitHub issue on every write, then writes the external_ref back, triggering another Dolt commit cycle. ~10s per write on a happy GitHub day.
- **Auto-push to Dolt remote** — another network round-trip
- **Telemetry shutdown** — a 5s timeout on OTel shutdown in bd's PersistentPostRun

None of those are fixable from forge's side. The right move is to stop assuming bd is a <2s local CLI call.

### Nice-to-haves (optional, can be separate issues)

- **Make the subprocess timeout configurable per anvil** in `forge.yaml` — e.g. `bd_timeout: 90s` — defaulting to something generous (60s). Anvils with local Dolt can tighten it; remote/pod-backed anvils can loosen it further.
- **Log the actual bd wall time** when it fails, so \"killed at 15s\" is obvious in the daemon log instead of a generic exit-1.
- **Treat exit-1-with-empty-output** from a bd subprocess as a possible timeout kill and surface that hypothesis in the error message (\"bd was killed, likely exceeded the N-second timeout\").

## Impact

- High severity: backlog is currently dead on munin because every schematic decomposition fails and every merged-bead close retries forever.
- The workaround is to manually close merged beads and manually manage decompositions, which defeats the purpose of the orchestrator.

## Related

- Robin831/Forge#506 — schematic tolerating `bd dep add` non-zero exit. That issue is now partially subsumed: with bumped timeouts the \"non-zero exit\" will genuinely mean a bd error again, not a kill. Still worth doing for defense in depth.
- Robin831/Forge#508 — schematic using json.Decoder + stdout-only capture. Also still worth doing for defense in depth, independent of timeouts.
- Robin831/beads@94bd18ae — removed the noisy orphan-detection \"migration\" that was firing on every write. Part of what I fixed while chasing this.

Source: https://github.com/Robin831/Forge/issues/510

---
Bead: Forge-u21i | Branch: forge/Forge-u21i
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)