### PR TITLE
Allow temper.lint to be configured as a required (non-optional) step (Forge-lsj4)

### DIFF
--- a/changelog.d/Forge-lsj4.md
+++ b/changelog.d/Forge-lsj4.md
@@ -1,0 +1,2 @@
+category: Added
+- **Configurable lint step severity** - Added `temper.lint_required` option to make the lint step fail the temper run instead of only warning. Default preserves existing advisory-only behavior. (Forge-lsj4)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,7 +255,8 @@ By default, Temper auto-detects the project type (Go, .NET, Node) and runs appro
 |-------|------|---------|-------------|
 | `temper.build` | string | | Custom build command (e.g. `"make build"`, `"cargo build"`). Replaces the auto-detected build step. |
 | `temper.test` | string | | Custom test command (e.g. `"make test"`, `"pytest"`). Replaces the auto-detected test step. |
-| `temper.lint` | string | | Custom lint command (e.g. `"make lint"`, `"ruff check ."`). Runs as an optional step (failure warns but doesn't block). |
+| `temper.lint` | string | | Custom lint command (e.g. `"make lint"`, `"ruff check ."`). Runs as an optional step by default (failure warns but doesn't block). Set `lint_required: true` to make lint failures fail the temper run. |
+| `temper.lint_required` | bool | `false` | When `true`, failures in `temper.lint` fail the temper run instead of warning. Default matches legacy behavior where lint is an advisory-only step. |
 
 When any `temper` field is set, **all** auto-detected steps are replaced — only the explicitly configured commands run. Omit a field to skip that step entirely.
 
@@ -283,6 +284,13 @@ anvils:
       build: "make build"
       test: "make test"
       lint: "make lint"
+  strict-node-app:
+    path: /home/user/source/strict-node-app
+    temper:
+      build: "npm run build"
+      test: "npm run test:run"
+      lint: "npm run lint"
+      lint_required: true   # make lint failures fail the temper run, matching CI
 ```
 
 ## Settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,7 +258,7 @@ By default, Temper auto-detects the project type (Go, .NET, Node) and runs appro
 | `temper.lint` | string | | Custom lint command (e.g. `"make lint"`, `"ruff check ."`). Runs as an optional step by default (failure warns but doesn't block). Set `lint_required: true` to make lint failures fail the temper run. |
 | `temper.lint_required` | bool | `false` | When `true`, failures in `temper.lint` fail the temper run instead of warning. Default matches legacy behavior where lint is an advisory-only step. |
 
-When any `temper` field is set, **all** auto-detected steps are replaced — only the explicitly configured commands run. Omit a field to skip that step entirely.
+When any `temper.build`, `temper.test`, or `temper.lint` command is set, **all** auto-detected steps are replaced — only the explicitly configured commands run. Omit a command field to skip that step entirely. Setting `temper.lint_required` by itself does not replace auto-detected steps; it only changes how a configured `temper.lint` command is handled.
 
 Commands are split on whitespace into executable + arguments. For commands requiring shell features (pipes, redirections, command chaining, or inline environment variables), use a wrapper script committed in the repo, or invoke a shell explicitly (for example, `sh -c 'FOO=bar pytest -q | tee test.log'`). Per-anvil `.forge/temper.yaml` does not currently support custom build/test/lint commands.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -175,6 +175,9 @@ type TemperCommandsConfig struct {
 	Test string `mapstructure:"test" yaml:"test,omitempty"`
 	// Lint is the lint command (e.g. "make lint", "ruff check .").
 	Lint string `mapstructure:"lint" yaml:"lint,omitempty"`
+	// LintRequired makes lint failures fail the temper run instead of warning.
+	// Default false preserves legacy behavior where lint is advisory-only.
+	LintRequired bool `mapstructure:"lint_required" yaml:"lint_required,omitempty"`
 }
 
 // IsEmpty returns true if no custom commands are configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1008,6 +1008,10 @@ func (c *Config) Validate() []string {
 		if anvil.AutoDispatch == "priority" && (anvil.AutoDispatchMinPriority < 0 || anvil.AutoDispatchMinPriority > 4) {
 			errs = append(errs, fmt.Sprintf("anvil %q: auto_dispatch_min_priority must be 0-4 (0 = critical-only) when auto_dispatch is \"priority\"", name))
 		}
+
+		if anvil.Temper != nil && anvil.Temper.LintRequired && anvil.Temper.Lint == "" {
+			errs = append(errs, fmt.Sprintf("anvil %q: temper.lint_required is true but temper.lint is not set", name))
+		}
 	}
 
 	return errs

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -869,3 +869,44 @@ anvils:
 	assert.Equal(t, "make lint", cfg.Anvils["myrepo"].Temper.Lint)
 	assert.Equal(t, "make build", cfg.Anvils["myrepo"].Temper.Build)
 }
+
+func TestConfig_Validate_LintRequired(t *testing.T) {
+	base := func() Config {
+		return Config{
+			Settings: SettingsConfig{
+				MaxTotalSmiths:        4,
+				MaxReviewAttempts:     5,
+				MaxPipelineIterations: 5,
+				PollInterval:          1 * time.Minute,
+				SmithTimeout:          30 * time.Minute,
+				BellowsInterval:       2 * time.Minute,
+				MaxCIFixAttempts:      5,
+				MaxReviewFixAttempts:  5,
+				MaxRebaseAttempts:     3,
+			},
+			Anvils: map[string]AnvilConfig{
+				"myrepo": {Path: "/some/path"},
+			},
+		}
+	}
+
+	t.Run("lint_required with lint set is valid", func(t *testing.T) {
+		cfg := base()
+		temper := cfg.Anvils["myrepo"]
+		temper.Temper = &TemperCommandsConfig{Lint: "make lint", LintRequired: true}
+		cfg.Anvils["myrepo"] = temper
+		errs := cfg.Validate()
+		for _, e := range errs {
+			assert.NotContains(t, e, "lint_required")
+		}
+	})
+
+	t.Run("lint_required without lint is invalid", func(t *testing.T) {
+		cfg := base()
+		temper := cfg.Anvils["myrepo"]
+		temper.Temper = &TemperCommandsConfig{LintRequired: true}
+		cfg.Anvils["myrepo"] = temper
+		errs := cfg.Validate()
+		assert.Contains(t, errs, `anvil "myrepo": temper.lint_required is true but temper.lint is not set`)
+	})
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -847,3 +847,25 @@ func TestProvidersForStageWithAnvil_AnvilNoStageProviders(t *testing.T) {
 	got := ProvidersForStageWithAnvil(s, anvil, "smith")
 	assert.Equal(t, []string{"claude"}, got)
 }
+
+func TestLoad_TemperLintRequired(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "forge.yaml")
+	content := `
+anvils:
+  myrepo:
+    path: /some/path
+    temper:
+      build: "make build"
+      lint: "make lint"
+      lint_required: true
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Anvils["myrepo"].Temper)
+	assert.True(t, cfg.Anvils["myrepo"].Temper.LintRequired)
+	assert.Equal(t, "make lint", cfg.Anvils["myrepo"].Temper.Lint)
+	assert.Equal(t, "make build", cfg.Anvils["myrepo"].Temper.Build)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4543,7 +4543,7 @@ func (d *Daemon) resolveTemperConfig(anvilCfg config.AnvilConfig) *temper.Config
 	if anvilCfg.Temper == nil || anvilCfg.Temper.IsEmpty() {
 		return nil
 	}
-	return temper.ConfigFromCommands(anvilCfg.Temper.Build, anvilCfg.Temper.Test, anvilCfg.Temper.Lint)
+	return temper.ConfigFromCommands(anvilCfg.Temper.Build, anvilCfg.Temper.Test, anvilCfg.Temper.Lint, anvilCfg.Temper.LintRequired)
 }
 
 // resolveGoRaceDetection resolves the effective Go race detection setting.

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -143,7 +143,7 @@ func LoadAnvilConfig(anvilPath string) (*TemperYAML, error) {
 // whitespace into the executable and arguments (no shell expansion).
 // If all commands are empty, it returns nil so callers can fall back to
 // auto-detection.
-func ConfigFromCommands(build, test, lint string) *Config {
+func ConfigFromCommands(build, test, lint string, lintRequired bool) *Config {
 	build = strings.TrimSpace(build)
 	test = strings.TrimSpace(test)
 	lint = strings.TrimSpace(lint)
@@ -167,7 +167,7 @@ func ConfigFromCommands(build, test, lint string) *Config {
 			Command:  cmd,
 			Args:     args,
 			Timeout:  3 * time.Minute,
-			Optional: true,
+			Optional: !lintRequired,
 		})
 	}
 	if test != "" {

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -244,7 +244,7 @@ func TestDetectSteps_NodeRootAndSubdir(t *testing.T) {
 }
 
 func TestConfigFromCommands_AllCommands(t *testing.T) {
-	cfg := ConfigFromCommands("make build", "make test", "make lint")
+	cfg := ConfigFromCommands("make build", "make test", "make lint", false)
 	require.NotNil(t, cfg)
 	assert.Len(t, cfg.Steps, 3)
 
@@ -266,7 +266,7 @@ func TestConfigFromCommands_AllCommands(t *testing.T) {
 }
 
 func TestConfigFromCommands_OnlyBuild(t *testing.T) {
-	cfg := ConfigFromCommands("cargo build", "", "")
+	cfg := ConfigFromCommands("cargo build", "", "", false)
 	require.NotNil(t, cfg)
 	assert.Len(t, cfg.Steps, 1)
 	assert.Equal(t, "build", cfg.Steps[0].Name)
@@ -275,7 +275,7 @@ func TestConfigFromCommands_OnlyBuild(t *testing.T) {
 }
 
 func TestConfigFromCommands_OnlyTest(t *testing.T) {
-	cfg := ConfigFromCommands("", "pytest -v", "")
+	cfg := ConfigFromCommands("", "pytest -v", "", false)
 	require.NotNil(t, cfg)
 	assert.Len(t, cfg.Steps, 1)
 	assert.Equal(t, "test", cfg.Steps[0].Name)
@@ -284,19 +284,19 @@ func TestConfigFromCommands_OnlyTest(t *testing.T) {
 }
 
 func TestConfigFromCommands_AllEmpty(t *testing.T) {
-	cfg := ConfigFromCommands("", "", "")
+	cfg := ConfigFromCommands("", "", "", false)
 	assert.Nil(t, cfg, "all empty commands should return nil")
 }
 
 func TestConfigFromCommands_SingleWordCommand(t *testing.T) {
-	cfg := ConfigFromCommands("", "pytest", "")
+	cfg := ConfigFromCommands("", "pytest", "", false)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "pytest", cfg.Steps[0].Command)
 	assert.Empty(t, cfg.Steps[0].Args)
 }
 
 func TestConfigFromCommands_Timeouts(t *testing.T) {
-	cfg := ConfigFromCommands("make build", "make test", "make lint")
+	cfg := ConfigFromCommands("make build", "make test", "make lint", false)
 	require.NotNil(t, cfg)
 
 	for _, s := range cfg.Steps {
@@ -324,4 +324,28 @@ func TestDefaultConfigWithRace_ExcludesRaceStepWhenDisabled(t *testing.T) {
 	assert.Contains(t, names, "build")
 	assert.Contains(t, names, "vet")
 	assert.Contains(t, names, "test")
+}
+
+func TestConfigFromCommands_LintRequired_True(t *testing.T) {
+	cfg := ConfigFromCommands("", "", "make lint", true)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 1)
+	assert.Equal(t, "lint", cfg.Steps[0].Name)
+	assert.False(t, cfg.Steps[0].Optional, "lint should not be optional when lintRequired is true")
+}
+
+func TestConfigFromCommands_LintRequired_False_PreservesDefault(t *testing.T) {
+	cfg := ConfigFromCommands("", "", "make lint", false)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 1)
+	assert.Equal(t, "lint", cfg.Steps[0].Name)
+	assert.True(t, cfg.Steps[0].Optional, "lint should be optional when lintRequired is false")
+}
+
+func TestConfigFromCommands_LintRequired_EmptyLint_NoStep(t *testing.T) {
+	cfg := ConfigFromCommands("make build", "", "", true)
+	require.NotNil(t, cfg)
+	for _, s := range cfg.Steps {
+		assert.NotEqual(t, "lint", s.Name, "no lint step should be added when lint command is empty")
+	}
 }


### PR DESCRIPTION
## Changes

- **Configurable lint step severity** - Added `temper.lint_required` option to make the lint step fail the temper run instead of only warning. Default preserves existing advisory-only behavior. (Forge-lsj4)

## Original Issue (feature): Allow temper.lint to be configured as a required (non-optional) step

## Problem

`temper.ConfigFromCommands` at `internal/temper/temper.go:163-172` unconditionally marks the `lint` step as `Optional: true`:

```go
if lint != "" {
    cmd, args := splitCommand(lint)
    steps = append(steps, Step{
        Name:     "lint",
        Command:  cmd,
        Args:     args,
        Timeout:  3 * time.Minute,
        Optional: true,  // ← hardcoded
    })
}
```

An optional step that fails is reported as a "warning" and **does not** fail `Result.Passed`. The practical consequence: a user who configures `temper.lint: "npm run lint"` expecting parity with CI discovers that when lint actually fails, temper reports "All required checks passed in X.Xs (1 optional step(s) warned)", burnish happily pushes the broken commit, and CI catches what temper refused to. This is the *exact* failure pattern that motivated Forge-syrn (the push-gating fix) — but the hardcoded Optional flag re-opens the same hole through a config misunderstanding.

The only workarounds today are:

1. Abuse the `build:` slot (put the lint command there) — makes the slot name misleading and precludes an actual build command.
2. Write a wrapper script that combines build+lint+test+typecheck and point `build:` at it — works but punts the problem to the user.

Neither is discoverable. A user reading `docs/configuration.md:239-275` has no reason to expect that `lint:` is silently treated as a warning.

## Fix

Add an explicit opt-in to make the configured lint command required. Two implementation choices:

### Option A (minimal, back-compat default)

Add a single bool field to `TemperCommandsConfig` in `internal/config/config.go:171-183`:

```go
type TemperCommandsConfig struct {
    Build        string `mapstructure:"build" yaml:"build,omitempty"`
    Test         string `mapstructure:"test" yaml:"test,omitempty"`
    Lint         string `mapstructure:"lint" yaml:"lint,omitempty"`
    LintRequired bool   `mapstructure:"lint_required" yaml:"lint_required,omitempty"`
}
```

Default: `false` (preserves current behavior for existing configs).

Thread it through `ConfigFromCommands(build, test, lint)` → `ConfigFromCommandsV2(build, test, lint string, lintRequired bool)` (or just modify the existing function — it's only called from `daemon.go:4542`, so no external breakage). In the resulting step, set `Optional: !lintRequired`.

### Option B (richer, slightly more invasive)

Promote each slot to an object form with per-step options:

```yaml
temper:
  build: "go build ./..."         # shorthand, stays required
  test: "go test ./..."
  lint:
    command: "golangci-lint run ./..."
    required: true
    timeout: 5m
```

Requires custom unmarshal to accept both the string shorthand and the object form. Same pattern as how Go projects often handle multi-shape YAML fields. A bit more code.

**Recommend Option A.** It's 15 lines of code total, is a strict superset of current capability, and Forge-bead-3 (arbitrary steps list) will handle the richer case anyway — no point building Option B as an intermediate state.

## Tests

`internal/temper/temper_test.go` — add:

- `TestConfigFromCommands_LintRequired_True`: pass `lintRequired=true`, assert the lint step in the returned Config has `Optional: false`.
- `TestConfigFromCommands_LintRequired_False_PreservesDefault`: pass `lintRequired=false`, assert `Optional: true` (back-compat).
- `TestConfigFromCommands_LintRequired_EmptyLint_NoStep`: when `lint` is empty, `lintRequired` has no effect (no step is added).
- Existing tests should not need changes beyond possibly updating the signature.

`internal/config/config_test.go` — add yaml round-trip test covering `lint_required: true` parses correctly.

## Docs

Update `docs/configuration.md`:

- **Custom Temper Commands table** (`docs/configuration.md:243-247`): add a row:
  | `temper.lint_required` | bool | `false` | When `true`, failures in `temper.lint` fail the temper run instead of warning. Default matches legacy behavior where lint is an advisory-only step. |

- **Surrounding paragraph** at line 247: update the existing description of `temper.lint` from "Runs as an optional step (failure warns but doesn't block)." to "Runs as an optional step by default (failure warns but doesn't block). Set `lint_required: true` to make lint failures fail the temper run."

- **Custom Temper Commands examples** (`docs/configuration.md:253-275`): add one example block using `lint_required: true` so the user can copy-paste:

  ```yaml
  anvils:
    strict-node-app:
      path: /home/user/source/strict-node-app
      temper:
        build: "npm run build"
        test:  "npm run test:run"
        lint:  "npm run lint"
        lint_required: true   # make lint failures fail the temper run, matching CI
  ```

- **Full Example section** (`docs/configuration.md:11-112`): no change needed unless you want to add a temper block to one of the example anvils. Leave as-is to keep the example compact.

## Chain context

This bead is ordered to land **after** Forge-w8rb (hooks in burnish/quench) because hooks landing first means users who set `lint_required: true` will have working hooks to complement it. No hard technical dependency — the two changes touch different files. Ordering is for predictable rollout.

This bead is ordered to land **before** Forge-bead-3 (arbitrary steps list) because the steps-list form makes `lint_required` obsolete — each step in the list has its own `required` flag. Landing lint_required first gives users an immediate, low-risk win while the bigger steps-list change is in review.

## Files touched

- `internal/temper/temper.go` — `ConfigFromCommands` signature + step generation
- `internal/temper/temper_test.go` — new tests
- `internal/config/config.go` — `TemperCommandsConfig.LintRequired` field
- `internal/config/config_test.go` — yaml round-trip test
- `internal/daemon/daemon.go:4542` — pass the new field to `ConfigFromCommands`
- `docs/configuration.md` — table row, description, example
- `changelog.d/Forge-<id>.md` — Added category fragment

## Acceptance criteria

- A config with `temper.lint: "false-positive-lint"` and `temper.lint_required: true` fails the temper run when the lint command exits non-zero.
- A config with `temper.lint: "false-positive-lint"` and `lint_required` unset or false continues to warn without failing (back-compat).
- `docs/configuration.md` Custom Temper Commands section includes a `lint_required` row and at least one example with `lint_required: true`.

---
Bead: Forge-lsj4 | Branch: forge/Forge-lsj4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)