### PR TITLE
bd subprocess timeout: bump from 60s to 5 minutes (or make it large by default) (Forge-apqe)

### DIFF
--- a/changelog.d/Forge-apqe.md
+++ b/changelog.d/Forge-apqe.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bump bd subprocess timeout to 5 minutes** - Increase `executil.DefaultBdTimeout` from 60 seconds to 5 minutes to prevent premature kills on anvils with remote Dolt, kubectl port-forward, or GitHub auto-sync under concurrent load. (Forge-apqe)

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -13,7 +13,7 @@ import (
 // bd operations on anvils with remote Dolt (e.g. via kubectl port-forward)
 // and GitHub auto-sync can routinely take 20-30 seconds per write, so the
 // timeout must be generous enough to accommodate that latency.
-const DefaultBdTimeout = 60 * time.Second
+const DefaultBdTimeout = 5 * time.Minute
 
 // DecodeJSON decodes one JSON value from subprocess output that may contain
 // leading or trailing non-JSON noise (log lines, diagnostics, etc.).


### PR DESCRIPTION
## Changes

- **Bump bd subprocess timeout to 5 minutes** - Increase `executil.DefaultBdTimeout` from 60 seconds to 5 minutes to prevent premature kills on anvils with remote Dolt, kubectl port-forward, or GitHub auto-sync under concurrent load. (Forge-apqe)

## Original Issue (task): bd subprocess timeout: bump from 60s to 5 minutes (or make it large by default)

## Context

Follow-up to Robin831/Forge#510, which bumped `executil.DefaultBdTimeout` from 15s/30s to 60s. On the munin anvil (Dolt-in-a-pod via kubectl port-forward + `github.sync.auto = true`) we're **still** seeing schematic decomposition fail with "exit status 1" and a valid sub-bead JSON in the error, i.e. bd wrote its output but was killed just before finishing.

Interactive timing on munin after the fix:
- `bd create --json` (simple): ~25s
- `bd create --json --deps blocks:<parent>`: ~31s
- `bd create --json` under concurrent load (2 parallel): ~24-27s each

So interactively bd fits inside 60s. But when spawned from the forge daemon it occasionally exceeds 60s — likely because of concurrent bd invocations from other forge workers contending on the same Dolt server, or network jitter on the port-forward, or GitHub autosync being slower in sustained use.

## Why the timeout exists at all

Forge wraps every bd subprocess in a `context.WithTimeout`. The purpose is narrow:

1. **Hang detection** — if bd hangs indefinitely on a dead socket or deadlocked goroutine, forge should not wait forever.
2. **Resource protection** — zombie bd processes could accumulate if forge has many concurrent workers and any of them hang.

Neither of those cases care whether the timeout is 60s, 5 minutes, or 1 hour. The timeout only needs to be **longer than any legitimately slow bd call** by a comfortable margin.

## Proposed change

Bump `executil.DefaultBdTimeout` from `60 * time.Second` to `5 * time.Minute` (or even `10 * time.Minute`). Reasoning:

- **No downside**: bd calls are relatively rare (a handful per bead pipeline). Waiting 5 minutes for a pathologically slow one doesn't hurt forge's throughput meaningfully.
- **Leaves margin for worst case**: port-forward blips, concurrent Dolt writes, GitHub rate limits, Dolt auto-push to a slow remote, etc. all compound. 5 minutes gives plenty of headroom for a bd operation that *should* take 30 seconds but gets unlucky.
- **Hang detection still works**: a truly stuck bd (e.g. Dolt connection deadlocked) will still be killed at the 5-minute mark, just later.
- **User-visible slowness is already mitigated elsewhere**: forge's poll loop is independent of any single bd call, so a slow bd doesn't block other work.

Alternative: make it **configurable per anvil** via `forge.yaml` (e.g. `bd_timeout: 5m`) so local anvils can stay tight (~60s) and remote/pod-backed anvils can loosen as needed. But a generous default is probably sufficient — anyone with a faster anvil isn't going to notice the generous timeout because fast operations complete far before it.

## Concrete proposal

1. `internal/executil/executil.go` — bump `DefaultBdTimeout = 60 * time.Second` to `DefaultBdTimeout = 5 * time.Minute`.
2. Optional (nice-to-have): expose a `settings.bd_subprocess_timeout` in `forge.yaml` so operators can override for specific environments.

## Background

Today's munin debugging session chased this exact symptom across several layers:
- Robin831/Forge#506 — tolerate bd dep add non-zero exit (already merged)
- Robin831/Forge#508 — json.Decoder + stdout-only capture for bd output (already merged)
- Robin831/Forge#510 — bump timeouts from 15s/30s to 60s (already merged)
- Robin831/beads@94bd18ae — remove orphan_detection diagnostic from compat migrations (forge fork)

All four were symptom-chasing. The root problem turned out to be: **forge's default timeouts are too tight for any anvil where bd isn't instant**. #510 took a step in the right direction by introducing `DefaultBdTimeout` and using it everywhere in schematic; this issue finishes the job by making the default actually generous.

Source: https://github.com/Robin831/Forge/issues/512

---
Bead: Forge-apqe | Branch: forge/Forge-apqe
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)