### PR TITLE
Burnish: gate push on Temper verification to break the burnish↔quench loop (Forge-syrn)

### DIFF
--- a/changelog.d/Forge-syrn.md
+++ b/changelog.d/Forge-syrn.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Burnish temper verification gate** - Burnish now runs Temper verification before pushing review-fix commits, breaking the burnish-quench infinite loop on PRs with automated review comments. Previously, burnish trusted Smith to only push working code, but Smith often pushed broken builds which triggered quench, which then triggered another Copilot review, restarting the cycle. (Forge-syrn)

--- a/internal/burnish/burnish.go
+++ b/internal/burnish/burnish.go
@@ -9,13 +9,16 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/Robin831/Forge/internal/cost"
+	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/state"
+	"github.com/Robin831/Forge/internal/temper"
 	"github.com/Robin831/Forge/internal/vcs"
 )
 
@@ -54,6 +57,12 @@ type FixParams struct {
 	// VCS is the VCS provider for repository operations. When set,
 	// it is used for GetRepoOwnerAndName instead of creating a throwaway instance.
 	VCS vcs.Provider
+	// TemperConfig is the per-anvil temper configuration. Nil means auto-detect.
+	TemperConfig *temper.Config
+	// DetectOptions controls temper auto-detection behavior (e.g. golangci-lint).
+	DetectOptions *temper.DetectOptions
+	// GoRaceDetection enables Go race detection in temper steps.
+	GoRaceDetection bool
 }
 
 // FixResult captures the outcome of addressing review comments.
@@ -94,6 +103,12 @@ type BatchFixParams struct {
 	Comments []vcs.ReviewComment
 	// VCS is the VCS provider for thread resolution.
 	VCS vcs.Provider
+	// TemperConfig is the per-anvil temper configuration. Nil means auto-detect.
+	TemperConfig *temper.Config
+	// DetectOptions controls temper auto-detection behavior (e.g. golangci-lint).
+	DetectOptions *temper.DetectOptions
+	// GoRaceDetection enables Go race detection in temper steps.
+	GoRaceDetection bool
 }
 
 // BatchFix combines multiple review comments into one Smith prompt.
@@ -131,7 +146,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 			log.Printf("[burnish] PR #%d: Provider %s rate limited, retrying with %s",
 				p.PRNumber, providers[pi-1].Label(), pv.Label())
 		}
-		process, err := smith.SpawnWithProvider(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
+		process, err := smithSpawnFn(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
 		if err != nil {
 			result.Error = fmt.Errorf("spawning smith (%s) for batch review fix: %w", pv.Label(), err)
 			result.Duration = time.Since(start)
@@ -194,7 +209,42 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 		return result
 	}
 
-	log.Printf("[burnish] PR #%d: batch review fix applied for %d comments", p.PRNumber, len(actionable))
+	// Verify locally before pushing.
+	temperCfg := resolveTemperConfig(p.WorktreePath, p.TemperConfig, p.DetectOptions, p.GoRaceDetection)
+	verifyResult := temperRunFn(ctx, p.WorktreePath, temperCfg, p.DB, p.BeadID, p.AnvilName)
+	if !verifyResult.Passed {
+		log.Printf("[burnish] PR #%d: batch Temper failed (failed step: %s) — not pushing",
+			p.PRNumber, verifyResult.FailedStep)
+		if p.DB != nil {
+			_ = p.DB.LogEvent(state.EventBurnishTemperFailed,
+				fmt.Sprintf("PR #%d: batch temper failed at step %s", p.PRNumber, verifyResult.FailedStep),
+				p.BeadID, p.AnvilName)
+		}
+		result.Error = fmt.Errorf("batch review fix: temper verification failed at step %s", verifyResult.FailedStep)
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	// Temper passed — push the verified commits (unless Smith already pushed).
+	localHead, _ := gitRevParseFn(ctx, p.WorktreePath, "HEAD")
+	remoteHead, _ := gitRevParseFn(ctx, p.WorktreePath, "origin/"+p.Branch)
+	if localHead == "" || localHead != remoteHead {
+		if err := gitPushFn(ctx, p.WorktreePath, p.Branch); err != nil {
+			log.Printf("[burnish] PR #%d: push failed after temper-verified batch fix: %v", p.PRNumber, err)
+			if p.DB != nil {
+				_ = p.DB.LogEvent(state.EventBurnishFailed,
+					fmt.Sprintf("PR #%d: push failed after temper-verified batch fix: %v", p.PRNumber, err),
+					p.BeadID, p.AnvilName)
+			}
+			result.Error = fmt.Errorf("push after temper verification: %w", err)
+			result.Duration = time.Since(start)
+			return result
+		}
+	} else {
+		log.Printf("[burnish] PR #%d: Smith already pushed (HEAD matches origin/%s), skipping explicit push", p.PRNumber, p.Branch)
+	}
+
+	log.Printf("[burnish] PR #%d: batch review fix verified and pushed for %d comments", p.PRNumber, len(actionable))
 	result.Addressed = true
 
 	// Resolve threads after successful fix.
@@ -261,9 +311,9 @@ func buildBatchReviewPrompt(prNumber int, branch, beadID string, comments []vcs.
 2. Make the requested changes — follow each reviewer's guidance
 3. **Run the test suite** and fix any failures before continuing
 4. Commit with message: "fix: address review comments for %s"
-5. Push to branch: %s
+5. Do NOT push — Forge will run verification and push for you. Exit cleanly after committing.
 
-`, len(comments), beadID, branch)
+`, len(comments), beadID)
 
 	return b.String()
 }
@@ -320,11 +370,16 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 	}
 	activeProviderIdx := 0
 
+	var lastTemperFailure *temper.Result
+
 	for attempt := 1; attempt <= p.MaxAttempts; attempt++ {
 		result.Attempts = attempt
 
-		// Step 2: Build fix prompt
+		// Step 2: Build fix prompt, including previous temper failure if any.
 		prompt := buildReviewFixPrompt(p, actionable)
+		if lastTemperFailure != nil {
+			prompt = formatTemperFailureForPrompt(lastTemperFailure) + prompt
+		}
 
 		// Step 3: Spawn Smith (with provider fallback on rate limit)
 		_ = p.DB.LogEvent(state.EventBurnishStarted,
@@ -343,7 +398,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 						p.PRNumber, attempt, providers[pi-1].Label(), pv.Label()),
 					p.BeadID, p.AnvilName)
 			}
