### PR TITLE
Support arbitrary named steps in per-anvil temper config (temper.steps) (Forge-mycv)

### DIFF
--- a/changelog.d/Forge-mycv.md
+++ b/changelog.d/Forge-mycv.md
@@ -1,0 +1,2 @@
+category: Added
+- **Custom temper steps** - Support arbitrary named steps in per-anvil temper config via `temper.steps`, enabling pipelines with more than three steps, per-step working directories, timeouts, and required/optional control. The existing `build`/`test`/`lint` shorthand remains supported. (Forge-mycv)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,13 @@ anvils:
     max_smiths: 3
     auto_dispatch: tagged
     auto_dispatch_tag: forge-auto
+    temper:
+      steps:
+        - { name: install,   command: npm, args: [ci],             dir: web, timeout: 5m }
+        - { name: lint,      command: npm, args: [run, lint],      dir: web }
+        - { name: typecheck, command: npm, args: [run, typecheck], dir: web }
+        - { name: build,     command: npm, args: [run, build],     dir: web }
+        - { name: test,      command: npm, args: [run, test:run],  dir: web }
 
   legacy-repo:
     path: /path/to/repos/legacy
@@ -251,6 +258,10 @@ Omitting `platform` or setting it to an empty string defaults to `github`. Exist
 
 By default, Temper auto-detects the project type (Go, .NET, Node) and runs appropriate build/test/lint steps. The `temper` object lets you override these with custom commands, enabling support for Python, Rust, or repos with non-standard build tooling.
 
