### PR TITLE
Temper: skip steps when changed files don't match a configurable glob filter (Forge-p0sa)

### DIFF
--- a/changelog.d/Forge-p0sa.md
+++ b/changelog.d/Forge-p0sa.md
@@ -1,0 +1,2 @@
+category: Added
+- **Temper path-based step filtering** - Temper steps can now include an optional `paths` glob filter. When set, the step is skipped if no changed files in the diff match the patterns, saving time on multi-stack repos where not all steps are relevant to every change. (Forge-p0sa)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,6 +316,7 @@ For pipelines that need more than three steps, per-step working directories, or 
 | `dir` | string | worktree root | Working directory for the step. Relative paths resolve against the worktree; absolute paths used as-is. |
 | `timeout` | duration | `5m` | Per-step timeout. Same parsing as elsewhere in Forge config (`5m`, `30s`, `1h`). |
 | `required` | bool | `true` | When `true`, failure fails the whole temper run. When `false`, failure is reported as a warning. |
+| `paths` | `[]string` | `[]` (always run) | Glob patterns (doublestar syntax, e.g. `client/**`, `**/*.go`). When set, the step is skipped if no changed files in the PR diff match any pattern. When empty or omitted, the step always runs. |
 
 **Precedence:** If `temper.steps` is set and non-empty, it takes precedence over `temper.build`/`test`/`lint`. A warning is logged if both are present. If neither `steps` nor the shorthand fields are set, auto-detection applies as usual.
 
@@ -367,26 +368,34 @@ anvils:
         - name: go-build
           command: go
           args: [build, ./...]
+          paths: ["**/*.go", "go.mod", "go.sum"]
         - name: go-vet
           command: go
           args: [vet, ./...]
+          paths: ["**/*.go"]
         - name: go-test
           command: go
           args: [test, -short, ./...]
+          paths: ["**/*.go", "go.mod", "go.sum"]
         - name: npm-install
           command: npm
           args: [ci]
           dir: web
           timeout: 5m
+          paths: ["web/**"]
         - name: npm-lint
           command: npm
           args: [run, lint]
           dir: web
+          paths: ["web/**"]
         - name: npm-build
           command: npm
           args: [run, build]
           dir: web