-			process, err := smith.SpawnWithProvider(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
+			process, err := smithSpawnFn(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
 			if err != nil {
 				result.Error = fmt.Errorf("spawning smith (%s) for review fix: %w", pv.Label(), err)
 				_ = p.DB.LogEvent(state.EventBurnishFailed, result.Error.Error(), p.BeadID, p.AnvilName)
@@ -418,8 +473,43 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			continue
 		}
 
-		// Smith succeeded — assume fixes were committed and pushed
-		log.Printf("[burnish] PR #%d: Review fixes applied on attempt %d", p.PRNumber, attempt)
+		// Smith succeeded — verify locally before pushing.
+		temperCfg := resolveTemperConfig(p.WorktreePath, p.TemperConfig, p.DetectOptions, p.GoRaceDetection)
+		verifyResult := temperRunFn(ctx, p.WorktreePath, temperCfg, p.DB, p.BeadID, p.AnvilName)
+
+		// Defensive check: did Smith push despite being told not to?
+		smithAlreadyPushed := false
+		localHead, _ := gitRevParseFn(ctx, p.WorktreePath, "HEAD")
+		remoteHead, _ := gitRevParseFn(ctx, p.WorktreePath, "origin/"+p.Branch)
+		if localHead != "" && localHead == remoteHead {
+			smithAlreadyPushed = true
+			log.Printf("[burnish] PR #%d: Smith already pushed (HEAD matches origin/%s)", p.PRNumber, p.Branch)
+		}
+
+		if !verifyResult.Passed {
+			log.Printf("[burnish] PR #%d: Temper failed on attempt %d (failed step: %s) — looping with feedback",
+				p.PRNumber, attempt, verifyResult.FailedStep)
+			_ = p.DB.LogEvent(state.EventBurnishTemperFailed,
+				fmt.Sprintf("PR #%d: temper failed on attempt %d at step %s", p.PRNumber, attempt, verifyResult.FailedStep),
+				p.BeadID, p.AnvilName)
+			lastTemperFailure = verifyResult
+			continue
+		}
+
+		// Temper passed — push the verified commits.
+		if !smithAlreadyPushed {
+			if err := gitPushFn(ctx, p.WorktreePath, p.Branch); err != nil {
+				log.Printf("[burnish] PR #%d: push failed after temper-verified fix: %v", p.PRNumber, err)
+				_ = p.DB.LogEvent(state.EventBurnishFailed,
+					fmt.Sprintf("PR #%d: push failed after temper-verified fix: %v", p.PRNumber, err),
+					p.BeadID, p.AnvilName)
+				result.Error = fmt.Errorf("push after temper verification: %w", err)
+				result.Duration = time.Since(start)
+				return result
+			}
+		}
+
+		log.Printf("[burnish] PR #%d: Review fixes verified and pushed on attempt %d", p.PRNumber, attempt)
 		result.Addressed = true
 
 		// Resolve threads after successful fix.
@@ -516,11 +606,86 @@ func buildReviewFixPrompt(p FixParams, comments []vcs.ReviewComment) string {
 
 1. Address ALL review comments above
 2. Make the requested changes — follow the reviewer's guidance
-3. **Run the test suite** (e.g. "go test ./..." for Go, "dotnet test" for .NET, "npm test" or "npx vitest run" for Node/frontend) and fix any failures before continuing — do NOT commit or push if tests are failing
+3. **Run the test suite** (e.g. "go test ./..." for Go, "dotnet test" for .NET, "npm test" or "npx vitest run" for Node/frontend) and fix any failures before continuing — do NOT commit if tests are failing
 4. Commit with message: "fix: address review comments for %s"
-5. Push to branch: %s
+5. Do NOT push — Forge will run verification and push for you. Exit cleanly after committing.
 
-`, p.BeadID, p.Branch)
+`, p.BeadID)
 
 	return b.String()
+}
+
+// smithSpawnFn is the function used to spawn Smith. Package-level variable for test stubbing.
+var smithSpawnFn = smith.SpawnWithProvider
+
+// temperRunFn is the function used to run temper verification.
+// It is a package-level variable so tests can substitute a stub.
+var temperRunFn = temper.Run
+
+// gitPushFn is the function used to push commits to the remote.
+// It is a package-level variable so tests can substitute a stub.
+var gitPushFn = gitPush
+
+// gitRevParseFn is the function used to resolve git refs. Package-level for test stubbing.
+var gitRevParseFn = gitRevParse
+
+// gitPush pushes the current branch to origin.
+func gitPush(ctx context.Context, worktreePath, branch string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "push", "origin", branch)
+	executil.HideWindow(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git push origin %s: %w (output: %s)", branch, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// gitRevParse resolves a git ref to its commit hash.
+func gitRevParse(ctx context.Context, dir, ref string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", ref)
+	executil.HideWindow(cmd)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse %s: %s (%w)", ref, strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// resolveTemperConfig returns the temper config to use, falling back to auto-detection.
+func resolveTemperConfig(worktreePath string, cfg *temper.Config, opts *temper.DetectOptions, raceEnabled bool) temper.Config {
+	if cfg != nil {
+		return *cfg
+	}
+	return temper.DefaultConfigWithRace(worktreePath, opts, raceEnabled)
+}
+
+// formatTemperFailureForPrompt renders a temper failure as a prompt section
+// that can be prepended to the next Smith attempt.
+func formatTemperFailureForPrompt(r *temper.Result) string {
+	if r == nil || r.Passed {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Previous Verification Failure\n\n")
+	b.WriteString("Your previous attempt addressed the review comments but Temper failed when verifying:\n\n")
+	for _, step := range r.Steps {
+		if step.Passed {
+			continue
+		}
+		fmt.Fprintf(&b, "Failed step: %s\nCommand: %s\nOutput:\n```\n%s\n```\n\n",
+			step.Name, step.Command, truncateOutput(step.Output, 4000))
+		break // Only show the first failed step.
+	}
+	b.WriteString("You must address BOTH the original review comments AND fix this verification failure before committing.\n\n")
+	return b.String()
+}
+
+// truncateOutput returns the last maxLen characters of output, prepending
+// a truncation marker if it was shortened.
+func truncateOutput(output string, maxLen int) string {
+	if len(output) <= maxLen {
+		return output
+	}
+	return "... (truncated)\n" + output[len(output)-maxLen:]
 }

--- a/internal/burnish/burnish_test.go
+++ b/internal/burnish/burnish_test.go
@@ -2,12 +2,154 @@ package burnish
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Forge/internal/provider"
+	"github.com/Robin831/Forge/internal/smith"
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/Robin831/Forge/internal/temper"
 	"github.com/Robin831/Forge/internal/vcs"
 )
+
+// testHarness saves and restores the package-level function stubs.
+type testHarness struct {
+	origSmithSpawn  func(ctx context.Context, worktreePath, promptText, logDir string, pv provider.Provider, extraFlags []string) (*smith.Process, error)
+	origTemperRun   func(ctx context.Context, worktreePath string, cfg temper.Config, db *state.DB, beadID, anvil string) *temper.Result
+	origGitPush     func(ctx context.Context, worktreePath, branch string) error
+	origGitRevParse func(ctx context.Context, dir, ref string) (string, error)
+}
+
+func newTestHarness() *testHarness {
+	return &testHarness{
+		origSmithSpawn:  smithSpawnFn,
+		origTemperRun:   temperRunFn,
+		origGitPush:     gitPushFn,
+		origGitRevParse: gitRevParseFn,
+	}
+}
+
+func (h *testHarness) restore() {
+	smithSpawnFn = h.origSmithSpawn
+	temperRunFn = h.origTemperRun
+	gitPushFn = h.origGitPush
+	gitRevParseFn = h.origGitRevParse
+}
+
+// fakeVCS implements vcs.Provider for testing.
+type fakeVCS struct {
+	comments []vcs.ReviewComment
+	resolved []string
+	mu       sync.Mutex
+}
+
+func (f *fakeVCS) CreatePR(_ context.Context, _ vcs.CreateParams) (*vcs.PR, error) {
+	return nil, nil
+}
+func (f *fakeVCS) MergePR(_ context.Context, _ string, _ int, _ string) error { return nil }
+func (f *fakeVCS) CheckStatus(_ context.Context, _ string, _ int) (*vcs.PRStatus, error) {
+	return nil, nil
+}
+func (f *fakeVCS) CheckStatusLight(_ context.Context, _ string, _ int) (*vcs.PRStatus, error) {
+	return nil, nil
+}
+func (f *fakeVCS) ListOpenPRs(_ context.Context, _ string) ([]vcs.OpenPR, error) { return nil, nil }
+func (f *fakeVCS) GetRepoOwnerAndName(_ context.Context, _ string) (string, string, error) {
+	return "owner", "repo", nil
+}
+func (f *fakeVCS) FetchUnresolvedThreadCount(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
+func (f *fakeVCS) FetchPendingReviewRequests(_ context.Context, _ string, _ int) ([]vcs.ReviewRequest, error) {
+	return nil, nil
+}
+func (f *fakeVCS) FetchPRChecks(_ context.Context, _ string, _ int) (string, []vcs.CICheck, error) {
+	return "", nil, nil
+}
+func (f *fakeVCS) FetchCILogs(_ context.Context, _ string, _ []vcs.CICheck) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeVCS) FetchReviewComments(_ context.Context, _ string, _ int) ([]vcs.ReviewComment, error) {
+	return f.comments, nil
+}
+func (f *fakeVCS) ResolveThread(_ context.Context, _ string, threadID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resolved = append(f.resolved, threadID)
+	return nil
+}
+func (f *fakeVCS) Platform() vcs.Platform { return vcs.GitHub }
+
+func openTestDB(t *testing.T) *state.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := state.Open(dbPath)
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func makeSmithStub(exitCode int) func(ctx context.Context, worktreePath, promptText, logDir string, pv provider.Provider, extraFlags []string) (*smith.Process, error) {
+	return func(_ context.Context, _ string, _ string, _ string, _ provider.Provider, _ []string) (*smith.Process, error) {
+		return smith.NewProcessForTest(&smith.Result{
+			ExitCode:      exitCode,
+			ResultSubtype: "success",
+		}), nil
+	}
+}
+
+func makeTemperStub(passed bool, failedStep string) func(ctx context.Context, worktreePath string, cfg temper.Config, db *state.DB, beadID, anvil string) *temper.Result {
+	return func(_ context.Context, _ string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		r := &temper.Result{Passed: passed, FailedStep: failedStep}
+		if !passed {
+			r.Steps = []temper.StepResult{{
+				Name:    failedStep,
+				Command: "go test ./...",
+				Output:  "FAIL some/pkg",
+				Passed:  false,
+			}}
+		}
+		return r
+	}
+}
+
+func noPush(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func noRevParse(_ context.Context, _, _ string) (string, error) {
+	return "", fmt.Errorf("not a git repo")
+}
+
+func fixedRevParse(local, remote string) func(context.Context, string, string) (string, error) {
+	return func(_ context.Context, _ string, ref string) (string, error) {
+		if strings.HasPrefix(ref, "origin/") {
+			return remote, nil
+		}
+		return local, nil
+	}
+}
+
+func defaultFixParams(db *state.DB, vcsP vcs.Provider) FixParams {
+	return FixParams{
+		WorktreePath: os.TempDir(),
+		BeadID:       "test-1",
+		AnvilName:    "test-anvil",
+		PRNumber:     42,
+		Branch:       "forge/test",
+		DB:           db,
+		MaxAttempts:  3,
+		Providers:    []provider.Provider{{Kind: provider.Claude, Model: "test"}},
+		VCS:          vcsP,
+	}
+}
 
 func TestFilterActionableComments(t *testing.T) {
 	tests := []struct {
@@ -112,6 +254,9 @@ func TestBuildReviewFixPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "@copilot") {
 		t.Error("prompt should contain comment author")
 	}
+	if !strings.Contains(prompt, "Do NOT push") {
+		t.Error("prompt should instruct Smith not to push")
+	}
 }
 
 func TestBuildReviewFixPrompt_NoAuthorOrPath(t *testing.T) {
@@ -179,6 +324,10 @@ func TestBuildBatchReviewPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "3 review comments") {
 		t.Error("prompt should mention total number of comments in instructions")
 	}
+
+	if !strings.Contains(prompt, "Do NOT push") {
+		t.Error("prompt should instruct Smith not to push")
+	}
 }
 
 func TestBuildBatchReviewPrompt_NoAuthorOrPath(t *testing.T) {
@@ -231,3 +380,306 @@ func TestBatchFix_NoProviders(t *testing.T) {
 		t.Error("BatchFix should return an error when smith fails to spawn")
 	}
 }
+
+// --- Temper verification tests ---
+
+func TestFix_TemperPasses_Pushes(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(true, "")
+
+	pushCalled := 0
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled++
+		return nil
+	}
+	gitRevParseFn = noRevParse // HEAD != origin → push needed
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	result := Fix(context.Background(), defaultFixParams(db, v))
+
+	if !result.Addressed {
+		t.Error("expected Addressed=true when temper passes")
+	}
+	if pushCalled != 1 {
+		t.Errorf("expected push called once, got %d", pushCalled)
+	}
+	if result.Error != nil {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestFix_TemperFails_LoopsAndDoesNotPush(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+
+	smithSpawnFn = makeSmithStub(0)
+
+	temperAttempt := 0
+	var promptsSeen []string
+	temperRunFn = func(_ context.Context, _ string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		temperAttempt++
+		if temperAttempt == 1 {
+			return &temper.Result{
+				Passed:     false,
+				FailedStep: "test",
+				Steps: []temper.StepResult{{
+					Name: "test", Command: "go test ./...", Output: "FAIL pkg/foo", Passed: false,
+				}},
+			}
+		}
+		return &temper.Result{Passed: true}
+	}
+
+	// Capture prompts to verify temper failure is included on attempt 2.
+	origSmith := makeSmithStub(0)
+	smithSpawnFn = func(ctx context.Context, wt, prompt, logDir string, pv provider.Provider, flags []string) (*smith.Process, error) {
+		promptsSeen = append(promptsSeen, prompt)
+		return origSmith(ctx, wt, prompt, logDir, pv, flags)
+	}
+
+	pushCalled := 0
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled++
+		return nil
+	}
+	gitRevParseFn = noRevParse
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	result := Fix(context.Background(), defaultFixParams(db, v))
+
+	if !result.Addressed {
+		t.Error("expected Addressed=true after second attempt")
+	}
+	if result.Attempts != 2 {
+		t.Errorf("expected 2 attempts, got %d", result.Attempts)
+	}
+	if pushCalled != 1 {
+		t.Errorf("expected push called once (after attempt 2), got %d", pushCalled)
+	}
+	// The second prompt should contain the temper failure feedback.
+	if len(promptsSeen) < 2 {
+		t.Fatalf("expected at least 2 prompts, got %d", len(promptsSeen))
+	}
+	if !strings.Contains(promptsSeen[1], "Previous Verification Failure") {
+		t.Error("second prompt should contain temper failure feedback")
+	}
+	if !strings.Contains(promptsSeen[1], "FAIL pkg/foo") {
+		t.Error("second prompt should contain temper output")
+	}
+}
+
+func TestFix_TemperFailsAllAttempts_NoPush(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(false, "build")
+
+	pushCalled := 0
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled++
+		return nil
+	}
+	gitRevParseFn = noRevParse
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	params := defaultFixParams(db, v)
+	params.MaxAttempts = 3
+	result := Fix(context.Background(), params)
+
+	if result.Addressed {
+		t.Error("expected Addressed=false when temper fails all attempts")
+	}
+	if pushCalled != 0 {
+		t.Errorf("expected push never called, got %d", pushCalled)
+	}
+	if result.Error == nil {
+		t.Error("expected error when all attempts exhausted")
+	}
+}
+
+func TestFix_PushFails_ReturnsError(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(true, "")
+	gitRevParseFn = noRevParse // force push path
+
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		return fmt.Errorf("network error")
+	}
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	result := Fix(context.Background(), defaultFixParams(db, v))
+
+	if result.Addressed {
+		t.Error("expected Addressed=false when push fails")
+	}
+	if result.Error == nil {
+		t.Error("expected error when push fails")
+	}
+	if !strings.Contains(result.Error.Error(), "push after temper verification") {
+		t.Errorf("expected push error, got: %v", result.Error)
+	}
+}
+
+func TestFix_SmithPushedAnyway_TemperStillAuthoritative(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(false, "test")
+
+	// Simulate Smith already pushed: HEAD matches origin/branch.
+	gitRevParseFn = fixedRevParse("abc123", "abc123")
+
+	pushCalled := 0
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled++
+		return nil
+	}
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	params := defaultFixParams(db, v)
+	params.MaxAttempts = 1
+	result := Fix(context.Background(), params)
+
+	// Temper failed, so even though Smith pushed, result should NOT be Addressed.
+	if result.Addressed {
+		t.Error("expected Addressed=false when temper fails, even if Smith pushed")
+	}
+	if pushCalled != 0 {
+		t.Errorf("expected no gitPush call (Smith already pushed), got %d", pushCalled)
+	}
+}
+
+func TestBatchFix_TemperFails_DoesNotPush(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(false, "lint")
+
+	pushCalled := 0
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled++
+		return nil
+	}
+	gitRevParseFn = noRevParse
+
+	result := BatchFix(context.Background(), BatchFixParams{
+		WorktreePath: os.TempDir(),
+		BeadID:       "test-1",
+		AnvilName:    "test-anvil",
+		PRNumber:     42,
+		Branch:       "forge/test",
+		DB:           db,
+		Providers:    []provider.Provider{{Kind: provider.Claude, Model: "test"}},
+		Comments: []vcs.ReviewComment{
+			{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+		},
+	})
+
+	if result.Addressed {
+		t.Error("expected Addressed=false when temper fails in BatchFix")
+	}
+	if pushCalled != 0 {
+		t.Errorf("expected push never called, got %d", pushCalled)
+	}
+	if result.Error == nil {
+		t.Error("expected error when temper fails in BatchFix")
+	}
+	if !strings.Contains(result.Error.Error(), "temper verification failed") {
+		t.Errorf("expected temper error, got: %v", result.Error)
+	}
+}
+
+func TestFormatTemperFailureForPrompt(t *testing.T) {
+	t.Run("nil result returns empty", func(t *testing.T) {
+		if got := formatTemperFailureForPrompt(nil); got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("passed result returns empty", func(t *testing.T) {
+		r := &temper.Result{Passed: true}
+		if got := formatTemperFailureForPrompt(r); got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("failed result includes step info", func(t *testing.T) {
+		r := &temper.Result{
+			Passed:     false,
+			FailedStep: "test",
+			Steps: []temper.StepResult{
+				{Name: "build", Command: "go build ./...", Output: "ok", Passed: true},
+				{Name: "test", Command: "go test ./...", Output: "FAIL TestFoo", Passed: false},
+			},
+		}
+		got := formatTemperFailureForPrompt(r)
+		if !strings.Contains(got, "Previous Verification Failure") {
+			t.Error("should contain header")
+		}
+		if !strings.Contains(got, "Failed step: test") {
+			t.Error("should contain failed step name")
+		}
+		if !strings.Contains(got, "FAIL TestFoo") {
+			t.Error("should contain step output")
+		}
+	})
+}
+
+func TestTruncateOutput(t *testing.T) {
+	t.Run("short output unchanged", func(t *testing.T) {
+		got := truncateOutput("hello", 100)
+		if got != "hello" {
+			t.Errorf("expected 'hello', got %q", got)
+		}
+	})
+
+	t.Run("long output truncated from start", func(t *testing.T) {
+		long := strings.Repeat("x", 5000)
+		got := truncateOutput(long, 100)
+		if len(got) > 120 { // 100 + truncation marker
+			t.Errorf("expected truncated output, got length %d", len(got))
+		}
+		if !strings.HasPrefix(got, "... (truncated)") {
+			t.Error("should have truncation marker")
+		}
+	})
+}
+
+// Suppress unused import warnings for time — used in test setup.
+var _ = time.Second

--- a/internal/burnish/burnish_test.go
+++ b/internal/burnish/burnish_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
@@ -680,6 +679,3 @@ func TestTruncateOutput(t *testing.T) {
 		}
 	})
 }
-
-// Suppress unused import warnings for time — used in test setup.
-var _ = time.Second

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1035,35 +1035,43 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 					d.logger.Warn("failed to fetch review comments for batch fix, falling back to single fix", "pr", req.PRNumber, "error", fetchErr)
 					useBurnishBatch = false
 				} else {
+					burnishDetectOpts := temper.DetectOptionsFromAnvilFlag(anvilCfg.GolangciLint)
 					res = burnish.BatchFix(workerCtx, burnish.BatchFixParams{
-						WorktreePath: wt.Path,
-						BeadID:       req.BeadID,
-						AnvilName:    req.Anvil,
-						PRNumber:     req.PRNumber,
-						Branch:       req.Branch,
-						DB:           d.db,
-						WorkerID:     workerID,
-						ExtraFlags:   burnishCfg.Settings.ClaudeFlags,
-						Providers:    burnishProviders,
-						Comments:     comments,
-						VCS:          anvilVCS,
+						WorktreePath:    wt.Path,
+						BeadID:          req.BeadID,
+						AnvilName:       req.Anvil,
+						PRNumber:        req.PRNumber,
+						Branch:          req.Branch,
+						DB:              d.db,
+						WorkerID:        workerID,
+						ExtraFlags:      burnishCfg.Settings.ClaudeFlags,
+						Providers:       burnishProviders,
+						Comments:        comments,
+						VCS:             anvilVCS,
+						TemperConfig:    d.resolveTemperConfig(anvilCfg),
+						DetectOptions:   burnishDetectOpts,
+						GoRaceDetection: d.resolveGoRaceDetection(anvilCfg),
 					})
 				}
 			}
 			if !useBurnishBatch {
+				burnishDetectOpts := temper.DetectOptionsFromAnvilFlag(anvilCfg.GolangciLint)
 				res = burnish.Fix(workerCtx, burnish.FixParams{
-					WorktreePath: wt.Path,
-					BeadID:       req.BeadID,
-					AnvilName:    req.Anvil,
-					AnvilPath:    anvilCfg.Path,
-					PRNumber:     req.PRNumber,
-					Branch:       req.Branch,
-					DB:           d.db,
-					WorkerID:     workerID,
-					MaxAttempts:  burnishCfg.Settings.MaxReviewAttempts,
-					ExtraFlags:   burnishCfg.Settings.ClaudeFlags,
-					Providers:    burnishProviders,
-					VCS:          d.vcsForAnvil(req.Anvil),
+					WorktreePath:    wt.Path,
+					BeadID:          req.BeadID,
+					AnvilName:       req.Anvil,
+					AnvilPath:       anvilCfg.Path,
+					PRNumber:        req.PRNumber,
+					Branch:          req.Branch,
+					DB:              d.db,
+					WorkerID:        workerID,
+					MaxAttempts:     burnishCfg.Settings.MaxReviewAttempts,
+					ExtraFlags:      burnishCfg.Settings.ClaudeFlags,
+					Providers:       burnishProviders,
+					VCS:             d.vcsForAnvil(req.Anvil),
+					TemperConfig:    d.resolveTemperConfig(anvilCfg),
+					DetectOptions:   burnishDetectOpts,
+					GoRaceDetection: d.resolveGoRaceDetection(anvilCfg),
 				})
 			}
 			status := state.WorkerDone

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1350,6 +1350,7 @@ const (
 	EventBurnishFailed        EventType = "review_fix_failed"
 	EventReviewThreadResolved EventType = "review_thread_resolved"
 	EventBurnishSmithError    EventType = "review_fix_smith_error"
+	EventBurnishTemperFailed  EventType = "review_fix_temper_failed"
 	EventPRCreated            EventType = "pr_created"
 	EventPRMerged             EventType = "pr_merged"
 	EventPRClosed             EventType = "pr_closed"


### PR DESCRIPTION
## Changes

- **Burnish temper verification gate** - Burnish now runs Temper verification before pushing review-fix commits, breaking the burnish-quench infinite loop on PRs with automated review comments. Previously, burnish trusted Smith to only push working code, but Smith often pushed broken builds which triggered quench, which then triggered another Copilot review, restarting the cycle. (Forge-syrn)

## Original Issue (bug): Burnish: gate push on Temper verification to break the burnish↔quench loop

## Problem

Burnish is the only Smith-invoking worker in Forge that does **not** run Temper before declaring its work successful. Every other code-modifying worker (`pipeline.Run` for the initial PR, `quench.Run` for CI fixes) runs Temper as a verification gate. Burnish does not — it only checks Smith's exit code and trusts the prompt instruction "Run the test suite ... do NOT commit or push if tests are failing" (`burnish.go:519`), which Smith ignores often enough to matter.

This asymmetry is the structural cause of an observed infinite-loop pattern on PRs that receive Copilot review:

```
PR opens (clean — pipeline.Run already ran Temper before opening it)
  → Copilot reviews → leaves comments
  → bellows detects unresolved threads → spawns burnish
  → burnish: Smith addresses comments, may break tests/build/lint, pushes anyway
  → daemon resets bellows snapshot (daemon.go:1086) → fresh CI state detected
  → CI fails → bellows spawns quench
  → quench: Temper repro → Smith fixes CI → Temper verifies → push
  → daemon resets bellows snapshot (daemon.go:1009) → fresh review state
  → Copilot re-reviews the new commits → new comments
  → bellows detects unresolved threads → spawns burnish again
  → ... loop until max_review_fix_attempts (default 5) OR max_ci_fix_attempts (default 5) gives up
```

Worst-case ~10 Smith invocations per PR, all charged as Copilot premium requests when Copilot is the active provider, plus 10 CI runs and the GH-actions minutes that go with them.

The user-observable signature: initial PR creation rarely fails CI (because the pipeline already gates on Temper); the loop **only** starts after the first burnish cycle.

## Why burnish is the one outlier

Worker-by-worker map (verified by reading the source):

| Worker | File | Temper before declaring success? |
|---|---|---|
| Pipeline (initial Smith) | `internal/pipeline/pipeline.go` | ✅ Yes — between Smith and Warden, before PR creation |
| Quench (CI fix) | `internal/quench/quench.go:297, :412` | ✅ Yes — once for local repro, once to verify after Smith |
| **Burnish (review fix)** | `internal/burnish/burnish.go` | ❌ **No — no `temper.Run()` call anywhere in the package** |
| Rebase | `internal/rebase/` | N/A (no code changes, only conflict resolution) |

`grep -r 'temper\.\|temper.Run' internal/burnish` returns zero matches. `burnish.go` does not even import `internal/temper`.

## Fix: push gating in burnish

The cleanest fix is to move the `git push` out of Smith's session and into burnish itself, with Temper as the gate. Smith commits locally; burnish runs Temper; only on success does burnish push.

### Required changes

#### 1. Prompt updates — tell Smith to commit but NOT push

**`internal/burnish/burnish.go:515-523`** (`buildReviewFixPrompt` instructions block):

Replace step 4-5:
```
4. Commit with message: "fix: address review comments for %s"
5. Push to branch: %s
```
with:
```
4. Commit with message: "fix: address review comments for %s"
5. Do NOT push — Forge will run verification and push for you. Exit cleanly after committing.
```

**`internal/burnish/burnish.go:258-266`** (`buildBatchReviewPrompt` instructions block): same edit.

The "Run the test suite" instruction (step 3) can stay — Smith may still catch obvious issues during the session, which saves a Temper round. Just remove the push step.

#### 2. Add Temper verification after Smith exits

In `burnish.Fix` (`burnish.go:271-469`), after the existing `if smithResult.ExitCode != 0 { continue }` check at `:399-419` and before the "Smith succeeded — assume fixes were committed and pushed" log line at `:421-423`, insert:

```go
// Verify locally before pushing. Mirrors quench's verify-after-Smith pattern.
temperCfg := p.TemperConfig
if temperCfg == nil {
    detected := temper.DefaultConfigWithRace(p.WorktreePath, p.DetectOptions, p.GoRaceDetection)
    temperCfg = &detected
}
verifyResult := temper.Run(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
if !verifyResult.Passed {
    log.Printf("[burnish] PR #%d: Temper failed on attempt %d (failed step: %s) — looping with feedback",
        p.PRNumber, attempt, verifyResult.FailedStep)
    _ = p.DB.LogEvent(state.EventBurnishTemperFailed,
        fmt.Sprintf("PR #%d: temper failed on attempt %d at step %s", p.PRNumber, attempt, verifyResult.FailedStep),
        p.BeadID, p.AnvilName)
    // Build the next prompt with the temper failure appended so the next Smith
    // attempt has the failing step output as direct context.
    lastTemperFailure = verifyResult
    continue
}
```

Then, only after temper passes:

```go
// Temper passed — push the verified commits.
if err := gitPush(ctx, p.WorktreePath, p.Branch); err != nil {
    log.Printf("[burnish] PR #%d: push failed after temper-verified fix: %v", p.PRNumber, err)
    _ = p.DB.LogEvent(state.EventBurnishFailed,
        fmt.Sprintf("PR #%d: push failed after temper-verified fix: %v", p.PRNumber, err),
        p.BeadID, p.AnvilName)
    result.Error = fmt.Errorf("push after temper verification: %w", err)
    result.Duration = time.Since(start)
    return result
}

log.Printf("[burnish] PR #%d: Review fixes verified and pushed on attempt %d", p.PRNumber, attempt)
result.Addressed = true
```

Add the same wiring to `burnish.BatchFix` (`burnish.go:101-228`). BatchFix currently has a single attempt and no loop — for the verification path, keep it simple: if Temper fails after the batch fix, log and return `result.Error` so bellows treats it as a failed burnish cycle (it will then dispatch a fresh attempt on the next poll). Do not push if temper failed.

#### 3. Add a small `gitPush` helper

`internal/burnish/burnish.go` doesn't currently shell out to git directly. Add a tiny helper at the bottom of the file:

```go
func gitPush(ctx context.Context, worktreePath, branch string) error {
    cmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "push", "origin", branch)
    out, err := cmd.CombinedOutput()
    if err != nil {
        return fmt.Errorf("git push origin %s: %w (output: %s)", branch, err, strings.TrimSpace(string(out)))
    }
    return nil
}
```

(Compare to how `quench.go:341` uses `gitRevParse` — same pattern.)

#### 4. Plumb `TemperConfig`, `DetectOptions`, `GoRaceDetection` through `FixParams` and `BatchFixParams`

Currently `FixParams` (`burnish.go:28-57`) and `BatchFixParams` (`:73-97`) don't carry temper config. Add:

```go
TemperConfig    *temper.Config
DetectOptions   *temper.DetectOptions
GoRaceDetection bool
```

to both, and have the daemon dispatch site (`daemon.go:1054-1067` for `burnish.Fix`, `:1038-1050` for `burnish.BatchFix`) pass them from the same anvil config that quench uses today (`daemon.go` already constructs a `TemperConfig` for the quench dispatch path — search for how `quench.FixParams` gets it and mirror exactly).

#### 5. Append the previous Temper failure to the next prompt

Inside the `for attempt` loop in `burnish.Fix`, when `lastTemperFailure != nil` (set from a previous iteration), add a section to the prompt before the existing "Review Comments to Address" block:

```
## Previous Verification Failure

Your previous attempt addressed the review comments but Temper failed when verifying:

Failed step: <name>
Command: <command>
Output:
\`\`\`
<truncated to 4000 chars>
\`\`\`

You must address BOTH the original review comments AND fix this verification failure before committing.
```

This mirrors `buildCIFixPrompt` at `quench.go:463-525`. Extract a small `formatTemperFailureForPrompt(*temper.Result) string` helper to share with quench eventually (not required for this bead).

#### 6. New event type

Add `EventBurnishTemperFailed` to `internal/state/db.go` near the other burnish events at `:1348-1352`:

```go
EventBurnishTemperFailed  EventType = "review_fix_temper_failed"
```

This gives Hearth and the events panel visibility when burnish loops because of a verification failure (vs. Smith error vs. rate limit).

#### 7. Do NOT change the daemon's snapshot reset behavior

`daemon.go:1078-1088` resets the bellows snapshot after a successful burnish. Keep that — it's still correct because after a successful burnish (which now means temper-verified + pushed), CI will run on the verified push and the snapshot needs refreshing. The bug was never the reset; it was that "successful burnish" used to include broken pushes.

## Edge cases to handle

1. **Smith pushes anyway, ignoring the prompt.** Defensive check before `gitPush`: compare `git rev-parse origin/<branch>` against `HEAD`. If they're already equal (Smith pushed), log a warning and skip the explicit push but still treat temper result as authoritative — if temper failed, we cannot un-push, but we should still NOT mark `result.Addressed = true`, so the failed temper feeds into the next attempt and bellows still reacts to the resulting CI failure.

2. **No actionable comments** (existing early-return at `burnish.go:307-312`): unchanged. No fix means no commit means no push means no temper run.

3. **Smith made a commit but Temper fails on attempt N where N == MaxAttempts.** The current loop just falls through to the "could not address review comments after %d attempts" error at `burnish.go:463`. Important: in this case there is a local commit in the worktree that was never pushed. The worker cleanup path (`worktree.Remove`) discards the worktree, so the unpushed commit is dropped naturally. Verify with a test that no orphan branch is left behind on the remote.

4. **Worktree has no `go.mod` / `package.json` / `*.csproj`** (Temper detects nothing). Today `temper.DefaultConfig` returns an empty step list, and `temper.Run` reports `Passed = true` for an empty list. Confirm this is still true after the change — for repos with no detectable build system, burnish should fall through to the push step exactly like it does today (i.e., this fix is a no-op for non-Temper-detectable repos).

5. **Worktree-based race with bellows.** Bellows polls the PR status independently; we don't want bellows to detect the in-flight burnish state and dispatch a duplicate worker. The lifecycle manager already serializes per-PR (`internal/lifecycle/lifecycle.go`); confirm the worker remains marked `Phase: "burnish"` across the new Temper run so the in-flight check still applies.

## Testing

#### Unit tests in `internal/burnish/burnish_test.go`

Add cases (use the existing test scaffolding pattern):

1. **`TestFix_TemperPasses_Pushes`** — stub Smith to exit 0, stub a Temper that returns `Passed: true`, stub a push function. Assert push was called exactly once and `result.Addressed == true`.

2. **`TestFix_TemperFails_LoopsAndDoesNotPush`** — stub Smith to exit 0, stub Temper to return `Passed: false` on attempt 1 and `Passed: true` on attempt 2. Assert push was called exactly once (after attempt 2), `result.Attempts == 2`, `result.Addressed == true`, and that the second prompt contained the temper failure section.

3. **`TestFix_TemperFailsAllAttempts_NoPush`** — Temper fails on every attempt up to MaxAttempts. Assert push was never called, `result.Addressed == false`, `result.Error` mentions exhaustion, and an `EventBurnishTemperFailed` event was logged.

4. **`TestFix_PushFails_ReturnsError`** — Temper passes but `gitPush` returns an error. Assert `result.Addressed == false`, `result.Error` wraps the push error, and the worker is marked failed (so bellows can dispatch a retry).

5. **`TestFix_SmithPushedAnyway_TemperStillAuthoritative`** — defensive case for edge case 1 above. Stub the worktree so `origin/<branch>` already matches `HEAD` after Smith. Assert burnish does NOT call `gitPush` again, but if temper failed it still does NOT mark `result.Addressed = true`.

6. **`TestBatchFix_TemperFails_DoesNotPush`** — same as #3 but for the BatchFix path; just one attempt, returns error.

For tests 1-5, the existing test plumbing in `burnish_test.go` already stubs `smith.SpawnWithProvider` via the package-level test fakes — extend the same pattern for `temper.Run` (introduce a package-level `var temperRun = temper.Run` and override in tests) and for `gitPush` (same pattern: `var gitPushFn = gitPush`).

#### Integration smoke test (manual, after merge)

On a Hytte PR (mixed Go + npm — most likely place for a Temper auto-detect wrinkle):

1. Open a PR that knowingly fails one Copilot review check (e.g. trivial naming nit).
2. Watch `forge hearth` event log for: `review_fix_started` → `review_fix_temper_failed` (if Smith breaks something) OR `review_fix_success` directly.
3. Verify on the PR that **commits only appear after temper passes**, never before.
4. Force a regression: temporarily edit a test to fail, push it as a review-comment fix scenario, confirm burnish loops with the temper failure surfaced in the log, and the broken commit is never pushed.

## Files touched

- `internal/burnish/burnish.go` — main change
- `internal/burnish/burnish_test.go` — new tests + temper/push stubbing
- `internal/state/db.go` — new `EventBurnishTemperFailed` event type
- `internal/daemon/daemon.go` — pass `TemperConfig`/`DetectOptions`/`GoRaceDetection` to `burnish.Fix` and `burnish.BatchFix` (mirror existing quench dispatch)
- `changelog.d/Forge-<id>.md` — `Fixed` category fragment

## Out of scope (file separately if wanted)

- **Push gating in quench.** Quench has the same shape (Smith pushes from inside its session) but already has a verify-Temper, so the failure mode is contained. Worth doing for symmetry but it's not the bug.
- **Alternation circuit breaker in bellows.** Cap N burnish↔quench transitions per PR before flipping to `needs_human`. Nice safety net but unnecessary if push gating works as expected. Defer.
- **Sharing `formatTemperFailureForPrompt` between burnish and quench.** Pure refactor; do as a follow-up if both end up with near-identical helpers.

## Acceptance criteria

- `grep -n 'temper\.' internal/burnish/burnish.go` returns at least one `temper.Run` call.
- A burnish cycle that produces broken code never pushes to the remote (verified in unit test #3 and #5).
- A burnish cycle that produces working code pushes exactly once, after Temper passes (verified in unit test #1).
- The `forge hearth` event log shows `review_fix_temper_failed` events when burnish loops because of verification failure (not just generic Smith errors).
- A repeat of the original loop scenario on a real PR completes within `max_review_fix_attempts` cycles instead of bouncing between burnish and quench until both counters exhaust.

---
Bead: Forge-syrn | Branch: forge/Forge-syrn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)