+Use the shorthand when your project has a straightforward build/test/lint shape. For more complex pipelines, use the `steps` list described in [Custom Temper Steps](#custom-temper-steps-advanced) below.
+
+#### Shorthand (build/test/lint)
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `temper.build` | string | | Custom build command (e.g. `"make build"`, `"cargo build"`). Replaces the auto-detected build step. |
@@ -291,6 +302,137 @@ anvils:
       test: "npm run test:run"
       lint: "npm run lint"
       lint_required: true   # make lint failures fail the temper run, matching CI
+```
+
+#### Custom Temper Steps (advanced)
+
+For pipelines that need more than three steps, per-step working directories, or per-step timeout/required control, use `temper.steps`. Steps run in the order listed; a required step failure stops the run.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | **required** | Step identifier; appears in logs, summaries, and failure events. Must be non-empty and unique within the list. |
+| `command` | string | **required** | Executable to run (not shell-interpreted). For shell features, wrap in a checked-in script. |
+| `args` | `[]string` | `[]` | Arguments to the command. Use list form; avoid embedding in `command`. |
+| `dir` | string | worktree root | Working directory for the step. Relative paths resolve against the worktree; absolute paths used as-is. |
+| `timeout` | duration | `5m` | Per-step timeout. Same parsing as elsewhere in Forge config (`5m`, `30s`, `1h`). |
+| `required` | bool | `true` | When `true`, failure fails the whole temper run. When `false`, failure is reported as a warning. |
+
+**Precedence:** If `temper.steps` is set and non-empty, it takes precedence over `temper.build`/`test`/`lint`. A warning is logged if both are present. If neither `steps` nor the shorthand fields are set, auto-detection applies as usual.
+
+Both `temper.steps` and the shorthand form can be used on different anvils in the same config file.
+
+If your steps need one-shot setup (e.g. `npm ci`) that should persist across all temper invocations (initial pipeline, burnish, quench), consider using a `before_temper` hook instead of a step. See [Pipeline Hooks](#pipeline-hooks).
+
+##### Examples
+
+**Node.js matching CI exactly:**
+
+```yaml
+anvils:
+  my-node-app:
+    path: /home/user/source/my-node-app
+    temper:
+      steps:
+        - name: install
+          command: npm
+          args: [ci]
+          dir: web
+          timeout: 5m
+        - name: lint
+          command: npm
+          args: [run, lint]
+          dir: web
+        - name: typecheck
+          command: npm
+          args: [run, typecheck]
+          dir: web
+        - name: build
+          command: npm
+          args: [run, build]
+          dir: web
+        - name: test
+          command: npm
+          args: [run, test:run]
+          dir: web
+```
+
+**Go + Node mixed monorepo:**
+
+```yaml
+anvils:
+  hytte:
+    path: /home/user/source/Hytte
+    temper:
+      steps:
+        - name: go-build
+          command: go
+          args: [build, ./...]
+        - name: go-vet
+          command: go
+          args: [vet, ./...]
+        - name: go-test
+          command: go
+          args: [test, -short, ./...]
+        - name: npm-install
+          command: npm
+          args: [ci]
+          dir: web
+          timeout: 5m
+        - name: npm-lint
+          command: npm
+          args: [run, lint]
+          dir: web
+        - name: npm-build
+          command: npm
+          args: [run, build]
+          dir: web
+```
+
+**.NET with analyzers and format check:**
+
+```yaml
+anvils:
+  my-dotnet-app:
+    path: C:\src\my-dotnet-app
+    temper:
+      steps:
+        - name: restore
+          command: dotnet
+          args: [restore]
+        - name: format
+          command: dotnet
+          args: [format, --verify-no-changes, --no-restore]
+        - name: build
+          command: dotnet
+          args: [build, --configuration, Release, --no-restore]
+          timeout: 10m
+        - name: test
+          command: dotnet
+          args: [test, --configuration, Release, --no-build, --logger, "trx;LogFileName=test.trx"]
+          timeout: 15m
+```
+
+**Python with advisory step:**
+
+```yaml
+anvils:
+  my-python-lib:
+    path: /home/user/source/my-python-lib
+    temper:
+      steps:
+        - name: install
+          command: pip
+          args: [install, -e, ".[dev]"]
+        - name: ruff
+          command: ruff
+          args: [check, .]
+        - name: mypy
+          command: mypy
+          args: [src]
+          required: false   # advisory — warn but don't block
+        - name: test
+          command: pytest
+          args: [-q]
 ```
 
 ## Settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1038,16 +1038,24 @@ func (c *Config) Validate() []string {
 		if anvil.Temper != nil {
 			seen := make(map[string]bool)
 			for i, step := range anvil.Temper.Steps {
-				if step.Name == "" {
+				trimmedName := strings.TrimSpace(step.Name)
+				trimmedCommand := strings.TrimSpace(step.Command)
+
+				if trimmedName == "" {
 					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps[%d].name must be non-empty", name, i))
 				}
-				if step.Command == "" {
+				if trimmedCommand == "" {
 					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps[%d].command must be non-empty", name, i))
 				}
-				if step.Name != "" && seen[step.Name] {
-					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps has duplicate name %q", name, step.Name))
+				if trimmedName != "" {
+					if seen[trimmedName] {
+						errs = append(errs, fmt.Sprintf("anvil %q: temper.steps has duplicate name %q", name, trimmedName))
+					}
+					seen[trimmedName] = true
 				}
-				seen[step.Name] = true
+				if step.Timeout < 0 {
+					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps[%d].timeout must be non-negative", name, i))
+				}
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,11 +178,33 @@ type TemperCommandsConfig struct {
 	// LintRequired makes lint failures fail the temper run instead of warning.
 	// Default false preserves legacy behavior where lint is advisory-only.
 	LintRequired bool `mapstructure:"lint_required" yaml:"lint_required,omitempty"`
+	// Steps is an ordered list of named verification steps. When non-empty,
+	// it takes precedence over Build/Test/Lint. Each step runs in input order;
+	// a required step failure stops the run.
+	Steps []TemperStepConfig `mapstructure:"steps" yaml:"steps,omitempty"`
+}
+
+// TemperStepConfig defines a single named step in the temper.steps list.
+type TemperStepConfig struct {
+	// Name identifies the step in logs, summaries, and failure events.
+	Name string `mapstructure:"name" yaml:"name"`
+	// Command is the executable to run (not shell-interpreted).
+	Command string `mapstructure:"command" yaml:"command"`
+	// Args are the command arguments.
+	Args []string `mapstructure:"args" yaml:"args,omitempty"`
+	// Dir is the working directory for the step. Relative paths resolve
+	// against the worktree root; absolute paths are used as-is.
+	Dir string `mapstructure:"dir" yaml:"dir,omitempty"`
+	// Timeout is the per-step timeout. Defaults to 5m when zero.
+	Timeout time.Duration `mapstructure:"timeout" yaml:"timeout,omitempty"`
+	// Required controls whether failure fails the whole temper run.
+	// Pointer so we can distinguish unset (defaults to true) from explicit false.
+	Required *bool `mapstructure:"required" yaml:"required,omitempty"`
 }
 
 // IsEmpty returns true if no custom commands are configured.
 func (t *TemperCommandsConfig) IsEmpty() bool {
-	return t == nil || (t.Build == "" && t.Test == "" && t.Lint == "")
+	return t == nil || (t.Build == "" && t.Test == "" && t.Lint == "" && len(t.Steps) == 0)
 }
 
 // SettingsConfig holds global operational settings.
@@ -1009,8 +1031,24 @@ func (c *Config) Validate() []string {
 			errs = append(errs, fmt.Sprintf("anvil %q: auto_dispatch_min_priority must be 0-4 (0 = critical-only) when auto_dispatch is \"priority\"", name))
 		}
 
-		if anvil.Temper != nil && anvil.Temper.LintRequired && anvil.Temper.Lint == "" {
+		if anvil.Temper != nil && anvil.Temper.LintRequired && anvil.Temper.Lint == "" && len(anvil.Temper.Steps) == 0 {
 			errs = append(errs, fmt.Sprintf("anvil %q: temper.lint_required is true but temper.lint is not set", name))
+		}
+
+		if anvil.Temper != nil {
+			seen := make(map[string]bool)
+			for i, step := range anvil.Temper.Steps {
+				if step.Name == "" {
+					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps[%d].name must be non-empty", name, i))
+				}
+				if step.Command == "" {
+					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps[%d].command must be non-empty", name, i))
+				}
+				if step.Name != "" && seen[step.Name] {
+					errs = append(errs, fmt.Sprintf("anvil %q: temper.steps has duplicate name %q", name, step.Name))
+				}
+				seen[step.Name] = true
+			}
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -909,4 +910,130 @@ func TestConfig_Validate_LintRequired(t *testing.T) {
 		errs := cfg.Validate()
 		assert.Contains(t, errs, `anvil "myrepo": temper.lint_required is true but temper.lint is not set`)
 	})
+
+	t.Run("lint_required with steps is valid", func(t *testing.T) {
+		cfg := base()
+		a := cfg.Anvils["myrepo"]
+		a.Temper = &TemperCommandsConfig{
+			LintRequired: true,
+			Steps: []TemperStepConfig{
+				{Name: "lint", Command: "make", Args: []string{"lint"}},
+			},
+		}
+		cfg.Anvils["myrepo"] = a
+		errs := cfg.Validate()
+		for _, e := range errs {
+			assert.NotContains(t, e, "lint_required")
+		}
+	})
+
+	t.Run("steps missing name is invalid", func(t *testing.T) {
+		cfg := base()
+		a := cfg.Anvils["myrepo"]
+		a.Temper = &TemperCommandsConfig{
+			Steps: []TemperStepConfig{
+				{Name: "", Command: "make"},
+			},
+		}
+		cfg.Anvils["myrepo"] = a
+		errs := cfg.Validate()
+		assert.Contains(t, errs, `anvil "myrepo": temper.steps[0].name must be non-empty`)
+	})
+
+	t.Run("steps missing command is invalid", func(t *testing.T) {
+		cfg := base()
+		a := cfg.Anvils["myrepo"]
+		a.Temper = &TemperCommandsConfig{
+			Steps: []TemperStepConfig{
+				{Name: "build", Command: ""},
+			},
+		}
+		cfg.Anvils["myrepo"] = a
+		errs := cfg.Validate()
+		assert.Contains(t, errs, `anvil "myrepo": temper.steps[0].command must be non-empty`)
+	})
+
+	t.Run("steps duplicate names is invalid", func(t *testing.T) {
+		cfg := base()
+		a := cfg.Anvils["myrepo"]
+		a.Temper = &TemperCommandsConfig{
+			Steps: []TemperStepConfig{
+				{Name: "build", Command: "make"},
+				{Name: "build", Command: "cargo"},
+			},
+		}
+		cfg.Anvils["myrepo"] = a
+		errs := cfg.Validate()
+		assert.Contains(t, errs, `anvil "myrepo": temper.steps has duplicate name "build"`)
+	})
+
+	t.Run("valid steps pass validation", func(t *testing.T) {
+		cfg := base()
+		a := cfg.Anvils["myrepo"]
+		a.Temper = &TemperCommandsConfig{
+			Steps: []TemperStepConfig{
+				{Name: "build", Command: "make", Args: []string{"build"}},
+				{Name: "test", Command: "make", Args: []string{"test"}},
+			},
+		}
+		cfg.Anvils["myrepo"] = a
+		errs := cfg.Validate()
+		for _, e := range errs {
+			assert.NotContains(t, e, "temper.steps")
+		}
+	})
+}
+
+func TestTemperStepConfig_YAMLRoundTrip(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	original := &TemperCommandsConfig{
+		Steps: []TemperStepConfig{
+			{
+				Name:     "install",
+				Command:  "npm",
+				Args:     []string{"ci"},
+				Dir:      "web",
+				Timeout:  5 * time.Minute,
+				Required: boolPtr(true),
+			},
+			{
+				Name:    "lint",
+				Command: "npm",
+				Args:    []string{"run", "lint"},
+			},
+			{
+				Name:     "mypy",
+				Command:  "mypy",
+				Args:     []string{"src"},
+				Required: boolPtr(false),
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	var roundTripped TemperCommandsConfig
+	err = yaml.Unmarshal(data, &roundTripped)
+	require.NoError(t, err)
+
+	require.Len(t, roundTripped.Steps, 3)
+	assert.Equal(t, "install", roundTripped.Steps[0].Name)
+	assert.Equal(t, "npm", roundTripped.Steps[0].Command)
+	assert.Equal(t, []string{"ci"}, roundTripped.Steps[0].Args)
+	assert.Equal(t, "web", roundTripped.Steps[0].Dir)
+	assert.Equal(t, 5*time.Minute, roundTripped.Steps[0].Timeout)
+	require.NotNil(t, roundTripped.Steps[0].Required)
+	assert.True(t, *roundTripped.Steps[0].Required)
+
+	// Step without optional fields
+	assert.Equal(t, "lint", roundTripped.Steps[1].Name)
+	assert.Nil(t, roundTripped.Steps[1].Required)
+	assert.Empty(t, roundTripped.Steps[1].Dir)
+	assert.Equal(t, time.Duration(0), roundTripped.Steps[1].Timeout)
+
+	// Step with required: false
+	require.NotNil(t, roundTripped.Steps[2].Required)
+	assert.False(t, *roundTripped.Steps[2].Required)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4543,6 +4543,12 @@ func (d *Daemon) resolveTemperConfig(anvilCfg config.AnvilConfig) *temper.Config
 	if anvilCfg.Temper == nil || anvilCfg.Temper.IsEmpty() {
 		return nil
 	}
+	if len(anvilCfg.Temper.Steps) > 0 {
+		if anvilCfg.Temper.Build != "" || anvilCfg.Temper.Test != "" || anvilCfg.Temper.Lint != "" {
+			d.logger.Warn("temper.steps overrides temper.build/test/lint", "path", anvilCfg.Path)
+		}
+		return temper.ConfigFromSteps(anvilCfg.Temper.Steps)
+	}
 	return temper.ConfigFromCommands(anvilCfg.Temper.Build, anvilCfg.Temper.Test, anvilCfg.Temper.Lint, anvilCfg.Temper.LintRequired)
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2844,3 +2844,71 @@ func TestHandleIPC_WicketScan(t *testing.T) {
 		assert.Contains(t, msg["message"], "wicket scan triggered")
 	})
 }
+
+func TestResolveTemperConfig_StepsOverridesSlots(t *testing.T) {
+	var logBuf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	d := &Daemon{logger: logger}
+
+	t.Run("steps only", func(t *testing.T) {
+		logBuf.Reset()
+		anvilCfg := config.AnvilConfig{
+			Path: "/tmp/test-anvil",
+			Temper: &config.TemperCommandsConfig{
+				Steps: []config.TemperStepConfig{
+					{Name: "build", Command: "make", Args: []string{"build"}},
+					{Name: "test", Command: "make", Args: []string{"test"}},
+				},
+			},
+		}
+		cfg := d.resolveTemperConfig(anvilCfg)
+		require.NotNil(t, cfg)
+		assert.Len(t, cfg.Steps, 2)
+		assert.Equal(t, "build", cfg.Steps[0].Name)
+		assert.Equal(t, "test", cfg.Steps[1].Name)
+		assert.NotContains(t, logBuf.String(), "overrides")
+	})
+
+	t.Run("steps with build also set logs warning", func(t *testing.T) {
+		logBuf.Reset()
+		anvilCfg := config.AnvilConfig{
+			Path: "/tmp/test-anvil",
+			Temper: &config.TemperCommandsConfig{
+				Build: "make build",
+				Steps: []config.TemperStepConfig{
+					{Name: "custom-build", Command: "cargo", Args: []string{"build"}},
+				},
+			},
+		}
+		cfg := d.resolveTemperConfig(anvilCfg)
+		require.NotNil(t, cfg)
+		assert.Len(t, cfg.Steps, 1)
+		assert.Equal(t, "custom-build", cfg.Steps[0].Name)
+		assert.Contains(t, logBuf.String(), "overrides")
+	})
+
+	t.Run("legacy slots without steps", func(t *testing.T) {
+		logBuf.Reset()
+		anvilCfg := config.AnvilConfig{
+			Path: "/tmp/test-anvil",
+			Temper: &config.TemperCommandsConfig{
+				Build: "make build",
+				Test:  "make test",
+			},
+		}
+		cfg := d.resolveTemperConfig(anvilCfg)
+		require.NotNil(t, cfg)
+		assert.Len(t, cfg.Steps, 2)
+		assert.Equal(t, "build", cfg.Steps[0].Name)
+		assert.Equal(t, "test", cfg.Steps[1].Name)
+	})
+
+	t.Run("empty temper returns nil", func(t *testing.T) {
+		anvilCfg := config.AnvilConfig{
+			Path:   "/tmp/test-anvil",
+			Temper: &config.TemperCommandsConfig{},
+		}
+		cfg := d.resolveTemperConfig(anvilCfg)
+		assert.Nil(t, cfg)
+	})
+}

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/state"
 	"gopkg.in/yaml.v3"
@@ -180,6 +181,35 @@ func ConfigFromCommands(build, test, lint string, lintRequired bool) *Config {
 		})
 	}
 	return &Config{Steps: steps}
+}
+
+// ConfigFromSteps builds a Config from an ordered list of TemperStepConfig
+// entries. Returns nil if the slice is empty so callers can fall back to
+// auto-detection.
+func ConfigFromSteps(steps []config.TemperStepConfig) *Config {
+	if len(steps) == 0 {
+		return nil
+	}
+	out := make([]Step, len(steps))
+	for i, s := range steps {
+		timeout := s.Timeout
+		if timeout == 0 {
+			timeout = 5 * time.Minute
+		}
+		optional := false
+		if s.Required != nil && !*s.Required {
+			optional = true
+		}
+		out[i] = Step{
+			Name:     s.Name,
+			Command:  s.Command,
+			Args:     s.Args,
+			Dir:      s.Dir,
+			Timeout:  timeout,
+			Optional: optional,
+		}
+	}
+	return &Config{Steps: out}
 }
 
 // splitCommand splits a command string into the executable and arguments.

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -201,10 +201,10 @@ func ConfigFromSteps(steps []config.TemperStepConfig) *Config {
 			optional = true
 		}
 		out[i] = Step{
-			Name:     s.Name,
-			Command:  s.Command,
+			Name:     strings.TrimSpace(s.Name),
+			Command:  strings.TrimSpace(s.Command),
 			Args:     s.Args,
-			Dir:      s.Dir,
+			Dir:      strings.TrimSpace(s.Dir),
 			Timeout:  timeout,
 			Optional: optional,
 		}

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -422,9 +422,9 @@ func TestConfigFromSteps_EmptyList_ReturnsNil(t *testing.T) {
 	assert.Nil(t, cfg, "nil steps slice should return nil")
 }
 
-func TestConfigFromSteps_StopsOnRequiredFailure(t *testing.T) {
-	// This tests that the existing Run loop stops on required step failure.
-	// We build a Config with three steps where the middle one will fail.
+func TestConfigFromSteps_RequiredByDefault(t *testing.T) {
+	// This test verifies that ConfigFromSteps marks steps as required by default.
+	// It does not execute Temper's Run loop.
 	cfg := ConfigFromSteps([]config.TemperStepConfig{
 		{Name: "pass", Command: "true"},
 		{Name: "fail", Command: "false"},

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Robin831/Forge/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -347,5 +348,92 @@ func TestConfigFromCommands_LintRequired_EmptyLint_NoStep(t *testing.T) {
 	require.NotNil(t, cfg)
 	for _, s := range cfg.Steps {
 		assert.NotEqual(t, "lint", s.Name, "no lint step should be added when lint command is empty")
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestConfigFromSteps_BasicOrdering(t *testing.T) {
+	steps := []config.TemperStepConfig{
+		{Name: "install", Command: "npm", Args: []string{"ci"}},
+		{Name: "lint", Command: "npm", Args: []string{"run", "lint"}},
+		{Name: "test", Command: "npm", Args: []string{"run", "test:run"}},
+	}
+	cfg := ConfigFromSteps(steps)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 3)
+	assert.Equal(t, "install", cfg.Steps[0].Name)
+	assert.Equal(t, "lint", cfg.Steps[1].Name)
+	assert.Equal(t, "test", cfg.Steps[2].Name)
+	assert.Equal(t, "npm", cfg.Steps[0].Command)
+	assert.Equal(t, []string{"ci"}, cfg.Steps[0].Args)
+}
+
+func TestConfigFromSteps_RequiredDefault_True(t *testing.T) {
+	steps := []config.TemperStepConfig{
+		{Name: "build", Command: "make", Args: []string{"build"}},
+	}
+	cfg := ConfigFromSteps(steps)
+	require.NotNil(t, cfg)
+	assert.False(t, cfg.Steps[0].Optional, "step without required field should not be optional")
+}
+
+func TestConfigFromSteps_RequiredFalse_Optional(t *testing.T) {
+	steps := []config.TemperStepConfig{
+		{Name: "mypy", Command: "mypy", Args: []string{"src"}, Required: boolPtr(false)},
+	}
+	cfg := ConfigFromSteps(steps)
+	require.NotNil(t, cfg)
+	assert.True(t, cfg.Steps[0].Optional, "step with required: false should be optional")
+}
+
+func TestConfigFromSteps_RespectsDir(t *testing.T) {
+	steps := []config.TemperStepConfig{
+		{Name: "lint", Command: "npm", Args: []string{"run", "lint"}, Dir: "web"},
+	}
+	cfg := ConfigFromSteps(steps)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "web", cfg.Steps[0].Dir)
+}
+
+func TestConfigFromSteps_RespectsTimeout(t *testing.T) {
+	steps := []config.TemperStepConfig{
+		{Name: "test", Command: "pytest", Timeout: 10 * time.Minute},
+	}
+	cfg := ConfigFromSteps(steps)
+	require.NotNil(t, cfg)
+	assert.Equal(t, 10*time.Minute, cfg.Steps[0].Timeout)
+}
+
+func TestConfigFromSteps_DefaultTimeout(t *testing.T) {
+	steps := []config.TemperStepConfig{
+		{Name: "build", Command: "make"},
+	}
+	cfg := ConfigFromSteps(steps)
+	require.NotNil(t, cfg)
+	assert.Equal(t, 5*time.Minute, cfg.Steps[0].Timeout)
+}
+
+func TestConfigFromSteps_EmptyList_ReturnsNil(t *testing.T) {
+	cfg := ConfigFromSteps([]config.TemperStepConfig{})
+	assert.Nil(t, cfg, "empty steps slice should return nil")
+
+	cfg = ConfigFromSteps(nil)
+	assert.Nil(t, cfg, "nil steps slice should return nil")
+}
+
+func TestConfigFromSteps_StopsOnRequiredFailure(t *testing.T) {
+	// This tests that the existing Run loop stops on required step failure.
+	// We build a Config with three steps where the middle one will fail.
+	cfg := ConfigFromSteps([]config.TemperStepConfig{
+		{Name: "pass", Command: "true"},
+		{Name: "fail", Command: "false"},
+		{Name: "should-not-run", Command: "true"},
+	})
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 3)
+	// All steps are required (default) — verify Optional is false.
+	for _, s := range cfg.Steps {
+		assert.False(t, s.Optional, "all steps should be required by default")
 	}
 }


### PR DESCRIPTION
## Changes

- **Custom temper steps** - Support arbitrary named steps in per-anvil temper config via `temper.steps`, enabling pipelines with more than three steps, per-step working directories, timeouts, and required/optional control. The existing `build`/`test`/`lint` shorthand remains supported. (Forge-mycv)

## Original Issue (feature): Support arbitrary named steps in per-anvil temper config (temper.steps)

## Problem

Per-anvil temper configuration exposes exactly three named slots: `build`, `test`, `lint` (`internal/config/config.go:171-183`, `internal/temper/temper.go:141-183`). This shape can't express common real-world workflows without resorting to wrapper scripts:

**Example: typical Node.js CI pipeline**

CI runs, in order: `npm ci`, `npm run lint`, `npm run typecheck`, `npm run build`, `npm run test:run`. That's five steps (six if you count `npm ci`). Temper has three slots. A user has to either:

1. Write a `scripts/temper.sh` wrapper that chains them all, and point `build:` at it. The wrapper is an extra file to maintain in the anvil repo and duplicates whatever the CI workflow already does — inviting drift.
2. Abuse slots: put `npm run typecheck` in `test:`, `npm run lint` in `lint:` (which is secretly optional — see Forge-bead-2), etc. Misleading and fragile.
3. Use pipeline hooks (`before_temper`) to do `npm ci`, then use the three slots for three of the five commands, and skip the rest. Incomplete coverage.

**Example: Python/Rust/Go mixed anvil**

A repo with both a Go backend and a Python SDK in `sdk/` wants to run `go build`, `go vet`, `go test`, `cd sdk && pytest`, and `cd sdk && ruff check`. Five steps with distinct working directories. The current three-slot form can't represent the `dir` parameter at all — `ConfigFromCommands` doesn't expose `Step.Dir`, even though the underlying `Step` struct supports it (`temper.go:64-68`).

**Example: make-based project with multiple targets**

A project that uses `make build`, `make test`, `make lint`, `make integration-test` maps cleanly onto the existing slots — until it also needs `make vet` or `make format-check`. Back to wrapper-script land.

## Fix

Add a `steps` field to `TemperCommandsConfig` that accepts an ordered list of named steps with per-step options. Keep the existing three slots (`build`, `test`, `lint`) working for backwards compatibility.

### Config shape

```yaml
anvils:
  my-node-app:
    path: /home/user/source/my-node-app
    temper:
      steps:
        - name: install
          command: npm
          args: [ci]
          dir: web
          timeout: 5m
          required: true
        - name: lint
          command: npm
          args: [run, lint]
          dir: web
          required: true
        - name: typecheck
          command: npm
          args: [run, typecheck]
          dir: web
          required: true
        - name: build
          command: npm
          args: [run, build]
          dir: web
          required: true
        - name: test
          command: npm
          args: [run, test:run]
          dir: web
          required: true
```

### Field semantics

| Field | Type | Default | Description |
|---|---|---|---|
| `name` | string | **required** | Step identifier; appears in logs, summaries, and failure events. Must be non-empty. |
| `command` | string | **required** | Executable (not shell-interpreted). For shell features, wrap in a checked-in script. |
| `args` | `[]string` | `[]` | Arguments to the command. Use list form; avoid embedding in `command`. |
| `dir` | string | worktree root | Working directory for the step. Relative paths resolve against the worktree; absolute paths used as-is (same semantics as `Step.Dir` in `temper.go:64-68`). |
| `timeout` | duration | `5m` | Per-step timeout. Same parsing as elsewhere in Forge config (`5m`, `30s`, `1h`). |
| `required` | bool | `true` | When `true`, failure fails the whole temper run. When `false`, failure is reported as a warning (equivalent to today's `Optional: true`). **Note the flipped default vs. the current `lint:` slot** — in the steps list, steps default to *required*, matching the principle of least surprise. |

### Back-compat rules

- If `temper.steps` is set and non-empty, it takes precedence over `temper.build` / `temper.test` / `temper.lint`. Log a warning if both are present ("temper.steps overrides temper.build/test/lint") so users migrating don't get silent surprises.
- If `temper.steps` is unset, the existing three-slot code path runs unchanged (`ConfigFromCommands`).
- Auto-detection still applies when **neither** steps nor the three slots are set.

### Implementation sketch

1. **`internal/config/config.go`** — add to `TemperCommandsConfig`:

   ```go
   type TemperCommandsConfig struct {
       Build        string              `mapstructure:"build" yaml:"build,omitempty"`
       Test         string              `mapstructure:"test" yaml:"test,omitempty"`
       Lint         string              `mapstructure:"lint" yaml:"lint,omitempty"`
       LintRequired bool                `mapstructure:"lint_required" yaml:"lint_required,omitempty"` // added by Forge-lsj4
       Steps        []TemperStepConfig  `mapstructure:"steps" yaml:"steps,omitempty"`
   }

   type TemperStepConfig struct {
       Name     string        `mapstructure:"name" yaml:"name"`
       Command  string        `mapstructure:"command" yaml:"command"`
       Args     []string      `mapstructure:"args" yaml:"args,omitempty"`
       Dir      string        `mapstructure:"dir" yaml:"dir,omitempty"`
       Timeout  time.Duration `mapstructure:"timeout" yaml:"timeout,omitempty"`
       Required *bool         `mapstructure:"required" yaml:"required,omitempty"` // pointer so we can distinguish unset from false; unset = true
   }
   ```

   Update `TemperCommandsConfig.IsEmpty()` at `:181` to also return false when `Steps` is non-empty.

2. **`internal/temper/temper.go`** — add `ConfigFromSteps([]TemperStepConfig) *Config` that converts each `TemperStepConfig` into a `temper.Step`. Handle the `Required` pointer: unset or `*true` → `Optional: false`, `*false` → `Optional: true`. Default `Timeout` to `5 * time.Minute` when zero. Default `Dir` empty (worktree root).

3. **`internal/daemon/daemon.go:4538-4543`** — update `resolveTemperConfig`:

   ```go
   func (d *Daemon) resolveTemperConfig(anvilCfg config.AnvilConfig) *temper.Config {
       if anvilCfg.Temper == nil || anvilCfg.Temper.IsEmpty() {
           return nil
       }
       if len(anvilCfg.Temper.Steps) > 0 {
           if anvilCfg.Temper.Build != "" || anvilCfg.Temper.Test != "" || anvilCfg.Temper.Lint != "" {
               d.logger.Warn("temper.steps overrides temper.build/test/lint for anvil", "anvil", anvilCfg.Name)
           }
           return temper.ConfigFromSteps(anvilCfg.Temper.Steps)
       }
       return temper.ConfigFromCommands(anvilCfg.Temper.Build, anvilCfg.Temper.Test, anvilCfg.Temper.Lint, anvilCfg.Temper.LintRequired)
   }
   ```

4. **Validation** — in `config.go` `Config.Validate()`, for each step: name non-empty, command non-empty, no two steps share the same name (keeps logs unambiguous). Surface errors at daemon startup with the `settings.temper.steps[i]` path.

## Tests

- **`internal/temper/temper_test.go`**:
  - `TestConfigFromSteps_BasicOrdering`: three steps, verify they appear in the output Config in input order.
  - `TestConfigFromSteps_RequiredDefault_True`: step without `required` field → `Optional: false` in output.
  - `TestConfigFromSteps_RequiredFalse_Optional`: step with `required: false` → `Optional: true`.
  - `TestConfigFromSteps_RespectsDir`: step with `dir: web` → `Step.Dir == "web"`.
  - `TestConfigFromSteps_RespectsTimeout`: step with `timeout: 10m` → `Step.Timeout == 10 * time.Minute`.
  - `TestConfigFromSteps_DefaultTimeout`: step with no `timeout` → `Step.Timeout == 5 * time.Minute`.
  - `TestConfigFromSteps_EmptyList_ReturnsNil`: empty slice → nil Config (caller falls back to auto-detection).
  - `TestConfigFromSteps_StopsOnRequiredFailure`: integration-ish — run a Config with three steps where the middle one is required and fails; assert the third step never executes. (Temper's `Run` loop already does this; this test pins the contract.)

- **`internal/config/config_test.go`**:
  - Yaml round-trip test covering a full `temper.steps` block with all optional fields set and unset.
  - Validation test: missing `name` → validation error.
  - Validation test: duplicate step names → validation error.

- **`internal/daemon/daemon_test.go`**:
  - `TestResolveTemperConfig_StepsOverridesSlots`: set both `steps` and `build`, assert `ConfigFromSteps` is used and a warning is logged (capture via test logger).

## Docs

Update `docs/configuration.md` — this is the most important part of the bead because the whole point of filing Forge-w8rb/lsj4/this is so the user can copy-paste from the docs.

### Custom Temper Commands section (`docs/configuration.md:239-275`)

Rewrite/expand the existing section to cover both forms:

1. **Shorthand (existing)**: keep the current `build`/`test`/`lint` table and examples. Add a sentence: "Use the shorthand when your project has a straightforward build→test→lint shape. For more complex pipelines, use the `steps` list below."

2. **New subsection: "Custom Temper Steps (advanced)"** — covers the `steps` form. Include:
   - The field table (copy from the Field semantics table above).
   - At least **four** copy-ready example blocks under a `### Examples` heading:

     **Example A — Node.js matching CI exactly**
     ```yaml
     anvils:
       my-node-app:
         path: /home/user/source/my-node-app
         temper:
           steps:
             - name: install
               command: npm
               args: [ci]
               dir: web
               timeout: 5m
             - name: lint
               command: npm
               args: [run, lint]
               dir: web
             - name: typecheck
               command: npm
               args: [run, typecheck]
               dir: web
             - name: build
               command: npm
               args: [run, build]
               dir: web
             - name: test
               command: npm
               args: [run, test:run]
               dir: web
     ```

     **Example B — Go + Node mixed monorepo** (e.g. Hytte-style)
     ```yaml
     anvils:
       hytte:
         path: /home/user/source/Hytte
         temper:
           steps:
             - name: go-build
               command: go
               args: [build, ./...]
             - name: go-vet
               command: go
               args: [vet, ./...]
             - name: go-test
               command: go
               args: [test, -short, ./...]
             - name: npm-install
               command: npm
               args: [ci]
               dir: web
               timeout: 5m
             - name: npm-lint
               command: npm
               args: [run, lint]
               dir: web
             - name: npm-build
               command: npm
               args: [run, build]
               dir: web
     ```

     **Example C — .NET with analyzers and format check**
     ```yaml
     anvils:
       my-dotnet-app:
         path: C:\\src\\my-dotnet-app
         temper:
           steps:
             - name: restore
               command: dotnet
               args: [restore]
             - name: format
               command: dotnet
               args: [format, --verify-no-changes, --no-restore]
             - name: build
               command: dotnet
               args: [build, --configuration, Release, --no-restore]
               timeout: 10m
             - name: test
               command: dotnet
               args: [test, --configuration, Release, --no-build, --logger, "trx;LogFileName=test.trx"]
               timeout: 15m
     ```

     **Example D — Python with advisory step**
     ```yaml
     anvils:
       my-python-lib:
         path: /home/user/source/my-python-lib
         temper:
           steps:
             - name: install
               command: pip
               args: [install, -e, ".[dev]"]
             - name: ruff
               command: ruff
               args: [check, .]
             - name: mypy
               command: mypy
               args: [src]
               required: false   # advisory — warn but don't block
             - name: test
               command: pytest
               args: [-q]
     ```

3. **Cross-reference** to the Pipeline Hooks section (`:169`) in case users want `before_temper` to run one-shot setup that persists across temper invocations (after Forge-w8rb lands).

### Full Example section (`docs/configuration.md:11-112`)

Add a `temper.steps` block to one of the existing example anvils (probably `my-frontend`, since it's the natural fit for the Node.js example):

```yaml
  my-frontend:
    path: /path/to/repos/my-frontend
    platform: gitlab
    max_smiths: 3
    auto_dispatch: tagged
    auto_dispatch_tag: forge-auto
    temper:
      steps:
        - { name: install,   command: npm, args: [ci],             dir: web, timeout: 5m }
        - { name: lint,      command: npm, args: [run, lint],      dir: web }
        - { name: typecheck, command: npm, args: [run, typecheck], dir: web }
        - { name: build,     command: npm, args: [run, build],     dir: web }
        - { name: test,      command: npm, args: [run, test:run],  dir: web }
```

The flow style (`{ key: value, ... }`) keeps the Full Example compact. The expanded block form lives in the Custom Temper Steps subsection for readability.

## Chain context

This bead lands **after** Forge-lsj4 (lint_required flag). The `steps` form supersedes the need for `lint_required` — each step has its own `required` flag. Landing them in this order means:

1. Forge-w8rb: hooks work uniformly (unlocks the `before_temper: npm ci` trick everywhere).
2. Forge-lsj4: quick incremental win for users who just want to enforce lint without migrating.
3. **This bead**: proper fix. Users on the `steps` form get per-step control and no longer need `lint_required` at all.

Keep `lint_required` as-is in this bead (don't deprecate or remove it) — the shorthand form and `lint_required` together are still the lowest-ceremony option for simple projects.

## Out of scope

- Deprecating or removing the `build`/`test`/`lint` shorthand. They stay.
- Supporting step parallelism (`parallel: true` on a step). Temper runs steps sequentially by design so failed step summaries are deterministic. Can be a follow-up bead.
- Step-level environment variable overrides (`env: { FOO: bar }`). Users can set env in `before_temper` hooks or via wrapper scripts. Can be a follow-up bead.
- Cross-step dependencies / DAG ordering. Sequential in config order is sufficient for all known use cases.
- Moving `temper.steps` into the per-repo `.forge/temper.yaml` file (currently that file only supports `go_race_detection`). Worth considering but a separate bead — it has config-location implications that deserve their own design discussion.

## Files touched

- `internal/config/config.go` — `TemperCommandsConfig.Steps`, new `TemperStepConfig` type, validation, `IsEmpty` update
- `internal/config/config_test.go` — yaml round-trip + validation tests
- `internal/temper/temper.go` — new `ConfigFromSteps` function
- `internal/temper/temper_test.go` — new tests for `ConfigFromSteps`
- `internal/daemon/daemon.go:4538-4543` — `resolveTemperConfig` dispatch logic
- `internal/daemon/daemon_test.go` — `resolveTemperConfig` precedence test
- `docs/configuration.md` — Custom Temper Commands section expansion, Full Example update
- `changelog.d/Forge-<id>.md` — Added category fragment

## Acceptance criteria

- A config with `temper.steps` defined runs each step in input order, fails the temper run on the first required step failure, and emits `temper_failed` with the failed step name.
- A step with `required: false` that fails is reported as a warning in the temper summary and does not fail the run.
- Both `temper.steps` and the legacy `temper.build`/`test`/`lint` shorthand can be used on different anvils in the same config file.
- Setting both `temper.steps` and any shorthand field on the same anvil logs a warning at daemon startup and uses `steps`.
- `docs/configuration.md` Custom Temper Commands section contains a `steps` subsection with at least four copy-ready examples (Node-only, Go+Node, .NET, Python).
- The Full Example at the top of `docs/configuration.md` demonstrates `temper.steps` on at least one anvil.

---
Bead: Forge-mycv | Branch: forge/Forge-mycv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)