### PR TITLE
Temper hooks (before_temper / after_temper) don't fire in burnish and quench (Forge-w8rb)

### DIFF
--- a/changelog.d/Forge-w8rb.md
+++ b/changelog.d/Forge-w8rb.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Temper hooks fire in burnish and quench** - Pipeline stage hooks (`before_temper`, `after_temper`) now fire during burnish (review-fix) and quench (CI-fix) temper runs, not just during the initial pipeline. Setup commands like `npm ci` now apply uniformly across all temper invocations. (Forge-w8rb)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ anvils:
     depcheck_enabled: true         # Set to false to skip depcheck for this anvil
     hooks:                         # Pipeline stage hooks (optional)
       after_smith: './scripts/post-smith.sh'
-      before_temper: './scripts/pre-temper.sh'
+      before_temper: './scripts/pre-temper.sh'  # runs for every temper invocation (pipeline, burnish, quench)
 
   my-frontend:
     path: /path/to/repos/my-frontend
@@ -168,7 +168,7 @@ anvils:
 
 ### Pipeline Hooks
 
-Configure shell commands that run before or after each pipeline stage. Hooks are executed via a platform-appropriate shell (`sh -c` on Unix, `cmd /c` on Windows) with the worktree as the working directory and receive pipeline context as environment variables. Each hook has a 60-second timeout.
+Configure shell commands that run before or after each pipeline stage. Hooks fire before/after every temper invocation — initial pipeline, burnish review-fix, and quench CI-fix — so setup commands like `npm ci` or container startup work uniformly across all temper runs. Hooks are executed via a platform-appropriate shell (`sh -c` on Unix, `cmd /c` on Windows) with the worktree as the working directory and receive pipeline context as environment variables. Each hook has a 60-second timeout.
 
 ```yaml
 anvils:
@@ -197,9 +197,10 @@ anvils:
 | `hooks.after_warden` | string | | Runs after each Warden review. |
 
 **Hook behavior:**
-- **Before hooks** abort the pipeline on non-zero exit. Use them to enforce preconditions (e.g., required files, environment validation).
-- **After hooks** are best-effort — failures are logged but do not abort the pipeline. Use them for notifications, metrics, or cleanup.
+- **Before hooks** abort the current stage on non-zero exit. Use them to enforce preconditions (e.g., required files, environment validation).
+- **After hooks** are best-effort — failures are logged but do not abort the stage. Use them for notifications, metrics, or cleanup.
 - Hooks run in the worktree directory, so relative paths resolve against the worktree.
+- Temper hooks (`before_temper`, `after_temper`) fire for every temper invocation: initial pipeline, burnish (review-fix), and quench (CI-fix). This ensures setup commands (e.g. `npm ci`) apply uniformly.
 
 **Environment variables** available to all hooks:
 
@@ -214,6 +215,16 @@ anvils:
 | `FORGE_ITERATION` | Current Smith-Warden cycle number (1-based) for `smith`/`warden` stages; `schematic` hooks currently receive `1` even though they run outside the Smith-Warden loop |
 
 **Use cases:** custom linters, Slack/Teams notifications, prompt context injection, metrics collection, pre-flight checks.
+
+**Node.js example** — install dependencies before every temper run so that build/lint/test steps always have fresh `node_modules`:
+
+```yaml
+anvils:
+  my-node-app:
+    path: /home/user/source/my-node-app
+    hooks:
+      before_temper: 'cd web && npm ci'
+```
 
 ### Auto-Dispatch Modes
 

--- a/internal/burnish/burnish.go
+++ b/internal/burnish/burnish.go
@@ -92,6 +92,8 @@ type BatchFixParams struct {
 	BeadID string
 	// AnvilName for tracking.
 	AnvilName string
+	// AnvilPath is the repo root (used to populate FORGE_ANVIL_PATH in hook env).
+	AnvilPath string
 	// PRNumber being fixed.
 	PRNumber int
 	// Branch name for the PR.
@@ -222,6 +224,7 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 		WorktreePath: p.WorktreePath,
 		Branch:       p.Branch,
 		AnvilName:    p.AnvilName,
+		AnvilPath:    p.AnvilPath,
 		Stage:        "temper",
 		Iteration:    1,
 	}

--- a/internal/burnish/burnish.go
+++ b/internal/burnish/burnish.go
@@ -13,8 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/cost"
 	"github.com/Robin831/Forge/internal/executil"
+	"github.com/Robin831/Forge/internal/hooks"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/state"
@@ -63,6 +65,9 @@ type FixParams struct {
 	DetectOptions *temper.DetectOptions
 	// GoRaceDetection enables Go race detection in temper steps.
 	GoRaceDetection bool
+	// Hooks is the per-anvil hook configuration. When set, before_temper and
+	// after_temper hooks fire around every temper invocation.
+	Hooks *config.HooksConfig
 }
 
 // FixResult captures the outcome of addressing review comments.
@@ -109,6 +114,8 @@ type BatchFixParams struct {
 	DetectOptions *temper.DetectOptions
 	// GoRaceDetection enables Go race detection in temper steps.
 	GoRaceDetection bool
+	// Hooks is the per-anvil hook configuration for temper hooks.
+	Hooks *config.HooksConfig
 }
 
 // BatchFix combines multiple review comments into one Smith prompt.
@@ -210,8 +217,24 @@ func BatchFix(ctx context.Context, p BatchFixParams) *FixResult {
 	}
 
 	// Verify locally before pushing.
+	hEnv := hooks.HookEnv{
+		BeadID:       p.BeadID,
+		WorktreePath: p.WorktreePath,
+		Branch:       p.Branch,
+		AnvilName:    p.AnvilName,
+		Stage:        "temper",
+		Iteration:    1,
+	}
+	if err := hookRunFn(ctx, p.WorkerID, "before_temper", hooks.HookCmd(p.Hooks, "before_temper"), hEnv); err != nil {
+		result.Error = fmt.Errorf("before_temper hook: %w", err)
+		result.Duration = time.Since(start)
+		return result
+	}
 	temperCfg := resolveTemperConfig(p.WorktreePath, p.TemperConfig, p.DetectOptions, p.GoRaceDetection)
 	verifyResult := temperRunFn(ctx, p.WorktreePath, temperCfg, p.DB, p.BeadID, p.AnvilName)
+	if err := hookRunFn(ctx, p.WorkerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), hEnv); err != nil {
+		log.Printf("[burnish] PR #%d: after_temper hook failed (non-fatal): %v", p.PRNumber, err)
+	}
 	if !verifyResult.Passed {
 		log.Printf("[burnish] PR #%d: batch Temper failed (failed step: %s) — not pushing",
 			p.PRNumber, verifyResult.FailedStep)
@@ -474,8 +497,25 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		}
 
 		// Smith succeeded — verify locally before pushing.
+		hEnv := hooks.HookEnv{
+			BeadID:       p.BeadID,
+			WorktreePath: p.WorktreePath,
+			Branch:       p.Branch,
+			AnvilName:    p.AnvilName,
+			AnvilPath:    p.AnvilPath,
+			Stage:        "temper",
+			Iteration:    attempt,
+		}
+		if err := hookRunFn(ctx, p.WorkerID, "before_temper", hooks.HookCmd(p.Hooks, "before_temper"), hEnv); err != nil {
+			result.Error = fmt.Errorf("before_temper hook: %w", err)
+			result.Duration = time.Since(start)
+			return result
+		}
 		temperCfg := resolveTemperConfig(p.WorktreePath, p.TemperConfig, p.DetectOptions, p.GoRaceDetection)
 		verifyResult := temperRunFn(ctx, p.WorktreePath, temperCfg, p.DB, p.BeadID, p.AnvilName)
+		if err := hookRunFn(ctx, p.WorkerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), hEnv); err != nil {
+			log.Printf("[burnish] PR #%d: after_temper hook failed (non-fatal): %v", p.PRNumber, err)
+		}
 
 		// Defensive check: did Smith push despite being told not to?
 		smithAlreadyPushed := false
@@ -614,6 +654,9 @@ func buildReviewFixPrompt(p FixParams, comments []vcs.ReviewComment) string {
 
 	return b.String()
 }
+
+// hookRunFn is the function used to run hooks. Package-level variable for test stubbing.
+var hookRunFn = hooks.RunHook
 
 // smithSpawnFn is the function used to spawn Smith. Package-level variable for test stubbing.
 var smithSpawnFn = smith.SpawnWithProvider

--- a/internal/burnish/burnish_test.go
+++ b/internal/burnish/burnish_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/hooks"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/state"
@@ -22,6 +24,7 @@ type testHarness struct {
 	origTemperRun   func(ctx context.Context, worktreePath string, cfg temper.Config, db *state.DB, beadID, anvil string) *temper.Result
 	origGitPush     func(ctx context.Context, worktreePath, branch string) error
 	origGitRevParse func(ctx context.Context, dir, ref string) (string, error)
+	origHookRun     func(ctx context.Context, workerID, hookName, cmd string, env hooks.HookEnv) error
 }
 
 func newTestHarness() *testHarness {
@@ -30,6 +33,7 @@ func newTestHarness() *testHarness {
 		origTemperRun:   temperRunFn,
 		origGitPush:     gitPushFn,
 		origGitRevParse: gitRevParseFn,
+		origHookRun:     hookRunFn,
 	}
 }
 
@@ -38,6 +42,7 @@ func (h *testHarness) restore() {
 	temperRunFn = h.origTemperRun
 	gitPushFn = h.origGitPush
 	gitRevParseFn = h.origGitRevParse
+	hookRunFn = h.origHookRun
 }
 
 // fakeVCS implements vcs.Provider for testing.
@@ -678,4 +683,180 @@ func TestTruncateOutput(t *testing.T) {
 			t.Error("should have truncation marker")
 		}
 	})
+}
+
+// --- Hook tests ---
+
+func TestFix_BeforeTemperHook_Invoked(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(true, "")
+	gitPushFn = noPush
+	gitRevParseFn = noRevParse
+
+	var hooksCalled []string
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, env hooks.HookEnv) error {
+		if cmd != "" {
+			hooksCalled = append(hooksCalled, hookName)
+		}
+		return nil
+	}
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	params := defaultFixParams(db, v)
+	params.Hooks = &config.HooksConfig{
+		BeforeTemper: "echo before",
+		AfterTemper:  "echo after",
+	}
+
+	result := Fix(context.Background(), params)
+
+	if !result.Addressed {
+		t.Error("expected Addressed=true")
+	}
+	if len(hooksCalled) < 2 {
+		t.Fatalf("expected at least 2 hook calls, got %d: %v", len(hooksCalled), hooksCalled)
+	}
+	if hooksCalled[0] != "before_temper" {
+		t.Errorf("expected first hook to be before_temper, got %s", hooksCalled[0])
+	}
+	if hooksCalled[1] != "after_temper" {
+		t.Errorf("expected second hook to be after_temper, got %s", hooksCalled[1])
+	}
+}
+
+func TestFix_AfterTemperHook_Invoked(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(true, "")
+	gitPushFn = noPush
+	gitRevParseFn = noRevParse
+
+	afterCalled := false
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, env hooks.HookEnv) error {
+		if hookName == "after_temper" && cmd != "" {
+			afterCalled = true
+		}
+		return nil
+	}
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	params := defaultFixParams(db, v)
+	params.Hooks = &config.HooksConfig{AfterTemper: "echo done"}
+
+	result := Fix(context.Background(), params)
+
+	if !result.Addressed {
+		t.Error("expected Addressed=true")
+	}
+	if !afterCalled {
+		t.Error("expected after_temper hook to be called")
+	}
+}
+
+func TestFix_BeforeTemperHook_Fails_AbortsBurnish(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+	smithSpawnFn = makeSmithStub(0)
+
+	temperCalled := false
+	temperRunFn = func(_ context.Context, _ string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		temperCalled = true
+		return &temper.Result{Passed: true}
+	}
+
+	pushCalled := false
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled = true
+		return nil
+	}
+	gitRevParseFn = noRevParse
+
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "before_temper" && cmd != "" {
+			return fmt.Errorf("hook before_temper failed: exit status 1")
+		}
+		return nil
+	}
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	params := defaultFixParams(db, v)
+	params.Hooks = &config.HooksConfig{BeforeTemper: "exit 1"}
+
+	result := Fix(context.Background(), params)
+
+	if result.Addressed {
+		t.Error("expected Addressed=false when before_temper hook fails")
+	}
+	if result.Error == nil {
+		t.Fatal("expected error when before_temper hook fails")
+	}
+	if !strings.Contains(result.Error.Error(), "before_temper hook") {
+		t.Errorf("expected error to mention before_temper hook, got: %v", result.Error)
+	}
+	if temperCalled {
+		t.Error("temper.Run should NOT have been called after before_temper hook failure")
+	}
+	if pushCalled {
+		t.Error("push should NOT have been called after before_temper hook failure")
+	}
+}
+
+func TestFix_AfterTemperHook_Fails_Logged_Only(t *testing.T) {
+	h := newTestHarness()
+	defer h.restore()
+
+	db := openTestDB(t)
+	smithSpawnFn = makeSmithStub(0)
+	temperRunFn = makeTemperStub(true, "")
+	gitRevParseFn = noRevParse
+
+	pushCalled := false
+	gitPushFn = func(_ context.Context, _, _ string) error {
+		pushCalled = true
+		return nil
+	}
+
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "after_temper" && cmd != "" {
+			return fmt.Errorf("after_temper hook failed")
+		}
+		return nil
+	}
+
+	v := &fakeVCS{comments: []vcs.ReviewComment{
+		{Author: "copilot", Body: "fix this", State: "CHANGES_REQUESTED"},
+	}}
+
+	params := defaultFixParams(db, v)
+	params.Hooks = &config.HooksConfig{AfterTemper: "exit 1"}
+
+	result := Fix(context.Background(), params)
+
+	if !result.Addressed {
+		t.Error("expected Addressed=true even when after_temper hook fails")
+	}
+	if result.Error != nil {
+		t.Errorf("expected no error (after_temper is best-effort), got: %v", result.Error)
+	}
+	if !pushCalled {
+		t.Error("push should still happen after after_temper hook failure")
+	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1041,6 +1041,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 						WorktreePath:    wt.Path,
 						BeadID:          req.BeadID,
 						AnvilName:       req.Anvil,
+						AnvilPath:       anvilCfg.Path,
 						PRNumber:        req.PRNumber,
 						Branch:          req.Branch,
 						DB:              d.db,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -984,6 +984,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 					Providers:       quenchProviders,
 					VCS:             d.vcsForAnvil(req.Anvil),
 					LearnConfig:     d.quenchLearnConfig(req.Anvil),
+					Hooks:           anvilCfg.Hooks,
 				})
 			}
 			status := state.WorkerDone
@@ -1051,6 +1052,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 						TemperConfig:    d.resolveTemperConfig(anvilCfg),
 						DetectOptions:   burnishDetectOpts,
 						GoRaceDetection: d.resolveGoRaceDetection(anvilCfg),
+						Hooks:           anvilCfg.Hooks,
 					})
 				}
 			}
@@ -1072,6 +1074,7 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 					TemperConfig:    d.resolveTemperConfig(anvilCfg),
 					DetectOptions:   burnishDetectOpts,
 					GoRaceDetection: d.resolveGoRaceDetection(anvilCfg),
+					Hooks:           anvilCfg.Hooks,
 				})
 			}
 			status := state.WorkerDone

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,122 @@
+// Package hooks provides shared pipeline stage hook execution for pipeline,
+// burnish, and quench workers. Hooks are shell commands configured per-anvil
+// that run before or after specific pipeline stages (smith, temper, warden, etc.).
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/executil"
+)
+
+// HookTimeout is the maximum time a single hook command is allowed to run.
+const HookTimeout = 60 * time.Second
+
+// HookEnv holds the environment variables passed to pipeline hook commands.
+type HookEnv struct {
+	BeadID       string
+	WorktreePath string
+	Branch       string
+	AnvilName    string
+	AnvilPath    string
+	Stage        string
+	Iteration    int
+}
+
+// Environ returns the hook context as a slice of KEY=VALUE strings suitable
+// for appending to exec.Cmd.Env.
+func (h HookEnv) Environ() []string {
+	return []string{
+		"FORGE_BEAD_ID=" + h.BeadID,
+		"FORGE_WORKTREE_PATH=" + h.WorktreePath,
+		"FORGE_BRANCH=" + h.Branch,
+		"FORGE_ANVIL_NAME=" + h.AnvilName,
+		"FORGE_ANVIL_PATH=" + h.AnvilPath,
+		"FORGE_STAGE=" + h.Stage,
+		"FORGE_ITERATION=" + strconv.Itoa(h.Iteration),
+	}
+}
+
+// FilterForgeEnv returns a copy of environ with any existing FORGE_* variables
+// removed so that hook-specific values are not shadowed or duplicated.
+func FilterForgeEnv(environ []string) []string {
+	filtered := make([]string, 0, len(environ))
+	for _, e := range environ {
+		if !strings.HasPrefix(e, "FORGE_") {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// ShellArgs returns the platform-appropriate shell and flag for executing a
+// command string. On Windows it uses "cmd /c"; elsewhere "sh -c".
+func ShellArgs() (string, string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", "/c"
+	}
+	return "sh", "-c"
+}
+
+// RunHook executes a shell command with the given hook environment. It returns
+// nil when cmd is empty (no hook configured). The command is run via a
+// platform-appropriate shell (sh -c on Unix, cmd /c on Windows) with the
+// worktree as the working directory. A dedicated timeout of HookTimeout is
+// applied to prevent hooks from blocking the pipeline indefinitely.
+func RunHook(ctx context.Context, workerID, hookName, cmd string, env HookEnv) error {
+	if cmd == "" {
+		return nil
+	}
+	hookCtx, cancel := context.WithTimeout(ctx, HookTimeout)
+	defer cancel()
+
+	log.Printf("[hooks:%s] Running hook %s", workerID, hookName)
+	shell, flag := ShellArgs()
+	c := executil.HideWindow(exec.CommandContext(hookCtx, shell, flag, cmd))
+	c.Dir = env.WorktreePath
+	c.Env = append(FilterForgeEnv(os.Environ()), env.Environ()...)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		log.Printf("[hooks:%s] Hook %s failed: %v (output omitted)", workerID, hookName, err)
+		return fmt.Errorf("hook %s failed: %w", hookName, err)
+	}
+	log.Printf("[hooks:%s] Hook %s completed (%d bytes output)", workerID, hookName, len(out))
+	return nil
+}
+
+// HookCmd resolves the command string for a named hook from the anvil config.
+// Returns "" when hooks are not configured or the named hook is not set.
+func HookCmd(hooks *config.HooksConfig, name string) string {
+	if hooks == nil {
+		return ""
+	}
+	switch name {
+	case "before_schematic":
+		return hooks.BeforeSchematic
+	case "after_schematic":
+		return hooks.AfterSchematic
+	case "before_smith":
+		return hooks.BeforeSmith
+	case "after_smith":
+		return hooks.AfterSmith
+	case "before_temper":
+		return hooks.BeforeTemper
+	case "after_temper":
+		return hooks.AfterTemper
+	case "before_warden":
+		return hooks.BeforeWarden
+	case "after_warden":
+		return hooks.AfterWarden
+	default:
+		return ""
+	}
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,0 +1,131 @@
+package hooks
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func skipIfNoShell(t *testing.T) {
+	t.Helper()
+	shell, _ := ShellArgs()
+	if _, err := exec.LookPath(shell); err != nil {
+		t.Skipf("hooks require %s which is not available", shell)
+	}
+}
+
+// skipIfWindows skips tests that use POSIX shell syntax ($VAR, >>, redirection)
+// which is not compatible with cmd /c on Windows.
+func skipIfWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX shell syntax not supported by cmd /c on Windows")
+	}
+}
+
+func TestRunHook_Empty_NoOp(t *testing.T) {
+	err := RunHook(context.Background(), "w1", "before_smith", "", HookEnv{})
+	assert.NoError(t, err)
+}
+
+func TestRunHook_Success(t *testing.T) {
+	skipIfNoShell(t)
+	skipIfWindows(t) // uses POSIX $VAR expansion and > redirection
+	dir := t.TempDir()
+	env := HookEnv{
+		BeadID:       "bead-1",
+		WorktreePath: dir,
+		Branch:       "forge/bead-1",
+		AnvilName:    "myrepo",
+		AnvilPath:    "/tmp/myrepo",
+		Stage:        "smith",
+		Iteration:    2,
+	}
+	marker := filepath.Join(dir, "hook-ran.txt")
+	cmd := "echo $FORGE_BEAD_ID $FORGE_STAGE $FORGE_ITERATION > " + marker
+	err := RunHook(context.Background(), "w1", "before_smith", cmd, env)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(marker)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "bead-1 smith 2")
+}
+
+func TestRunHook_Failure(t *testing.T) {
+	skipIfNoShell(t)
+	env := HookEnv{WorktreePath: t.TempDir()}
+	err := RunHook(context.Background(), "w1", "before_temper", "exit 1", env)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hook before_temper failed")
+}
+
+func TestHookCmd_NilHooks(t *testing.T) {
+	assert.Equal(t, "", HookCmd(nil, "before_smith"))
+}
+
+func TestHookCmd_AllStages(t *testing.T) {
+	h := &config.HooksConfig{
+		BeforeSchematic: "a",
+		AfterSchematic:  "b",
+		BeforeSmith:     "c",
+		AfterSmith:      "d",
+		BeforeTemper:    "e",
+		AfterTemper:     "f",
+		BeforeWarden:    "g",
+		AfterWarden:     "h",
+	}
+	assert.Equal(t, "a", HookCmd(h, "before_schematic"))
+	assert.Equal(t, "b", HookCmd(h, "after_schematic"))
+	assert.Equal(t, "c", HookCmd(h, "before_smith"))
+	assert.Equal(t, "d", HookCmd(h, "after_smith"))
+	assert.Equal(t, "e", HookCmd(h, "before_temper"))
+	assert.Equal(t, "f", HookCmd(h, "after_temper"))
+	assert.Equal(t, "g", HookCmd(h, "before_warden"))
+	assert.Equal(t, "h", HookCmd(h, "after_warden"))
+	assert.Equal(t, "", HookCmd(h, "unknown"))
+}
+
+func TestHookEnv_Environ(t *testing.T) {
+	env := HookEnv{
+		BeadID:       "test-bead",
+		WorktreePath: "/tmp/wt",
+		Branch:       "forge/test-bead",
+		AnvilName:    "repo",
+		AnvilPath:    "/src/repo",
+		Stage:        "temper",
+		Iteration:    3,
+	}
+	vars := env.Environ()
+	assert.Contains(t, vars, "FORGE_BEAD_ID=test-bead")
+	assert.Contains(t, vars, "FORGE_WORKTREE_PATH=/tmp/wt")
+	assert.Contains(t, vars, "FORGE_BRANCH=forge/test-bead")
+	assert.Contains(t, vars, "FORGE_ANVIL_NAME=repo")
+	assert.Contains(t, vars, "FORGE_ANVIL_PATH=/src/repo")
+	assert.Contains(t, vars, "FORGE_STAGE=temper")
+	assert.Contains(t, vars, "FORGE_ITERATION=3")
+}
+
+func TestFilterForgeEnv(t *testing.T) {
+	input := []string{
+		"HOME=/home/user",
+		"FORGE_BEAD_ID=old-bead",
+		"PATH=/usr/bin",
+		"FORGE_STAGE=smith",
+		"GOPATH=/go",
+	}
+	got := FilterForgeEnv(input)
+	assert.Equal(t, []string{"HOME=/home/user", "PATH=/usr/bin", "GOPATH=/go"}, got)
+}
+
+func TestShellArgs(t *testing.T) {
+	shell, flag := ShellArgs()
+	assert.NotEmpty(t, shell)
+	assert.NotEmpty(t, flag)
+}

--- a/internal/pipeline/hooks.go
+++ b/internal/pipeline/hooks.go
@@ -2,120 +2,20 @@ package pipeline
 
 import (
 	"context"
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"runtime"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/Robin831/Forge/internal/config"
-	"github.com/Robin831/Forge/internal/executil"
+	"github.com/Robin831/Forge/internal/hooks"
 )
 
-// hookTimeout is the maximum time a single hook command is allowed to run.
-const hookTimeout = 60 * time.Second
+// hookEnv is a pipeline-local alias for hooks.HookEnv.
+type hookEnv = hooks.HookEnv
 
-// hookEnv holds the environment variables passed to pipeline hook commands.
-type hookEnv struct {
-	BeadID       string
-	WorktreePath string
-	Branch       string
-	AnvilName    string
-	AnvilPath    string
-	Stage        string
-	Iteration    int
-}
-
-// environ returns the hook context as a slice of KEY=VALUE strings suitable
-// for appending to exec.Cmd.Env.
-func (h hookEnv) environ() []string {
-	return []string{
-		"FORGE_BEAD_ID=" + h.BeadID,
-		"FORGE_WORKTREE_PATH=" + h.WorktreePath,
-		"FORGE_BRANCH=" + h.Branch,
-		"FORGE_ANVIL_NAME=" + h.AnvilName,
-		"FORGE_ANVIL_PATH=" + h.AnvilPath,
-		"FORGE_STAGE=" + h.Stage,
-		"FORGE_ITERATION=" + strconv.Itoa(h.Iteration),
-	}
-}
-
-// filterForgeEnv returns a copy of environ with any existing FORGE_* variables
-// removed so that hook-specific values are not shadowed or duplicated.
-func filterForgeEnv(environ []string) []string {
-	filtered := make([]string, 0, len(environ))
-	for _, e := range environ {
-		if !strings.HasPrefix(e, "FORGE_") {
-			filtered = append(filtered, e)
-		}
-	}
-	return filtered
-}
-
-// shellArgs returns the platform-appropriate shell and flag for executing a
-// command string. On Windows it uses "cmd /c"; elsewhere "sh -c".
-func shellArgs() (string, string) {
-	if runtime.GOOS == "windows" {
-		return "cmd", "/c"
-	}
-	return "sh", "-c"
-}
-
-// runHook executes a shell command with the given hook environment. It returns
-// nil when cmd is empty (no hook configured). The command is run via a
-// platform-appropriate shell (sh -c on Unix, cmd /c on Windows) with the
-// worktree as the working directory. A dedicated timeout of hookTimeout is
-// applied to prevent hooks from blocking the pipeline indefinitely.
+// runHook delegates to hooks.RunHook.
 func runHook(ctx context.Context, workerID, hookName, cmd string, env hookEnv) error {
-	if cmd == "" {
-		return nil
-	}
-	hookCtx, cancel := context.WithTimeout(ctx, hookTimeout)
-	defer cancel()
-
-	log.Printf("[pipeline:%s] Running hook %s", workerID, hookName)
-	shell, flag := shellArgs()
-	c := executil.HideWindow(exec.CommandContext(hookCtx, shell, flag, cmd))
-	c.Dir = env.WorktreePath
-	c.Env = append(filterForgeEnv(os.Environ()), env.environ()...)
-	out, err := c.CombinedOutput()
-	if err != nil {
-		// Log only the exit status, not the command or raw output, to avoid
-		// leaking secrets that may be embedded in hook commands or output.
-		log.Printf("[pipeline:%s] Hook %s failed: %v (output omitted)", workerID, hookName, err)
-		return fmt.Errorf("hook %s failed: %w", hookName, err)
-	}
-	log.Printf("[pipeline:%s] Hook %s completed (%d bytes output)", workerID, hookName, len(out))
-	return nil
+	return hooks.RunHook(ctx, workerID, hookName, cmd, env)
 }
 
-// hookCmd resolves the command string for a named hook from the anvil config.
-// Returns "" when hooks are not configured or the named hook is not set.
-func hookCmd(hooks *config.HooksConfig, name string) string {
-	if hooks == nil {
-		return ""
-	}
-	switch name {
-	case "before_schematic":
-		return hooks.BeforeSchematic
-	case "after_schematic":
-		return hooks.AfterSchematic
-	case "before_smith":
-		return hooks.BeforeSmith
-	case "after_smith":
-		return hooks.AfterSmith
-	case "before_temper":
-		return hooks.BeforeTemper
-	case "after_temper":
-		return hooks.AfterTemper
-	case "before_warden":
-		return hooks.BeforeWarden
-	case "after_warden":
-		return hooks.AfterWarden
-	default:
-		return ""
-	}
+// hookCmd delegates to hooks.HookCmd.
+func hookCmd(hc *config.HooksConfig, name string) string {
+	return hooks.HookCmd(hc, name)
 }

--- a/internal/pipeline/hooks_test.go
+++ b/internal/pipeline/hooks_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/hooks"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/state"
@@ -20,119 +21,17 @@ import (
 
 func skipIfNoShell(t *testing.T) {
 	t.Helper()
-	shell, _ := shellArgs()
+	shell, _ := hooks.ShellArgs()
 	if _, err := exec.LookPath(shell); err != nil {
 		t.Skipf("hooks require %s which is not available", shell)
 	}
 }
 
-// skipIfWindows skips tests that use POSIX shell syntax ($VAR, >>, redirection)
-// which is not compatible with cmd /c on Windows.
 func skipIfWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses POSIX shell syntax not supported by cmd /c on Windows")
 	}
-}
-
-func TestRunHook_Empty_NoOp(t *testing.T) {
-	err := runHook(context.Background(), "w1", "before_smith", "", hookEnv{})
-	assert.NoError(t, err)
-}
-
-func TestRunHook_Success(t *testing.T) {
-	skipIfNoShell(t)
-	skipIfWindows(t) // uses POSIX $VAR expansion and > redirection
-	dir := t.TempDir()
-	env := hookEnv{
-		BeadID:       "bead-1",
-		WorktreePath: dir,
-		Branch:       "forge/bead-1",
-		AnvilName:    "myrepo",
-		AnvilPath:    "/tmp/myrepo",
-		Stage:        "smith",
-		Iteration:    2,
-	}
-	marker := filepath.Join(dir, "hook-ran.txt")
-	cmd := "echo $FORGE_BEAD_ID $FORGE_STAGE $FORGE_ITERATION > " + marker
-	err := runHook(context.Background(), "w1", "before_smith", cmd, env)
-	require.NoError(t, err)
-
-	data, err := os.ReadFile(marker)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "bead-1 smith 2")
-}
-
-func TestRunHook_Failure(t *testing.T) {
-	skipIfNoShell(t)
-	env := hookEnv{WorktreePath: t.TempDir()}
-	err := runHook(context.Background(), "w1", "before_temper", "exit 1", env)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "hook before_temper failed")
-}
-
-func TestHookCmd_NilHooks(t *testing.T) {
-	assert.Equal(t, "", hookCmd(nil, "before_smith"))
-}
-
-func TestHookCmd_AllStages(t *testing.T) {
-	h := &config.HooksConfig{
-		BeforeSchematic: "a",
-		AfterSchematic:  "b",
-		BeforeSmith:     "c",
-		AfterSmith:      "d",
-		BeforeTemper:    "e",
-		AfterTemper:     "f",
-		BeforeWarden:    "g",
-		AfterWarden:     "h",
-	}
-	assert.Equal(t, "a", hookCmd(h, "before_schematic"))
-	assert.Equal(t, "b", hookCmd(h, "after_schematic"))
-	assert.Equal(t, "c", hookCmd(h, "before_smith"))
-	assert.Equal(t, "d", hookCmd(h, "after_smith"))
-	assert.Equal(t, "e", hookCmd(h, "before_temper"))
-	assert.Equal(t, "f", hookCmd(h, "after_temper"))
-	assert.Equal(t, "g", hookCmd(h, "before_warden"))
-	assert.Equal(t, "h", hookCmd(h, "after_warden"))
-	assert.Equal(t, "", hookCmd(h, "unknown"))
-}
-
-func TestHookEnv_Environ(t *testing.T) {
-	env := hookEnv{
-		BeadID:       "test-bead",
-		WorktreePath: "/tmp/wt",
-		Branch:       "forge/test-bead",
-		AnvilName:    "repo",
-		AnvilPath:    "/src/repo",
-		Stage:        "temper",
-		Iteration:    3,
-	}
-	vars := env.environ()
-	assert.Contains(t, vars, "FORGE_BEAD_ID=test-bead")
-	assert.Contains(t, vars, "FORGE_WORKTREE_PATH=/tmp/wt")
-	assert.Contains(t, vars, "FORGE_BRANCH=forge/test-bead")
-	assert.Contains(t, vars, "FORGE_ANVIL_NAME=repo")
-	assert.Contains(t, vars, "FORGE_ANVIL_PATH=/src/repo")
-	assert.Contains(t, vars, "FORGE_STAGE=temper")
-	assert.Contains(t, vars, "FORGE_ITERATION=3")
-}
-
-func TestFilterForgeEnv(t *testing.T) {
-	input := []string{
-		"HOME=/home/user",
-		"FORGE_BEAD_ID=old-bead",
-		"PATH=/usr/bin",
-		"FORGE_STAGE=smith",
-		"GOPATH=/go",
-	}
-	got := filterForgeEnv(input)
-	assert.Equal(t, []string{"HOME=/home/user", "PATH=/usr/bin", "GOPATH=/go"}, got)
-}
-
-func TestShellArgs(t *testing.T) {
-	shell, flag := shellArgs()
-	assert.NotEmpty(t, shell)
-	assert.NotEmpty(t, flag)
 }
 
 // TestBeforeSmithHook_Abort verifies that a failing before_smith hook aborts

--- a/internal/quench/quench.go
+++ b/internal/quench/quench.go
@@ -16,8 +16,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/cost"
 	"github.com/Robin831/Forge/internal/executil"
+	"github.com/Robin831/Forge/internal/hooks"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/state"
@@ -71,6 +73,9 @@ type FixParams struct {
 	// true, learned rules are inserted into the pending_warden_rules table
 	// instead of being written directly to the rules file.
 	LearnConfig *warden.LearnConfig
+	// Hooks is the per-anvil hook configuration. When set, before_temper and
+	// after_temper hooks fire around every temper invocation.
+	Hooks *config.HooksConfig
 }
 
 // FixResult captures the outcome of a CI fix attempt.
@@ -251,6 +256,9 @@ func buildBatchCIPrompt(p BatchFixParams) string {
 	return b.String()
 }
 
+// hookRunFn is the function used to run hooks. Package-level variable for test stubbing.
+var hookRunFn = hooks.RunHook
+
 // Fix attempts to resolve CI failures on a PR branch.
 func Fix(ctx context.Context, p FixParams) *FixResult {
 	start := time.Now()
@@ -294,7 +302,24 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			temperCfg = &detected
 		}
 
+		hEnv := hooks.HookEnv{
+			BeadID:       p.BeadID,
+			WorktreePath: p.WorktreePath,
+			Branch:       p.Branch,
+			AnvilName:    p.AnvilName,
+			AnvilPath:    p.AnvilPath,
+			Stage:        "temper",
+			Iteration:    attempt,
+		}
+		if err := hookRunFn(ctx, p.WorkerID, "before_temper", hooks.HookCmd(p.Hooks, "before_temper"), hEnv); err != nil {
+			result.Error = fmt.Errorf("before_temper hook: %w", err)
+			result.Duration = time.Since(start)
+			return result
+		}
 		temperResult := temper.Run(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
+		if err := hookRunFn(ctx, p.WorkerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), hEnv); err != nil {
+			log.Printf("[quench] PR #%d: after_temper hook failed (non-fatal): %v", p.PRNumber, err)
+		}
 		result.LastTemperResult = temperResult
 
 		if temperResult.Passed {
@@ -409,7 +434,24 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 		}
 
 		// Step 6: Verify the fix.
+		verifyEnv := hooks.HookEnv{
+			BeadID:       p.BeadID,
+			WorktreePath: p.WorktreePath,
+			Branch:       p.Branch,
+			AnvilName:    p.AnvilName,
+			AnvilPath:    p.AnvilPath,
+			Stage:        "temper",
+			Iteration:    attempt,
+		}
+		if err := hookRunFn(ctx, p.WorkerID, "before_temper", hooks.HookCmd(p.Hooks, "before_temper"), verifyEnv); err != nil {
+			result.Error = fmt.Errorf("before_temper hook: %w", err)
+			result.Duration = time.Since(start)
+			return result
+		}
 		verifyResult := temper.Run(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
+		if err := hookRunFn(ctx, p.WorkerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), verifyEnv); err != nil {
+			log.Printf("[quench] PR #%d: after_temper hook failed (non-fatal): %v", p.PRNumber, err)
+		}
 		result.LastTemperResult = verifyResult
 
 		if verifyResult.Passed {

--- a/internal/quench/quench.go
+++ b/internal/quench/quench.go
@@ -259,6 +259,16 @@ func buildBatchCIPrompt(p BatchFixParams) string {
 // hookRunFn is the function used to run hooks. Package-level variable for test stubbing.
 var hookRunFn = hooks.RunHook
 
+// temperRunFn is the function used to run temper checks. Package-level variable for test stubbing.
+var temperRunFn = func(ctx context.Context, worktreePath string, cfg temper.Config, db *state.DB, beadID, anvil string) *temper.Result {
+	return temper.Run(ctx, worktreePath, cfg, db, beadID, anvil)
+}
+
+// smithSpawnFn is the function used to spawn Smith. Package-level variable for test stubbing.
+var smithSpawnFn = func(ctx context.Context, worktreePath, prompt, logDir string, pv provider.Provider, extraFlags []string) (*smith.Process, error) {
+	return smith.SpawnWithProvider(ctx, worktreePath, prompt, logDir, pv, extraFlags)
+}
+
 // Fix attempts to resolve CI failures on a PR branch.
 func Fix(ctx context.Context, p FixParams) *FixResult {
 	start := time.Now()
@@ -316,7 +326,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			result.Duration = time.Since(start)
 			return result
 		}
-		temperResult := temper.Run(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
+		temperResult := temperRunFn(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
 		if err := hookRunFn(ctx, p.WorkerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), hEnv); err != nil {
 			log.Printf("[quench] PR #%d: after_temper hook failed (non-fatal): %v", p.PRNumber, err)
 		}
@@ -377,7 +387,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 				log.Printf("[quench] PR #%d: Provider %s rate limited, retrying with %s",
 					p.PRNumber, providers[pi-1].Label(), pv.Label())
 			}
-			process, err := smith.SpawnWithProvider(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
+			process, err := smithSpawnFn(ctx, p.WorktreePath, prompt, logDir, pv, p.ExtraFlags)
 			if err != nil {
 				result.Error = fmt.Errorf("spawning smith (%s) for CI fix: %w", pv.Kind, err)
 				result.Duration = time.Since(start)
@@ -448,7 +458,7 @@ func Fix(ctx context.Context, p FixParams) *FixResult {
 			result.Duration = time.Since(start)
 			return result
 		}
-		verifyResult := temper.Run(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
+		verifyResult := temperRunFn(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
 		if err := hookRunFn(ctx, p.WorkerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), verifyEnv); err != nil {
 			log.Printf("[quench] PR #%d: after_temper hook failed (non-fatal): %v", p.PRNumber, err)
 		}

--- a/internal/quench/quench_test.go
+++ b/internal/quench/quench_test.go
@@ -3,12 +3,16 @@ package quench
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/hooks"
 	"github.com/Robin831/Forge/internal/provider"
+	"github.com/Robin831/Forge/internal/smith"
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/Robin831/Forge/internal/temper"
 	"github.com/Robin831/Forge/internal/vcs"
 )
 
@@ -255,5 +259,235 @@ func TestHookRunFn_NilHooks_NoOp(t *testing.T) {
 	_ = hookRunFn(context.Background(), "w1", "before_temper", cmd, env)
 	if called {
 		t.Error("hook should not have been called with empty cmd")
+	}
+}
+
+// --- Fix-level hook ordering / abort tests ---
+
+// fakeVCS is a minimal vcs.Provider stub for quench Fix tests.
+type fakeVCS struct {
+	failingChecks []vcs.CICheck
+}
+
+func (f *fakeVCS) CreatePR(_ context.Context, _ vcs.CreateParams) (*vcs.PR, error) {
+	return nil, nil
+}
+func (f *fakeVCS) MergePR(_ context.Context, _ string, _ int, _ string) error { return nil }
+func (f *fakeVCS) CheckStatus(_ context.Context, _ string, _ int) (*vcs.PRStatus, error) {
+	return nil, nil
+}
+func (f *fakeVCS) CheckStatusLight(_ context.Context, _ string, _ int) (*vcs.PRStatus, error) {
+	return nil, nil
+}
+func (f *fakeVCS) ListOpenPRs(_ context.Context, _ string) ([]vcs.OpenPR, error) {
+	return nil, nil
+}
+func (f *fakeVCS) GetRepoOwnerAndName(_ context.Context, _ string) (string, string, error) {
+	return "owner", "repo", nil
+}
+func (f *fakeVCS) FetchUnresolvedThreadCount(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
+func (f *fakeVCS) FetchPendingReviewRequests(_ context.Context, _ string, _ int) ([]vcs.ReviewRequest, error) {
+	return nil, nil
+}
+func (f *fakeVCS) FetchPRChecks(_ context.Context, _ string, _ int) (string, []vcs.CICheck, error) {
+	return "", f.failingChecks, nil
+}
+func (f *fakeVCS) FetchCILogs(_ context.Context, _ string, _ []vcs.CICheck) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeVCS) FetchReviewComments(_ context.Context, _ string, _ int) ([]vcs.ReviewComment, error) {
+	return nil, nil
+}
+func (f *fakeVCS) ResolveThread(_ context.Context, _ string, _ string) error { return nil }
+func (f *fakeVCS) Platform() vcs.Platform                                     { return vcs.GitHub }
+
+// openTestDB opens a temporary SQLite state database for use in tests.
+func openTestDB(t *testing.T) *state.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := state.Open(dbPath)
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// quenchTestHarness saves and restores the package-level function stubs.
+type quenchTestHarness struct {
+	origHookRun    func(ctx context.Context, workerID, hookName, cmd string, env hooks.HookEnv) error
+	origTemperRun  func(ctx context.Context, worktreePath string, cfg temper.Config, db *state.DB, beadID, anvil string) *temper.Result
+	origSmithSpawn func(ctx context.Context, worktreePath, prompt, logDir string, pv provider.Provider, extraFlags []string) (*smith.Process, error)
+}
+
+func newQuenchTestHarness() *quenchTestHarness {
+	return &quenchTestHarness{
+		origHookRun:    hookRunFn,
+		origTemperRun:  temperRunFn,
+		origSmithSpawn: smithSpawnFn,
+	}
+}
+
+func (h *quenchTestHarness) restore() {
+	hookRunFn = h.origHookRun
+	temperRunFn = h.origTemperRun
+	smithSpawnFn = h.origSmithSpawn
+}
+
+// TestFix_BeforeTemper_AbortsOnError verifies that a before_temper hook failure
+// prevents temper from running and causes Fix to return an error.
+func TestFix_BeforeTemper_AbortsOnError(t *testing.T) {
+	h := newQuenchTestHarness()
+	defer h.restore()
+
+	temperCalled := false
+	temperRunFn = func(_ context.Context, _ string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		temperCalled = true
+		return &temper.Result{Passed: true}
+	}
+
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "before_temper" && cmd != "" {
+			return fmt.Errorf("before_temper hook failed")
+		}
+		return nil
+	}
+
+	cfg := temper.Config{}
+	result := Fix(context.Background(), FixParams{
+		PRNumber:     42,
+		Branch:       "forge/test",
+		BeadID:       "test-bead",
+		WorktreePath: t.TempDir(),
+		VCS:          &fakeVCS{},
+		Providers:    []provider.Provider{{Kind: provider.Claude}},
+		TemperConfig: &cfg,
+		Hooks:        &config.HooksConfig{BeforeTemper: "exit 1"},
+	})
+
+	if result.Fixed {
+		t.Error("Fix should not be Fixed=true when before_temper hook aborts")
+	}
+	if result.Error == nil {
+		t.Fatal("Fix should return an error when before_temper hook fails")
+	}
+	if !strings.Contains(result.Error.Error(), "before_temper") {
+		t.Errorf("error should mention before_temper, got: %v", result.Error)
+	}
+	if temperCalled {
+		t.Error("temperRunFn should not be called when before_temper hook aborts")
+	}
+}
+
+// TestFix_AfterTemper_NonFatal_ReproRun verifies that an after_temper hook
+// failure during the repro temper run is non-fatal: Fix continues and returns
+// Fixed=true when temper passes and no CI checks are failing.
+func TestFix_AfterTemper_NonFatal_ReproRun(t *testing.T) {
+	h := newQuenchTestHarness()
+	defer h.restore()
+
+	temperRunFn = func(_ context.Context, _ string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		return &temper.Result{Passed: true}
+	}
+
+	afterTemperCalled := false
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "after_temper" && cmd != "" {
+			afterTemperCalled = true
+			return fmt.Errorf("after_temper hook failed")
+		}
+		return nil
+	}
+
+	cfg := temper.Config{}
+	// VCS returns no failing checks — so temper passing means we're fixed.
+	result := Fix(context.Background(), FixParams{
+		PRNumber:     42,
+		Branch:       "forge/test",
+		BeadID:       "test-bead",
+		WorktreePath: t.TempDir(),
+		VCS:          &fakeVCS{},
+		Providers:    []provider.Provider{{Kind: provider.Claude}},
+		TemperConfig: &cfg,
+		Hooks:        &config.HooksConfig{AfterTemper: "exit 1"},
+	})
+
+	if !afterTemperCalled {
+		t.Error("after_temper hook should have been called")
+	}
+	if !result.Fixed {
+		t.Errorf("Fix should return Fixed=true even when after_temper hook fails (non-fatal); error: %v", result.Error)
+	}
+	if result.Error != nil {
+		t.Errorf("Fix should not return an error when after_temper hook fails (non-fatal), got: %v", result.Error)
+	}
+}
+
+// TestFix_AfterTemper_NonFatal_VerifyRun verifies that an after_temper hook
+// failure during the verify temper run (after Smith) is also non-fatal: Fix
+// continues and returns Fixed=true when the verify temper passes.
+func TestFix_AfterTemper_NonFatal_VerifyRun(t *testing.T) {
+	h := newQuenchTestHarness()
+	defer h.restore()
+
+	// First temper call (repro) fails so we proceed to smith.
+	// Second temper call (verify) passes.
+	callCount := 0
+	temperRunFn = func(_ context.Context, _ string, _ temper.Config, _ *state.DB, _, _ string) *temper.Result {
+		callCount++
+		if callCount == 1 {
+			return &temper.Result{Passed: false, FailedStep: "build"}
+		}
+		return &temper.Result{Passed: true}
+	}
+
+	// Smith succeeds.
+	smithSpawnFn = func(_ context.Context, _, _, _ string, _ provider.Provider, _ []string) (*smith.Process, error) {
+		return smith.NewProcessForTest(&smith.Result{
+			ExitCode:      0,
+			ResultSubtype: "success",
+			IsError:       false,
+		}), nil
+	}
+
+	afterTemperCallCount := 0
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "after_temper" && cmd != "" {
+			afterTemperCallCount++
+			return fmt.Errorf("after_temper hook failed")
+		}
+		return nil
+	}
+
+	cfg := temper.Config{}
+	db := openTestDB(t)
+	// VCS returns one failing check so Fix doesn't short-circuit on the repro pass.
+	result := Fix(context.Background(), FixParams{
+		PRNumber:     42,
+		Branch:       "forge/test",
+		BeadID:       "test-bead",
+		WorktreePath: t.TempDir(),
+		VCS: &fakeVCS{
+			failingChecks: []vcs.CICheck{{Name: "build", Status: "failure"}},
+		},
+		Providers:    []provider.Provider{{Kind: provider.Claude}},
+		TemperConfig: &cfg,
+		Hooks:        &config.HooksConfig{AfterTemper: "exit 1"},
+		DB:           db,
+	})
+
+	if callCount != 2 {
+		t.Errorf("expected 2 temperRunFn calls (repro + verify), got %d", callCount)
+	}
+	if afterTemperCallCount < 1 {
+		t.Error("after_temper hook should have been called at least once (on the verify run)")
+	}
+	if !result.Fixed {
+		t.Errorf("Fix should return Fixed=true even when after_temper hook fails (non-fatal); error: %v", result.Error)
+	}
+	if result.Error != nil {
+		t.Errorf("Fix should not return an error when after_temper hook fails (non-fatal), got: %v", result.Error)
 	}
 }

--- a/internal/quench/quench_test.go
+++ b/internal/quench/quench_test.go
@@ -2,9 +2,12 @@ package quench
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/hooks"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/vcs"
 )
@@ -143,5 +146,114 @@ func TestTruncateOutput(t *testing.T) {
 	}
 	if len(got) > 50+len("... (truncated)\n") {
 		t.Errorf("truncated output too long: %d chars", len(got))
+	}
+}
+
+// --- Hook tests ---
+
+func TestHookRunFn_BeforeTemperHook_Invoked(t *testing.T) {
+	origHookRun := hookRunFn
+	defer func() { hookRunFn = origHookRun }()
+
+	var hooksCalled []string
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if cmd != "" {
+			hooksCalled = append(hooksCalled, hookName)
+		}
+		return nil
+	}
+
+	// HookCmd should resolve the configured hook.
+	hc := &config.HooksConfig{BeforeTemper: "echo setup"}
+	cmd := hooks.HookCmd(hc, "before_temper")
+	if cmd != "echo setup" {
+		t.Errorf("expected 'echo setup', got %q", cmd)
+	}
+
+	// Simulate what quench does: call hookRunFn.
+	env := hooks.HookEnv{
+		BeadID:    "test-bead",
+		Stage:     "temper",
+		Iteration: 1,
+	}
+	err := hookRunFn(context.Background(), "w1", "before_temper", cmd, env)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(hooksCalled) != 1 || hooksCalled[0] != "before_temper" {
+		t.Errorf("expected [before_temper], got %v", hooksCalled)
+	}
+}
+
+func TestHookRunFn_BeforeTemperHook_Fails_AbortsQuench(t *testing.T) {
+	origHookRun := hookRunFn
+	defer func() { hookRunFn = origHookRun }()
+
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "before_temper" && cmd != "" {
+			return fmt.Errorf("hook before_temper failed: exit status 1")
+		}
+		return nil
+	}
+
+	hc := &config.HooksConfig{BeforeTemper: "exit 1"}
+	cmd := hooks.HookCmd(hc, "before_temper")
+
+	env := hooks.HookEnv{BeadID: "test-bead", Stage: "temper", Iteration: 1}
+	err := hookRunFn(context.Background(), "w1", "before_temper", cmd, env)
+	if err == nil {
+		t.Fatal("expected error from before_temper hook")
+	}
+	if !strings.Contains(err.Error(), "before_temper") {
+		t.Errorf("error should mention before_temper, got: %v", err)
+	}
+}
+
+func TestHookRunFn_AfterTemperHook_Fails_NonFatal(t *testing.T) {
+	origHookRun := hookRunFn
+	defer func() { hookRunFn = origHookRun }()
+
+	hookRunFn = func(_ context.Context, _, hookName, cmd string, _ hooks.HookEnv) error {
+		if hookName == "after_temper" && cmd != "" {
+			return fmt.Errorf("after_temper hook failed")
+		}
+		return nil
+	}
+
+	hc := &config.HooksConfig{AfterTemper: "exit 1"}
+	cmd := hooks.HookCmd(hc, "after_temper")
+
+	env := hooks.HookEnv{BeadID: "test-bead", Stage: "temper", Iteration: 1}
+	err := hookRunFn(context.Background(), "w1", "after_temper", cmd, env)
+	// The error is returned by hookRunFn, but quench only logs it.
+	// Verify the hook does return an error (quench's code path logs it and continues).
+	if err == nil {
+		t.Fatal("expected error from after_temper hook")
+	}
+}
+
+func TestHookRunFn_NilHooks_NoOp(t *testing.T) {
+	origHookRun := hookRunFn
+	defer func() { hookRunFn = origHookRun }()
+
+	called := false
+	hookRunFn = func(_ context.Context, _, _, cmd string, _ hooks.HookEnv) error {
+		if cmd != "" {
+			called = true
+		}
+		return nil
+	}
+
+	// HookCmd with nil hooks returns "".
+	cmd := hooks.HookCmd(nil, "before_temper")
+	if cmd != "" {
+		t.Errorf("expected empty cmd for nil hooks, got %q", cmd)
+	}
+
+	// hookRunFn with empty cmd is a no-op (the real RunHook returns nil immediately).
+	env := hooks.HookEnv{BeadID: "test-bead", Stage: "temper"}
+	_ = hookRunFn(context.Background(), "w1", "before_temper", cmd, env)
+	if called {
+		t.Error("hook should not have been called with empty cmd")
 	}
 }


### PR DESCRIPTION
## Changes

- **Temper hooks fire in burnish and quench** - Pipeline stage hooks (`before_temper`, `after_temper`) now fire during burnish (review-fix) and quench (CI-fix) temper runs, not just during the initial pipeline. Setup commands like `npm ci` now apply uniformly across all temper invocations. (Forge-w8rb)

## Original Issue (bug): Temper hooks (before_temper / after_temper) don't fire in burnish and quench

## Problem

Pipeline stage hooks (`hooks.before_temper`, `hooks.after_temper`) defined in an anvil's `forge.yaml` only fire during the initial `pipeline.Run` path. They are **not** invoked during burnish (review fix) or quench (CI fix) temper runs, even though those workers now call `temper.Run` on the same worktree.

**Concrete symptom:** a user on a Node anvil sets `hooks.before_temper: cd web && npm ci` so the initial pipeline run has `node_modules` available when temper runs. That works for the initial PR creation. Then Copilot reviews the PR → Forge dispatches burnish → burnish calls `temper.Run` → but the `before_temper` hook is never invoked, and temper fails (or spuriously warns) because deps aren't fresh after Smith touched `package.json`. Same problem for quench on a CI failure.

This gap became visible when Forge-syrn landed (burnish gate-push-on-temper). Before that, burnish didn't run temper at all, so the missing hooks were invisible. Now that burnish does run temper, users discover their hooks don't apply there.

## Current state

- `internal/pipeline/hooks.go:67-93` — `runHook` executes a command via `sh -c` / `cmd /c`, 60s timeout, receives `FORGE_*` env vars. Used only from `internal/pipeline/pipeline.go:1207` (before_temper) and `:1232` (after_temper).
- `internal/pipeline/hooks.go:95-121` — `hookCmd` resolves the command string for a named hook from `AnvilConfig.Hooks`. Takes `*HooksConfig` and a hook name.
- `internal/burnish/burnish.go` — calls `temper.Run` (after Forge-syrn lands) but doesn't import anything from `internal/pipeline`. No hook invocation.
- `internal/quench/quench.go:297,412` — calls `temper.Run` twice (pre-Smith for repro, post-Smith for verify). No hook invocation.

## Fix

### 1. Extract hooks to a shared location

`runHook` and `hookCmd` currently live in `internal/pipeline/hooks.go` and are private to the pipeline package. Burnish and quench cannot import them without introducing an unwanted pipeline dependency. Two options:

- **(a)** Move them to a new `internal/hooks` package. Update `pipeline.go` imports. Burnish and quench import `internal/hooks`.
- **(b)** Leave them in `internal/pipeline/hooks.go` and expose `RunHook` / `HookCmd` (capitalized) so other packages can call them. Simpler but creates a non-obvious dependency edge from burnish/quench to pipeline.

**Prefer (a)** — the cleaner package boundary. It's a pure move + rename of the package (no logic change).

### 2. Thread `AnvilConfig.Hooks` through to burnish.Fix / burnish.BatchFix / quench.Fix

The daemon dispatch site at `internal/daemon/daemon.go:971` (quench) and `:1054` (burnish.Fix) and `:1038` (burnish.BatchFix) already has `anvilCfg` in scope — just add a `Hooks *config.HooksConfig` field to `FixParams` / `BatchFixParams` (both burnish and quench) and populate it with `anvilCfg.Hooks`.

### 3. Wrap `temper.Run` calls in burnish and quench with the hook pattern

Mirror what `pipeline.go:1204-1235` does. For burnish, the new temper gate in `burnish.Fix` (from Forge-syrn):

```go
// inside the attempt loop, after Smith exits cleanly
hEnv := hookEnv{
    BeadID:       p.BeadID,
    WorktreePath: p.WorktreePath,
    Branch:       p.Branch,
    AnvilName:    p.AnvilName,
    AnvilPath:    p.AnvilPath,
    Stage:        "temper",
    Iteration:    attempt,
}
if err := hooks.RunHook(ctx, workerID, "before_temper", hooks.HookCmd(p.Hooks, "before_temper"), hEnv); err != nil {
    result.Error = fmt.Errorf("before_temper hook: %w", err)
    return result
}
verifyResult := temper.Run(ctx, p.WorktreePath, *temperCfg, p.DB, p.BeadID, p.AnvilName)
if err := hooks.RunHook(ctx, workerID, "after_temper", hooks.HookCmd(p.Hooks, "after_temper"), hEnv); err != nil {
    log.Printf("[burnish] after_temper hook failed (non-fatal): %v", err)
}
// ... continue with verifyResult.Passed check
```

Same pattern for quench's two temper calls at `quench.go:297` and `:412`. Note for quench: the pre-Smith call is conceptually a "reproduction" run, not a verification run. Still wrap it with before/after so the hook is idempotent and users don't have to mentally track which temper run gets hooked.

### 4. `before_temper` failure semantics

Pipeline aborts the stage on non-zero `before_temper` exit. Match that in burnish and quench: a `before_temper` failure fails the whole burnish/quench cycle with a clear error. `after_temper` is best-effort and logged-only (mirrors pipeline at `pipeline.go:1232-1235`).

### 5. New event types (optional, nice-to-have)

Currently hook failures are logged but not surfaced in the Hearth events panel. Consider adding:

- `EventHookFailed` (`hook_failed`) with payload `{stage, worker, error}`
- Log `EventBurnishFailed` / `EventQuenchFailed` with the wrapped hook error when a before hook blocks the stage

Not strictly required for the fix but makes debugging much easier.

## Tests

- `internal/hooks/hooks_test.go` (moved from `internal/pipeline/hooks_test.go`) — existing tests should still pass after the package move. Pure rename + import update.
- `internal/burnish/burnish_test.go` — new cases:
  - `TestFix_BeforeTemperHook_Invoked`: supply a `Hooks.BeforeTemper` command (via stubbed `hooks.RunHook`), verify it's called with expected env vars before `temper.Run`.
  - `TestFix_AfterTemperHook_Invoked`: same for after_temper.
  - `TestFix_BeforeTemperHook_Fails_AbortsBurnish`: stub before_temper to return an error, assert burnish returns with `result.Error` wrapping the hook error and does NOT call `temper.Run` or push.
  - `TestFix_AfterTemperHook_Fails_Logged_Only`: stub after_temper to error, assert burnish still proceeds and pushes on successful verify.
- `internal/quench/quench_test.go` — mirror the above for quench's two temper calls.

## Docs

Update `docs/configuration.md`:

- **Pipeline Hooks section** (`docs/configuration.md:169-216`): remove or reword any implication that hooks only fire during the initial pipeline. Add a sentence near line 199 (Hook behavior): "Hooks fire before/after every temper invocation — initial pipeline, burnish review-fix, and quench CI-fix — so setup commands like `npm ci` or container startup work uniformly across all temper runs."
- **Full Example section** (`docs/configuration.md:11-112`): the existing `before_temper: './scripts/pre-temper.sh'` example at line 27 already demonstrates the hook. Add a short comment next to it: `# runs for every temper invocation (pipeline, burnish, quench)`.
- **New subsection under Pipeline Hooks** — a Node.js example showing a real before_temper that installs deps and a realistic workflow:

  ```yaml
  anvils:
    my-node-app:
      path: /home/user/source/my-node-app
      hooks:
        before_temper: 'cd web && npm ci'
  ```