+          paths: ["web/**"]
 ```
+
+When a PR only changes Go files, the npm steps are automatically skipped (and vice versa). Steps without `paths` always run.
 
 **.NET with analyzers and format check:**
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,6 +200,11 @@ type TemperStepConfig struct {
 	// Required controls whether failure fails the whole temper run.
 	// Pointer so we can distinguish unset (defaults to true) from explicit false.
 	Required *bool `mapstructure:"required" yaml:"required,omitempty"`
+	// Paths is an optional list of glob patterns (doublestar syntax, e.g.
+	// "client/**", "*.cs"). When set, the step is skipped if none of the
+	// changed files in the diff match any pattern. When empty or nil the
+	// step always runs (backward compatible).
+	Paths []string `mapstructure:"paths" yaml:"paths,omitempty"`
 }
 
 // IsEmpty returns true if no custom commands are configured.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1218,24 +1218,30 @@ func Run(ctx context.Context, p Params) *Outcome {
 		if p.DB != nil {
 			logIngotErr(workerID, "temper", ingot.UpdateIngotStatus(p.DB.Conn(), p.Bead.ID, p.AnvilName, ingot.StatusTemper))
 		}
-		temperCfg := p.TemperConfig
-		if temperCfg == nil {
-			detected := temper.DefaultConfigWithRace(wt.Path, temper.DetectOptionsFromAnvilFlag(p.AnvilConfig.GolangciLint), p.GoRaceDetection)
-			temperCfg = &detected
+		// Build a per-iteration copy of the temper config so we never mutate
+		// the shared p.TemperConfig and always have a fresh changed-file list.
+		var iterTemperCfg temper.Config
+		if p.TemperConfig != nil {
+			iterTemperCfg = *p.TemperConfig
+		} else {
+			iterTemperCfg = temper.DefaultConfigWithRace(wt.Path, temper.DetectOptionsFromAnvilFlag(p.AnvilConfig.GolangciLint), p.GoRaceDetection)
 		}
 
-		// Populate changed-file list for path-based step filtering.
-		// Use the worktree's base branch as the comparison ref so that
-		// all files in the PR are considered, not just the latest iteration.
-		if temperCfg.ChangedFiles == nil {
-			baseBranch := wt.BaseBranch
-			if baseBranch == "" {
-				baseBranch = "main"
+		// Recompute the changed-file list every iteration so that files added
+		// by Smith in later iterations are not silently missed by path filters.
+		// Resolve the base ref the same way as the worktree manager: try
+		// origin/main first, then fall back to origin/master.
+		baseRef := resolveTemperBaseRef(ctx, wt.Path, wt.BaseBranch)
+		if baseRef != "" {
+			changed, err := temper.ChangedFilesFromGit(ctx, wt.Path, baseRef)
+			if err != nil {
+				log.Printf("[pipeline:%s] Warning: could not compute changed files for path filtering: %v", workerID, err)
+			} else {
+				iterTemperCfg.ChangedFiles = changed
 			}
-			temperCfg.ChangedFiles = temper.ChangedFilesFromGit(wt.Path, "origin/"+baseBranch)
 		}
 
-		temperResult := runTemper(ctx, wt.Path, *temperCfg, p.DB, p.Bead.ID, p.AnvilName)
+		temperResult := runTemper(ctx, wt.Path, iterTemperCfg, p.DB, p.Bead.ID, p.AnvilName)
 		outcome.TemperResult = temperResult
 		recordIngotTemperResults(p.DB, workerID, p.Bead.ID, p.AnvilName, temperResult, ingotRec)
 
@@ -1501,6 +1507,24 @@ func gitRevParseHEAD(worktreePath string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// resolveTemperBaseRef returns the git ref to use as the base for computing
+// changed files for Temper path filtering. When baseBranch is set explicitly
+// it is used directly (as "origin/<baseBranch>"). Otherwise it mirrors the
+// worktree manager's auto-detection: try origin/main, then origin/master.
+// Returns an empty string if no valid ref is found.
+func resolveTemperBaseRef(ctx context.Context, worktreePath, baseBranch string) string {
+	if baseBranch != "" {
+		return "origin/" + baseBranch
+	}
+	for _, candidate := range []string{"origin/main", "origin/master"} {
+		cmd := executil.HideWindow(exec.CommandContext(ctx, "git", "-C", worktreePath, "rev-parse", "--verify", candidate))
+		if err := cmd.Run(); err == nil {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // hasEmptyDiff reports whether the worktree has no uncommitted changes and no

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1224,6 +1224,17 @@ func Run(ctx context.Context, p Params) *Outcome {
 			temperCfg = &detected
 		}
 
+		// Populate changed-file list for path-based step filtering.
+		// Use the worktree's base branch as the comparison ref so that
+		// all files in the PR are considered, not just the latest iteration.
+		if temperCfg.ChangedFiles == nil {
+			baseBranch := wt.BaseBranch
+			if baseBranch == "" {
+				baseBranch = "main"
+			}
+			temperCfg.ChangedFiles = temper.ChangedFilesFromGit(wt.Path, "origin/"+baseBranch)
+		}
+
 		temperResult := runTemper(ctx, wt.Path, *temperCfg, p.DB, p.Bead.ID, p.AnvilName)
 		outcome.TemperResult = temperResult
 		recordIngotTemperResults(p.DB, workerID, p.Bead.ID, p.AnvilName, temperResult, ingotRec)

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/state"
+	"github.com/bmatcuk/doublestar/v4"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,6 +40,9 @@ type StepResult struct {
 	// Optional mirrors the Step.Optional flag — failure here does not fail
 	// the overall check. Surfaced so summaries can render it distinctly.
 	Optional bool
+	// Skipped is true when the step was skipped because no changed files
+	// matched its Paths globs.
+	Skipped bool
 }
 
 // Result is the overall Temper verification result.
@@ -70,6 +75,9 @@ type Step struct {
 	Timeout time.Duration
 	// Optional means failure here doesn't fail the overall check.
 	Optional bool
+	// Paths is a list of glob patterns (doublestar syntax). When non-empty,
+	// the step is skipped if no changed files match any pattern.
+	Paths []string
 }
 
 // Config holds per-anvil verification configuration.
@@ -83,6 +91,11 @@ type Config struct {
 	// accordingly (e.g., via DefaultConfigWithRace). Default is false since
 	// -race slows tests and increases memory usage.
 	GoRaceDetection bool
+	// ChangedFiles is the list of file paths changed in the current diff
+	// (relative to the repository root). When non-nil, steps with Paths
+	// globs are checked against this list and skipped when no files match.
+	// A nil value means "unknown" and disables path-based filtering.
+	ChangedFiles []string
 }
 
 // DetectOptions controls optional steps during auto-detection.
@@ -207,6 +220,7 @@ func ConfigFromSteps(steps []config.TemperStepConfig) *Config {
 			Dir:      strings.TrimSpace(s.Dir),
 			Timeout:  timeout,
 			Optional: optional,
+			Paths:    s.Paths,
 		}
 	}
 	return &Config{Steps: out}
@@ -233,6 +247,44 @@ func DefaultConfigWithRace(worktreePath string, opts *DetectOptions, raceEnabled
 	}
 }
 
+// matchesChangedFiles returns true if any file in changedFiles matches any of
+// the given glob patterns (doublestar syntax). Returns true when patterns is
+// empty or nil (step always runs). Returns false when changedFiles is empty and
+// patterns is non-empty (nothing to match).
+func matchesChangedFiles(patterns, changedFiles []string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, f := range changedFiles {
+		for _, p := range patterns {
+			if ok, _ := doublestar.Match(p, f); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ChangedFilesFromGit returns the list of changed file paths (relative to the
+// repo root) by running "git diff --name-only <base>..HEAD" in the worktree.
+func ChangedFilesFromGit(worktreePath, baseBranch string) []string {
+	if baseBranch == "" {
+		return nil
+	}
+	cmd := executil.HideWindow(exec.Command("git", "-C", worktreePath, "diff", "--name-only", baseBranch+"..HEAD"))
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files
+}
+
 // Run executes all verification steps in sequence.
 // It stops on the first non-optional failure.
 // db, beadID, and anvil are used to log lifecycle events; db may be nil to skip logging.
@@ -245,6 +297,19 @@ func Run(ctx context.Context, worktreePath string, cfg Config, db *state.DB, bea
 	}
 
 	for _, step := range cfg.Steps {
+		// Skip steps whose path filters don't match any changed files.
+		if len(step.Paths) > 0 && cfg.ChangedFiles != nil && !matchesChangedFiles(step.Paths, cfg.ChangedFiles) {
+			log.Printf("[temper] Skipping step %q: no changed files match paths %v", step.Name, step.Paths)
+			result.Steps = append(result.Steps, StepResult{
+				Name:     step.Name,
+				Command:  fmt.Sprintf("%s %s", step.Command, strings.Join(step.Args, " ")),
+				Passed:   true,
+				Skipped:  true,
+				Optional: step.Optional,
+			})
+			continue
+		}
+
 		stepResult := runStep(ctx, worktreePath, step)
 		result.Steps = append(result.Steps, stepResult)
 
@@ -452,6 +517,8 @@ func buildSummary(r *Result) string {
 	for _, s := range r.Steps {
 		var status string
 		switch {
+		case s.Skipped:
+			status = "SKIP"
 		case s.Passed:
 			status = "PASS"
 		case s.Optional:

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -250,14 +250,20 @@ func DefaultConfigWithRace(worktreePath string, opts *DetectOptions, raceEnabled
 // matchesChangedFiles returns true if any file in changedFiles matches any of
 // the given glob patterns (doublestar syntax). Returns true when patterns is
 // empty or nil (step always runs). Returns false when changedFiles is empty and
-// patterns is non-empty (nothing to match).
+// patterns is non-empty (nothing to match). An invalid glob pattern is logged
+// and treated as a match so the step runs rather than being silently skipped.
 func matchesChangedFiles(patterns, changedFiles []string) bool {
 	if len(patterns) == 0 {
 		return true
 	}
 	for _, f := range changedFiles {
 		for _, p := range patterns {
-			if ok, _ := doublestar.Match(p, f); ok {
+			ok, err := doublestar.Match(p, f)
+			if err != nil {
+				log.Printf("[temper] invalid glob pattern %q: %v — treating as match", p, err)
+				return true
+			}
+			if ok {
 				return true
 			}
 		}
@@ -267,14 +273,16 @@ func matchesChangedFiles(patterns, changedFiles []string) bool {
 
 // ChangedFilesFromGit returns the list of changed file paths (relative to the
 // repo root) by running "git diff --name-only <base>..HEAD" in the worktree.
-func ChangedFilesFromGit(worktreePath, baseBranch string) []string {
+// It returns an error if git fails or times out, so callers can log a warning
+// and distinguish "no changes" from "couldn't compute changes".
+func ChangedFilesFromGit(ctx context.Context, worktreePath, baseBranch string) ([]string, error) {
 	if baseBranch == "" {
-		return nil
+		return nil, nil
 	}
-	cmd := executil.HideWindow(exec.Command("git", "-C", worktreePath, "diff", "--name-only", baseBranch+"..HEAD"))
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "git", "-C", worktreePath, "diff", "--name-only", baseBranch+"..HEAD"))
 	out, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("git diff --name-only %s..HEAD: %w", baseBranch, err)
 	}
 	var files []string
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
@@ -282,7 +290,7 @@ func ChangedFilesFromGit(worktreePath, baseBranch string) []string {
 			files = append(files, line)
 		}
 	}
-	return files
+	return files, nil
 }
 
 // Run executes all verification steps in sequence.

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -1,6 +1,7 @@
 package temper
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -436,4 +437,110 @@ func TestConfigFromSteps_RequiredByDefault(t *testing.T) {
 	for _, s := range cfg.Steps {
 		assert.False(t, s.Optional, "all steps should be required by default")
 	}
+}
+
+func TestConfigFromSteps_PropagatesPaths(t *testing.T) {
+	cfg := ConfigFromSteps([]config.TemperStepConfig{
+		{Name: "lint", Command: "npm", Args: []string{"run", "lint"}, Paths: []string{"client/**"}},
+		{Name: "build", Command: "dotnet", Args: []string{"build"}},
+	})
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 2)
+	assert.Equal(t, []string{"client/**"}, cfg.Steps[0].Paths)
+	assert.Nil(t, cfg.Steps[1].Paths)
+}
+
+func TestMatchesChangedFiles_EmptyPatterns_AlwaysMatches(t *testing.T) {
+	assert.True(t, matchesChangedFiles(nil, []string{"foo.go"}))
+	assert.True(t, matchesChangedFiles([]string{}, []string{"foo.go"}))
+}
+
+func TestMatchesChangedFiles_NoFiles_NoMatch(t *testing.T) {
+	assert.False(t, matchesChangedFiles([]string{"**/*.go"}, nil))
+	assert.False(t, matchesChangedFiles([]string{"**/*.go"}, []string{}))
+}
+
+func TestMatchesChangedFiles_DoublestarGlob(t *testing.T) {
+	files := []string{"client/src/app.tsx", "client/package.json", "README.md"}
+
+	assert.True(t, matchesChangedFiles([]string{"client/**"}, files))
+	assert.False(t, matchesChangedFiles([]string{"api/**"}, files))
+}
+
+func TestMatchesChangedFiles_ExtensionGlob(t *testing.T) {
+	files := []string{"internal/temper/temper.go", "internal/config/config.go"}
+
+	assert.True(t, matchesChangedFiles([]string{"**/*.go"}, files))
+	assert.False(t, matchesChangedFiles([]string{"**/*.cs"}, files))
+}
+
+func TestMatchesChangedFiles_MultiplePatterns(t *testing.T) {
+	files := []string{"docs/README.md"}
+
+	// Second pattern matches
+	assert.True(t, matchesChangedFiles([]string{"api/**", "docs/**"}, files))
+	// Neither matches
+	assert.False(t, matchesChangedFiles([]string{"api/**", "client/**"}, files))
+}
+
+func TestMatchesChangedFiles_ExactFile(t *testing.T) {
+	files := []string{"go.mod", "internal/temper/temper.go"}
+	assert.True(t, matchesChangedFiles([]string{"go.mod"}, files))
+	assert.False(t, matchesChangedFiles([]string{"go.sum"}, files))
+}
+
+func TestBuildSummary_SkippedStep(t *testing.T) {
+	r := &Result{
+		Steps: []StepResult{
+			{Name: "client-lint", Passed: true, Skipped: true},
+			{Name: "api-build", Passed: true, Duration: 2_000_000_000},
+		},
+		Passed: true,
+	}
+	summary := buildSummary(r)
+
+	assert.Contains(t, summary, "[SKIP] client-lint")
+	assert.Contains(t, summary, "[PASS] api-build")
+	assert.Contains(t, summary, "All required checks passed")
+}
+
+func TestRun_SkipsStepWhenPathsDontMatch(t *testing.T) {
+	cfg := Config{
+		Steps: []Step{
+			{Name: "always-run", Command: "echo", Args: []string{"hello"}, Timeout: 5 * time.Second},
+			{Name: "client-only", Command: "echo", Args: []string{"client"}, Timeout: 5 * time.Second, Paths: []string{"client/**"}},
+			{Name: "api-only", Command: "echo", Args: []string{"api"}, Timeout: 5 * time.Second, Paths: []string{"api/**"}},
+		},
+		ChangedFiles: []string{"api/main.go", "api/handler.go"},
+	}
+
+	result := Run(context.Background(), t.TempDir(), cfg, nil, "test-bead", "test-anvil")
+
+	require.Len(t, result.Steps, 3)
+	// "always-run" has no paths — runs normally
+	assert.False(t, result.Steps[0].Skipped)
+	assert.True(t, result.Steps[0].Passed)
+	// "client-only" has paths that don't match — skipped
+	assert.True(t, result.Steps[1].Skipped)
+	assert.True(t, result.Steps[1].Passed)
+	// "api-only" has paths that match — runs normally
+	assert.False(t, result.Steps[2].Skipped)
+	assert.True(t, result.Steps[2].Passed)
+
+	assert.True(t, result.Passed)
+}
+
+func TestRun_NilChangedFiles_NeverSkips(t *testing.T) {
+	cfg := Config{
+		Steps: []Step{
+			{Name: "with-paths", Command: "echo", Args: []string{"ok"}, Timeout: 5 * time.Second, Paths: []string{"nonexistent/**"}},
+		},
+		ChangedFiles: nil, // unknown — should not skip
+	}
+
+	result := Run(context.Background(), t.TempDir(), cfg, nil, "test-bead", "test-anvil")
+
+	require.Len(t, result.Steps, 1)
+	assert.False(t, result.Steps[0].Skipped, "step should not be skipped when ChangedFiles is nil")
+	assert.True(t, result.Steps[0].Passed)
 }


### PR DESCRIPTION
## Changes

- **Temper path-based step filtering** - Temper steps can now include an optional `paths` glob filter. When set, the step is skipped if no changed files in the diff match the patterns, saving time on multi-stack repos where not all steps are relevant to every change. (Forge-p0sa)

## Original Issue (feature): Temper: skip steps when changed files don't match a configurable glob filter

## Problem

Temper runs ALL configured steps on every pipeline run, regardless of which files were changed. A frontend-only PR still runs `dotnet build` and `dotnet test`; a backend-only PR still runs `npm run lint`, `npm run typecheck`, and `npm run build`. On repos with both .NET and Node.js this wastes minutes per run on steps that can't possibly fail.

## Proposed fix

Add an optional `glob` (or `paths`) field to each temper step definition. When set, temper checks the Smith diff (files changed vs base branch) against the glob patterns and skips the step if no changed files match.

Example config:

```yaml
temper:
  steps:
    - name: client-lint
      command: npm
      args: [run, lint]
      dir: client
      paths: ["client/**"]
    - name: client-typecheck
      command: npm
      args: [run, typecheck]
      dir: client
      paths: ["client/**"]
    - name: api-build
      command: dotnet
      args: [build, -c, Release]
      dir: api
      paths: ["api/**"]
    - name: api-test
      command: dotnet
      args: [test, -c, Release, --no-build, -v=q]
      dir: api
      paths: ["api/**"]
```

Behavior:
- If `paths` is omitted or empty: step always runs (current behavior, fully backward compatible)
- If `paths` is set: temper computes the changed-file list (git diff against base branch), matches each file against the glob patterns, and skips the step if zero files match — logging "skipped: no matching changed files" so the operator knows why
- Glob syntax should match gitignore/doublestar patterns (`**` for recursive, `*.cs` for extension, etc.)

## Implementation notes

- The diff file list is already available in the pipeline context (Smith produces it, and warden uses it). Temper just needs to receive it or compute it via `git diff --name-only <base>..HEAD`.
- Use Go's `doublestar` package (or `filepath.Match` if patterns are simple enough) for glob matching.
- The step-skip decision should be logged clearly so users can debug unexpected skips.
- For auto-detected steps (when no custom temper config exists), `paths` would not be set and all steps run as today — no behavior change for the default case.

---
Bead: Forge-p0sa | Branch: forge/Forge-p0sa
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)