### PR TITLE
Documentation update: CLAUDE.md, README, CLI help after feature batch (Forge-dmym)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ forge anvil list                      # List registered anvils
 forge anvil remove <name>             # Deregister an anvil
 forge queue list                      # Show queued beads
 forge queue run <id>                  # Manually dispatch a bead
-forge queue stop <id>                 # Kill worker, prevent re-dispatch
+forge queue stop <id> --anvil <name>  # Kill worker, prevent re-dispatch
 forge queue clarify <id>              # Mark bead as needing clarification
 forge queue unclarify <id>            # Clear clarification flag
 forge queue retry <id>                # Reset dispatch circuit breaker
@@ -46,7 +46,7 @@ forge ingots list                     # List ingot records (bead lifecycle)
 forge ingots show <id>                # Show ingot details with test results
 forge ledger                          # Open interactive bead management TUI
 forge quest list                      # List discovered E2E quests
-forge quest run <quest>               # Execute a quest and report results
+forge quest run <quest> --anvil <name>  # Execute a quest and report results
 forge wicket status                   # Show Wicket issue triage status
 forge scan                            # Run govulncheck on Go anvils
 forge scan --anvil <name>             # Scan a specific anvil
@@ -157,8 +157,8 @@ category: Fixed
 bd ready (poller) → pipeline.Run()
   → worktree.Create (git worktree add)
   → [before_schematic hook] → schematic.Analyze (optional) → [after_schematic hook]
-  → deny_patterns validation (file globs + command globs, resets on violation)
   → [before_smith hook] → smith.Spawn (claude CLI) → [after_smith hook]
+  → deny_patterns validation (file globs + command globs, resets on violation)
   → [before_temper hook] → temper.Run (build/test/lint) → [after_temper hook]
   → [before_warden hook] → warden.Review (second claude session) → [after_warden hook]
   → if request_changes: loop back to Smith (max max_review_attempts iterations)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,18 @@ forge anvil list                      # List registered anvils
 forge anvil remove <name>             # Deregister an anvil
 forge queue list                      # Show queued beads
 forge queue run <id>                  # Manually dispatch a bead
+forge queue stop <id>                 # Kill worker, prevent re-dispatch
 forge queue clarify <id>              # Mark bead as needing clarification
 forge queue unclarify <id>            # Clear clarification flag
 forge queue retry <id>                # Reset dispatch circuit breaker
 forge history                         # Show recent worker history
 forge history events                  # Show event log
+forge ingots list                     # List ingot records (bead lifecycle)
+forge ingots show <id>                # Show ingot details with test results
+forge ledger                          # Open interactive bead management TUI
+forge quest list                      # List discovered E2E quests
+forge quest run <quest>               # Execute a quest and report results
+forge wicket status                   # Show Wicket issue triage status
 forge scan                            # Run govulncheck on Go anvils
 forge scan --anvil <name>             # Scan a specific anvil
 forge autostart install               # Enable auto-start via Windows Task Scheduler
@@ -79,6 +86,7 @@ Forge is a **Go orchestrator daemon** that autonomously drives Claude Code agent
 | `internal/smith` | Spawns `claude` CLI as a subprocess in a worktree |
 | `internal/temper` | Runs build/lint/test checks; auto-detects Go, .NET, Node |
 | `internal/warden` | Code review agent — validates Smith's diff, learns rules from Copilot comments |
+| `internal/hooks` | Pipeline hook execution — shell commands before/after each stage |
 | `internal/bellows` | Monitors open PRs for CI failures, review comments, and merge conflicts |
 | `internal/crucible` | Orchestrates parent beads with children on feature branches — auto-detects, sequences, merges |
 | `internal/depcheck` | Multi-language dependency update scanner (Go, .NET, Node) — creates beads for outdated deps |
@@ -92,6 +100,9 @@ Forge is a **Go orchestrator daemon** that autonomously drives Claude Code agent
 | `internal/worktree` | Creates/removes `git worktree` branches for each bead |
 | `internal/state` | SQLite at `~/.forge/state.db` — workers, prs, events, retries, costs |
 | `internal/cost` | Token usage and USD cost tracking per bead and per day |
+| `internal/forge` | Core types and constants (version info) |
+| `internal/ingot` | Data model and persistence for ingots (bead lifecycle snapshots) |
+| `internal/ledger` | Interactive bead management TUI |
 | `internal/ipc` | Named pipe (Windows) / Unix socket daemon↔CLI protocol; newline-delimited JSON |
 | `internal/hearth` | Bubbletea TUI: three-column layout (Queue+Crucibles(when active)+ReadyToMerge+NeedsAttention / Workers / LiveActivity+Events) |
 | `internal/config` | Viper config loading — `forge.yaml` in cwd or `~/.forge/config.yaml` |