This is the main motivating use case for this bead and the user should be able to copy-paste from the docs.

## Out of scope

- Anything about what temper **runs** (that's Forge-bead-2 and Forge-bead-3 in this chain). This bead is purely about **when hooks fire**.
- Sharing hook config between anvils, or global hooks. Keep it per-anvil, matching the current model.

## Files touched

- `internal/pipeline/hooks.go` → moved to `internal/hooks/hooks.go` (rename + package change)
- `internal/pipeline/hooks_test.go` → moved to `internal/hooks/hooks_test.go`
- `internal/pipeline/pipeline.go` — update imports, call sites
- `internal/burnish/burnish.go` — add `Hooks` field to `FixParams`/`BatchFixParams`, wrap temper call
- `internal/burnish/burnish_test.go` — new test cases
- `internal/quench/quench.go` — add `Hooks` field to `FixParams`, wrap both temper calls
- `internal/quench/quench_test.go` — new test cases
- `internal/daemon/daemon.go` — pass `anvilCfg.Hooks` to burnish and quench dispatch sites
- `docs/configuration.md` — hooks section + Full Example comment + new Node.js example
- `changelog.d/Forge-<id>.md` — Fixed category fragment

## Acceptance criteria

- `grep -rn 'RunHook\|runHook' internal/burnish internal/quench` returns at least one match each.
- A burnish cycle with `hooks.before_temper: 'echo HOOK_RAN'` set logs "HOOK_RAN" in the worker log exactly once per attempt before the temper step.
- A `before_temper` hook that exits non-zero during burnish causes `result.Error` to reference the hook and NO push happens.
- `docs/configuration.md` Pipeline Hooks section explicitly states hooks fire for burnish and quench temper runs, not just initial pipeline.

---
Bead: Forge-w8rb | Branch: forge/Forge-w8rb
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)