@@ -101,11 +112,16 @@ Forge is a **Go orchestrator daemon** that autonomously drives Claude Code agent
 | `internal/changelog` | Changelog fragment parsing and assembly |
 | `internal/lifecycle` | Worker lifecycle management |
 | `internal/retry` | Exponential backoff and retry logic |
+| `internal/questgiver` | E2E quest discovery and execution |
+| `internal/adventurer` | Headless browser quest executor (drives quest steps via rod) |
+| `internal/smelter` | Batches pending warden rules into PRs |
 | `internal/watchdog` | Stale worker detection |
 | `internal/hotreload` | fsnotify watcher — reloads `forge.yaml` without restart |
 | `internal/notify` | MS Teams Adaptive Card webhooks |
 | `internal/shutdown` | Graceful shutdown: SIGINT drain, orphan worktree cleanup |
 | `internal/autostart` | Windows Task Scheduler integration |
+| `internal/executil` | Platform-specific process execution |
+| `internal/worker` | Worker process abstraction |
 | `cmd/forge` | Cobra CLI — subcommands wired to daemon/state/ipc |
 
 ### Changelog Fragments
@@ -140,10 +156,11 @@ category: Fixed
 ```
 bd ready (poller) → pipeline.Run()
   → worktree.Create (git worktree add)
-  → schematic.Analyze (optional pre-analysis: plan, decompose, or skip)
-  → smith.Spawn (claude CLI subprocess, reads prompt from prompt.Builder)
-  → temper.Run (go build/vet/test or dotnet or npm)
-  → warden.Review (second claude session, reviews diff)
+  → [before_schematic hook] → schematic.Analyze (optional) → [after_schematic hook]
+  → deny_patterns validation (file globs + command globs, resets on violation)
+  → [before_smith hook] → smith.Spawn (claude CLI) → [after_smith hook]
+  → [before_temper hook] → temper.Run (build/test/lint) → [after_temper hook]
+  → [before_warden hook] → warden.Review (second claude session) → [after_warden hook]
   → if request_changes: loop back to Smith (max max_review_attempts iterations)
   → if approved: vcs.Provider.CreatePR (gh pr create)
   → bellows monitors open PRs (CI fix, review fix, rebase)
@@ -182,7 +199,7 @@ The daemon exposes a named pipe (Windows: `\\.\pipe\forge`) or Unix socket. Mess
 
 ### Configuration
 
-Config resolution order: `--config` flag → `./forge.yaml` → `~/.forge/config.yaml`. Environment variables override with `FORGE_` prefix (e.g. `FORGE_SETTINGS_MAX_TOTAL_SMITHS=4`). The daemon hot-reloads the config file on change via fsnotify. See [docs/configuration.md](docs/configuration.md) for the full settings reference including `daily_cost_limit`, `max_ci_fix_attempts`, `max_review_fix_attempts`, `max_rebase_attempts`, `smith_providers`, `merge_strategy`, `schematic_enabled`, `depcheck_interval`, and more.
+Config resolution order: `--config` flag → `./forge.yaml` → `~/.forge/config.yaml`. Environment variables override with `FORGE_` prefix (e.g. `FORGE_SETTINGS_MAX_TOTAL_SMITHS=4`). The daemon hot-reloads the config file on change via fsnotify. See [docs/configuration.md](docs/configuration.md) for the full settings reference including `daily_cost_limit`, `max_ci_fix_attempts`, `max_review_fix_attempts`, `max_rebase_attempts`, `stage_providers`, `merge_strategy`, `schematic_enabled`, `depcheck_interval`, per-anvil `hooks`, `smith.deny_patterns`, `temper` commands/steps, and more.
 
 ### Per-Anvil Smith Prompt Customization
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The Forge uses a blacksmith metaphor throughout:
 | **Crucible** | Epic orchestrator (parent-child beads on feature branches) |
 | **Depcheck** | Multi-language dependency update scanner (Go, .NET, Node) |
 | **Wicket**   | GitHub issue triage monitor — classifies issues and creates beads |
+| **Quench**   | CI failure fix worker — spawns Smith with targeted fix prompt |
+| **Burnish**  | Review comment fix worker — addresses PR review feedback |
+| **Smelter**  | Batches pending warden rules into PRs                    |
+| **QuestGiver** | E2E quest discovery and execution                      |
 | **Anvil**    | Repository workspace                                    |
 | **Heat**     | Work batch / session                                    |
 
@@ -32,6 +36,10 @@ The Forge uses a blacksmith metaphor throughout:
 │  ┌──────────┐ ┌──────────┐  ┌───────────┐           │
 │  │ Depcheck │ │ Crucible │  │ Watchdog  │           │
 │  │(dep scan)│ │(epics)   │  │(stale det)│           │
+│  └──────────┘ └──────────┘  └───────────┘           │
+│  ┌──────────┐ ┌──────────┐  ┌───────────┐           │
+│  │ Wicket  │ │ Smelter  │  │QuestGiver │           │
+│  │(triage) │ │(rules PR)│  │(E2E tests)│           │
 │  └──────────┘ └──────────┘  └───────────┘           │
 │        │            │              │                 │
 │        ▼            ▼              ▼                 │
@@ -101,6 +109,18 @@ anvils:
     path: C:\source\fhigit\Legacy
     auto_dispatch: priority
     auto_dispatch_min_priority: 1  # Only P0 and P1
+    smith:
+      deny_patterns:
+        files: ["*.env", "*.key"]       # Reject changes to sensitive files
+        commands: ["rm -rf /*"]         # Block dangerous commands
+    hooks:
+      before_temper: 'npm ci'           # Run before each temper invocation
+    temper:
+      steps:                            # Custom build/test/lint steps
+        - { name: build, command: npm, args: [run, build] }
+        - { name: test,  command: npm, args: [run, test] }
+    stage_providers:                    # Per-anvil provider overrides
+      smith: [claude/claude-opus-4-6]
 
 settings:
   poll_interval: 5m
@@ -168,6 +188,7 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ```
 bd ready → Claim bead → Create worktree → [Schematic (optional pre-analysis)]
+    → [hooks: before/after each stage] → deny_patterns validation
     → Smith (Claude) → Temper (build/test) → Warden (review)
     → PR creation → bd close → Bellows (monitor PR, CI fix, review fix, rebase)
 ```
@@ -209,6 +230,22 @@ forge warden list --anvil heimdall     # List learned rules
 forge warden forget <rule-id> --anvil heimdall  # Remove a rule
 ```
 
+### Pipeline Hooks
+
+Shell commands can run before or after each pipeline stage (Schematic, Smith, Temper, Warden). "Before" hooks abort on non-zero exit; "after" hooks are best-effort. Hooks receive pipeline context via environment variables (`FORGE_BEAD_ID`, `FORGE_WORKTREE_PATH`, `FORGE_BRANCH`, etc.). Configure per-anvil under `hooks`.
+
+### Smith Deny Patterns
+
+Restrict what files Smith can modify and what commands it can execute. File patterns are matched against the git diff; command patterns are matched against bash commands in Smith's output. Violations reset the worktree and retry with feedback. Configure per-anvil under `smith.deny_patterns`.
+
+### Custom Temper Commands
+
+Override auto-detected build/test/lint with custom commands via the `temper` per-anvil config. Use the shorthand (`build`/`test`/`lint`) for simple cases, or `temper.steps` for ordered multi-step pipelines with per-step timeouts and required/optional control.
+
+### Per-Stage Providers
+
+Use `stage_providers` (global or per-anvil) to assign different AI providers to each pipeline stage: `smith`, `warden`, `schematic`, `cifix`, `reviewfix`. Fallback chain: anvil `stage_providers` → global `stage_providers` → `smith_providers` (deprecated) → `providers`.
+
 ### Cost Tracking
 
 Token usage and USD cost estimates are tracked per-bead and per-day. Set `daily_cost_limit` to automatically pause auto-dispatch when the daily budget is exceeded. View current costs via `forge status`.
@@ -238,6 +275,7 @@ Forge/
 ├── cmd/forge/            # CLI entry point (Cobra commands)
 │   └── main.go
 ├── internal/
+│   ├── adventurer/       # Headless browser quest executor
 │   ├── bellows/          # PR monitoring (CI fix, review fix, rebase)
 │   ├── changelog/        # Changelog fragment parsing & assembly
 │   ├── quench/           # CI failure fix worker (quench)
@@ -247,27 +285,34 @@ Forge/
 │   ├── daemon/           # Main background process, poll loop, IPC server
 │   ├── depcheck/         # Multi-language dependency update scanner
 │   ├── executil/         # Platform-specific process execution
+│   ├── forge/            # Core types and constants (version info)
 │   ├── vcs/              # VCS provider interface & GitHub implementation
 │   ├── hearth/           # Bubbletea TUI dashboard
+│   ├── hooks/            # Pipeline hook execution (before/after each stage)
 │   ├── hotreload/        # fsnotify config watcher
+│   ├── ingot/            # Ingot data model & persistence (bead lifecycle)
 │   ├── ipc/              # Named pipe / Unix socket protocol
+│   ├── ledger/           # Interactive bead management TUI
 │   ├── lifecycle/        # Worker lifecycle management
 │   ├── notify/           # MS Teams webhook notifications
 │   ├── pipeline/         # Smith → Temper → Warden orchestration
 │   ├── poller/           # bd ready integration & Crucible detection
 │   ├── prompt/           # Smith prompt builder
 │   ├── provider/         # AI provider fallback chain
+│   ├── questgiver/       # E2E quest discovery & execution
 │   ├── rebase/           # Conflict rebase handling
 │   ├── retry/            # Exponential backoff & retry logic
 │   ├── burnish/          # Review comment fix worker (burnish)
 │   ├── schematic/        # Pre-analysis worker (decompose complex beads)
 │   ├── shutdown/         # Graceful shutdown & orphan cleanup
+│   ├── smelter/          # Batches pending warden rules into PRs
 │   ├── smith/            # Claude Code worker spawning & lifecycle
 │   ├── state/            # SQLite state management (WAL mode)
 │   ├── temper/           # Build/lint/test verification (Go, .NET, Node)
 │   ├── vulncheck/        # Vulnerability scanning (govulncheck)
 │   ├── warden/           # Code review agent & rule learning
 │   ├── watchdog/         # Stale worker detection
+│   ├── wicket/           # GitHub issue triage monitor
 │   ├── worker/           # Worker process abstraction
 │   └── worktree/         # Git worktree creation/removal
 ├── docs/                 # Reference documentation

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ See [docs/configuration.md](docs/configuration.md) for the full reference.
 
 ```
 bd ready → Claim bead → Create worktree → [Schematic (optional pre-analysis)]
-    → [hooks: before/after each stage] → deny_patterns validation
-    → Smith (Claude) → Temper (build/test) → Warden (review)
+    → [hooks: before/after each stage] → Smith (Claude)
+    → deny_patterns validation → Temper (build/test) → Warden (review)
     → PR creation → bd close → Bellows (monitor PR, CI fix, review fix, rebase)
 ```
 
@@ -244,7 +244,7 @@ Override auto-detected build/test/lint with custom commands via the `temper` per
 
 ### Per-Stage Providers
 
-Use `stage_providers` (global or per-anvil) to assign different AI providers to each pipeline stage: `smith`, `warden`, `schematic`, `cifix`, `reviewfix`. Fallback chain: anvil `stage_providers` → global `stage_providers` → `smith_providers` (deprecated) → `providers`.
+Use `stage_providers` (global or per-anvil) to assign different AI providers to each pipeline stage: `smith`, `warden`, `schematic`, `cifix`, `reviewfix`. Fallback chain for `smith`, `warden`, and `schematic`: anvil `stage_providers` → global `stage_providers` → `smith_providers` (deprecated) → `providers`. For `cifix` and `reviewfix`: anvil `stage_providers` → global `stage_providers` → `providers`.
 
 ### Cost Tracking
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,8 @@ settings:
   auto_learn_rules: true
   smelter_enabled: true
   smelter_interval: 8h
+  questgiver_enabled: false
+  questgiver_interval: 24h
   crucible_enabled: true
   auto_merge_crucible_children: true
 
@@ -136,6 +138,7 @@ Each key under `anvils` is the anvil name. The name is used in CLI output, logs,
 | `temper` | object\|null | null (auto-detect) | Custom Temper commands for this anvil. When set, replaces auto-detected build/test/lint steps. See [Custom Temper Commands](#custom-temper-commands) below. |
 | `depcheck_enabled` | bool\|null | null (enabled) | Per-anvil toggle for depcheck scanning. When null, depcheck runs as normal. Set to `false` to skip this anvil entirely. |
 | `auto_merge` | bool | `false` | When enabled, PRs that reach the ready-to-merge state (CI passing, no conflicts, no unresolved threads, no pending reviews) are automatically merged using the configured `merge_strategy`. External PRs (`ext-*`) are never auto-merged. |
+| `questgiver_enabled` | bool\|null | null (use global) | Per-anvil override for QuestGiver E2E quest scanning. When null, uses `settings.questgiver_enabled`. Set to `false` to opt this anvil out entirely. |
 | `questgiver_setup_cmd` | string | | Shell command to run before executing quests for this anvil (e.g. `"podman compose up -d"`). Runs in the anvil's root directory. If the command fails, quest execution is aborted. Used by `forge quest run` and the QuestGiver monitor. |
 | `questgiver_teardown_cmd` | string | | Shell command to run after executing quests for this anvil (e.g. `"podman compose down"`). Runs in the anvil's root directory. Always runs even if quests fail; teardown failures are logged as warnings rather than errors. |
 | `wicket_enabled` | bool\|null | null (use global) | Per-anvil override for Wicket issue triage scanning. When null, uses `settings.wicket_enabled`. Set to `false` to opt this anvil out entirely. |
@@ -478,6 +481,8 @@ anvils:
 | `smelter_interval` | duration | `8h` | `1h` or `0` | How often the Smelter runs its background processing. `0` disables scheduled runs. The Smelter skips the startup run if it already flushed within this interval, so daemon restarts don't produce redundant PRs. For low-volume setups where warden rules accumulate slowly, `48h` or `72h` is a reasonable value. |
 | `crucible_enabled` | bool | `false` | | Enable Crucible auto-orchestration for parent beads with children. When a ready bead blocks other beads, the Crucible creates a feature branch, dispatches children in topological order, merges each child PR, then creates a final PR to main. |
 | `auto_merge_crucible_children` | bool | `true` | | Auto-merge child PRs targeting a Crucible feature branch after the pipeline succeeds. Set to `false` to require manual merge of child PRs. |
+| `questgiver_enabled` | bool | `false` | | Enable the QuestGiver E2E quest monitor globally. When false, no quest scanning occurs. |
+| `questgiver_interval` | duration | `24h` | `0` | How often the QuestGiver polls anvils for quests. `0` disables. |
 | `wicket_enabled` | bool | `false` | | Enable the Wicket GitHub issue triage monitor globally. When false, no issue scanning occurs. |
 | `wicket_interval` | duration | `15m` | `1m` or `0` | How often Wicket polls repositories for new issues. `0` disables. |
 | `wicket_provider` | string | `""` (uses `providers`) | | AI provider used for triage decisions. When empty, the global `providers` chain is used. |
@@ -715,6 +720,8 @@ Environment variables with the `FORGE_` prefix override YAML values. Nested keys
 | `FORGE_SETTINGS_GO_RACE_DETECTION` | `settings.go_race_detection` |
 | `FORGE_SETTINGS_CRUCIBLE_ENABLED` | `settings.crucible_enabled` |
 | `FORGE_SETTINGS_AUTO_MERGE_CRUCIBLE_CHILDREN` | `settings.auto_merge_crucible_children` |
+| `FORGE_SETTINGS_QUESTGIVER_ENABLED` | `settings.questgiver_enabled` |
+| `FORGE_SETTINGS_QUESTGIVER_INTERVAL` | `settings.questgiver_interval` |
 | `FORGE_SETTINGS_WICKET_ENABLED` | `settings.wicket_enabled` |
 | `FORGE_SETTINGS_WICKET_INTERVAL` | `settings.wicket_interval` |
 | `FORGE_SETTINGS_WICKET_PROVIDER` | `settings.wicket_provider` |
@@ -746,6 +753,7 @@ The config is validated at load time. Errors are reported as a list:
 - `daily_cost_limit` must be a non-negative finite number
 - `stale_interval` must be >= 30s when enabled, or 0 to disable
 - `smelter_interval` must be >= 1h when enabled, or 0 to disable
+- `questgiver_interval` must be > 0 when questgiver is enabled, or 0 to disable
 - `depcheck_interval` must be >= 1h when enabled, or 0 to disable
 - `depcheck_timeout` must not be negative
 - Each anvil `path` must be non-empty


### PR DESCRIPTION
## Changes

Documentation-only update that accurately adds missing CLI commands, component map entries, and config keys to match recently landed features.

## Original Issue (chore): Documentation update: CLAUDE.md, README, CLI help after feature batch

After the pipeline hooks, deny patterns, custom temper, per-stage providers, and package rename beads land, update all documentation:

1. CLAUDE.md — update component map, config reference, CLI quick reference
2. README.md — update feature list if applicable
3. docs/configuration.md — add new config keys (deny_patterns, temper_commands, hooks, stage providers)
4. CLI help text — verify forge doctor, forge status reflect new features
5. Verify all internal/package references are consistent after the quench/burnish rename

This should be the final bead in the chain to ensure docs match the code.

---
Bead: Forge-dmym | Branch: forge/Forge-dmym
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)