### PR TITLE
Worktree: auto-junction client/node_modules from main checkout (Forge-jqyw)

### DIFF
--- a/changelog.d/Forge-jqyw.md
+++ b/changelog.d/Forge-jqyw.md
@@ -1,0 +1,2 @@
+category: Added
+- **Auto-link node_modules in worktrees** - After creating a git worktree, Forge now automatically symlinks (or creates junctions on Windows) node_modules directories from the main checkout into the worktree. This eliminates the need for npm ci during temper for Node.js projects. (Forge-jqyw)

--- a/internal/worktree/junction_unix.go
+++ b/internal/worktree/junction_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package worktree
+
+// createJunction is a no-op on Unix — the caller uses os.Symlink directly.
+// This stub exists only to satisfy the compiler on non-Windows platforms;
+// createDirLink never calls it when runtime.GOOS != "windows".
+func createJunction(src, dst string) error {
+	panic("createJunction called on non-Windows platform")
+}

--- a/internal/worktree/junction_windows.go
+++ b/internal/worktree/junction_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package worktree
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// createJunction creates an NTFS junction from dst pointing to src.
+// Junctions do not require elevated privileges (unlike symlinks on Windows)
+// and are transparent to all file I/O.
+func createJunction(src, dst string) error {
+	// mklink /J creates a directory junction — no admin rights needed.
+	cmd := exec.Command("cmd", "/C", "mklink", "/J", dst, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("mklink /J %s %s: %s: %w", dst, src, out, err)
+	}
+	return nil
+}

--- a/internal/worktree/junction_windows.go
+++ b/internal/worktree/junction_windows.go
@@ -5,6 +5,8 @@ package worktree
 import (
 	"fmt"
 	"os/exec"
+
+	"github.com/Robin831/Forge/internal/executil"
 )
 
 // createJunction creates an NTFS junction from dst pointing to src.
@@ -12,7 +14,7 @@ import (
 // and are transparent to all file I/O.
 func createJunction(src, dst string) error {
 	// mklink /J creates a directory junction — no admin rights needed.
-	cmd := exec.Command("cmd", "/C", "mklink", "/J", dst, src)
+	cmd := executil.HideWindow(exec.Command("cmd", "/C", "mklink", "/J", dst, src))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("mklink /J %s %s: %s: %w", dst, src, out, err)
 	}

--- a/internal/worktree/nodemodules.go
+++ b/internal/worktree/nodemodules.go
@@ -34,6 +34,8 @@ func linkNodeModules(anvilPath, worktreePath string) error {
 		// If the destination already exists (dir, symlink, or junction), skip.
 		if _, err := os.Lstat(dstNM); err == nil {
 			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("checking existing node_modules destination %s: %w", sub, err)
 		}
 
 		// Ensure the parent directory exists in the worktree. For root-level

--- a/internal/worktree/nodemodules.go
+++ b/internal/worktree/nodemodules.go
@@ -1,0 +1,60 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// nodeModulesDirs is the list of directories where a Node.js project might
+// have a node_modules folder. An empty string means the repository root.
+// This mirrors the subdirectories checked by temper's detectNodeDirs.
+var nodeModulesDirs = []string{"", "web", "frontend", "client", "app", "ui"}
+
+// linkNodeModules creates symlinks (or junctions on Windows) from the
+// worktree's node_modules directories to the corresponding directories in
+// the main anvil checkout. This allows Smiths to run npm scripts without
+// a fresh npm ci, since the main checkout already has node_modules populated.
+//
+// Only directories where the main checkout has a node_modules are linked.
+// If the worktree already has a node_modules (e.g. from a reused worktree),
+// the existing directory is left untouched.
+func linkNodeModules(anvilPath, worktreePath string) error {
+	for _, sub := range nodeModulesDirs {
+		srcNM := filepath.Join(anvilPath, sub, "node_modules")
+		info, err := os.Stat(srcNM)
+		if err != nil || !info.IsDir() {
+			continue // no node_modules in the main checkout at this path
+		}
+
+		dstParent := filepath.Join(worktreePath, sub)
+		dstNM := filepath.Join(dstParent, "node_modules")
+
+		// If the destination already exists (dir, symlink, or junction), skip.
+		if _, err := os.Lstat(dstNM); err == nil {
+			continue
+		}
+
+		// Ensure the parent directory exists in the worktree. For root-level
+		// node_modules this is always true, but subdirectories like "client/"
+		// might not be checked out yet if they are empty.
+		if err := os.MkdirAll(dstParent, 0o755); err != nil {
+			return fmt.Errorf("creating parent dir for node_modules link %s: %w", sub, err)
+		}
+
+		if err := createDirLink(srcNM, dstNM); err != nil {
+			return fmt.Errorf("linking node_modules %s: %w", sub, err)
+		}
+	}
+	return nil
+}
+
+// createDirLink creates a directory symlink (Unix) or junction (Windows)
+// pointing from dst to src.
+func createDirLink(src, dst string) error {
+	if runtime.GOOS == "windows" {
+		return createJunction(src, dst)
+	}
+	return os.Symlink(src, dst)
+}

--- a/internal/worktree/nodemodules_test.go
+++ b/internal/worktree/nodemodules_test.go
@@ -1,0 +1,166 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestLinkNodeModules_RootLevel(t *testing.T) {
+	anvilPath := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// Create node_modules in the anvil root.
+	srcNM := filepath.Join(anvilPath, "node_modules")
+	if err := os.Mkdir(srcNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Place a marker file so we can verify the link target.
+	if err := os.WriteFile(filepath.Join(srcNM, "marker.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+		t.Fatalf("linkNodeModules: %v", err)
+	}
+
+	dstNM := filepath.Join(worktreePath, "node_modules")
+	// Verify the link exists and is a symlink (Unix) or junction (Windows).
+	info, err := os.Lstat(dstNM)
+	if err != nil {
+		t.Fatalf("Lstat %s: %v", dstNM, err)
+	}
+	if runtime.GOOS != "windows" {
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected symlink, got %v", info.Mode())
+		}
+	}
+
+	// Verify we can read through the link.
+	data, err := os.ReadFile(filepath.Join(dstNM, "marker.txt"))
+	if err != nil {
+		t.Fatalf("reading through link: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("unexpected content: %q", data)
+	}
+}
+
+func TestLinkNodeModules_Subdirectory(t *testing.T) {
+	anvilPath := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// Create client/node_modules in the anvil.
+	srcNM := filepath.Join(anvilPath, "client", "node_modules")
+	if err := os.MkdirAll(srcNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcNM, "marker.txt"), []byte("client"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the client/ dir in the worktree (as git would).
+	if err := os.MkdirAll(filepath.Join(worktreePath, "client"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+		t.Fatalf("linkNodeModules: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(worktreePath, "client", "node_modules", "marker.txt"))
+	if err != nil {
+		t.Fatalf("reading through link: %v", err)
+	}
+	if string(data) != "client" {
+		t.Fatalf("unexpected content: %q", data)
+	}
+}
+
+func TestLinkNodeModules_SkipsExisting(t *testing.T) {
+	anvilPath := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// Create node_modules in both anvil and worktree.
+	srcNM := filepath.Join(anvilPath, "node_modules")
+	if err := os.Mkdir(srcNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcNM, "marker.txt"), []byte("anvil"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dstNM := filepath.Join(worktreePath, "node_modules")
+	if err := os.Mkdir(dstNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dstNM, "marker.txt"), []byte("worktree"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+		t.Fatalf("linkNodeModules: %v", err)
+	}
+
+	// Should not have been replaced.
+	data, err := os.ReadFile(filepath.Join(dstNM, "marker.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "worktree" {
+		t.Fatalf("existing node_modules was replaced: got %q", data)
+	}
+}
+
+func TestLinkNodeModules_NoNodeModules(t *testing.T) {
+	anvilPath := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// No node_modules anywhere — should be a no-op.
+	if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+		t.Fatalf("linkNodeModules: %v", err)
+	}
+
+	entries, err := os.ReadDir(worktreePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty worktree dir, got %d entries", len(entries))
+	}
+}
+
+func TestLinkNodeModules_MultipleSubdirs(t *testing.T) {
+	anvilPath := t.TempDir()
+	worktreePath := t.TempDir()
+
+	// Create node_modules in web/ and client/.
+	for _, sub := range []string{"web", "client"} {
+		srcNM := filepath.Join(anvilPath, sub, "node_modules")
+		if err := os.MkdirAll(srcNM, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(srcNM, "id.txt"), []byte(sub), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Create parent dir in worktree.
+		if err := os.MkdirAll(filepath.Join(worktreePath, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+		t.Fatalf("linkNodeModules: %v", err)
+	}
+
+	for _, sub := range []string{"web", "client"} {
+		data, err := os.ReadFile(filepath.Join(worktreePath, sub, "node_modules", "id.txt"))
+		if err != nil {
+			t.Fatalf("reading %s link: %v", sub, err)
+		}
+		if string(data) != sub {
+			t.Fatalf("%s: unexpected content: %q", sub, data)
+		}
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -135,6 +135,12 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 			}
 			_ = git(worktreePath, "checkout", "--force", "HEAD")
 			_ = git(worktreePath, "clean", "-fd")
+			// Re-link node_modules — git clean -fd removes untracked symlinks.
+			if !opts.LocalHead {
+				if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to link node_modules: %v\n", err)
+				}
+			}
 			return &Worktree{Path: worktreePath, Branch: targetBranch}, nil
 		}
 		// Not a valid worktree — remove the stale directory.
@@ -221,6 +227,16 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 	if err := installBeadsRedirect(anvilPath, worktreePath); err != nil {
 		// Non-fatal: log but don't fail the worktree creation
 		fmt.Fprintf(os.Stderr, "Warning: failed to install .beads/redirect: %v\n", err)
+	}
+
+	// Link node_modules from the main checkout so Smiths can run npm scripts
+	// without a fresh npm ci. Skip for LocalHead (scan-only) worktrees where
+	// the anvil path IS the worktree and linking would be circular.
+	if !opts.LocalHead {
+		if err := linkNodeModules(anvilPath, worktreePath); err != nil {
+			// Non-fatal: temper will fall back to npm ci if needed
+			fmt.Fprintf(os.Stderr, "Warning: failed to link node_modules: %v\n", err)
+		}
 	}
 
 	return &Worktree{

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -234,7 +234,8 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 	// the anvil path IS the worktree and linking would be circular.
 	if !opts.LocalHead {
 		if err := linkNodeModules(anvilPath, worktreePath); err != nil {
-			// Non-fatal: temper will fall back to npm ci if needed
+			// Non-fatal: later temper Node steps may fail if dependencies are not
+			// already present or installed by another component/user.
 			fmt.Fprintf(os.Stderr, "Warning: failed to link node_modules: %v\n", err)
 		}
 	}


### PR DESCRIPTION
## Changes

- **Auto-link node_modules in worktrees** - After creating a git worktree, Forge now automatically symlinks (or creates junctions on Windows) node_modules directories from the main checkout into the worktree. This eliminates the need for npm ci during temper for Node.js projects. (Forge-jqyw)

## Original Issue (feature): Worktree: auto-junction client/node_modules from main checkout

After git worktree add, create a Windows junction from worktree client/node_modules to main checkout client/node_modules. Eliminates npm ci in temper. See forgeLocal/node-modules-junction-worktree.md for full design.

---
Bead: Forge-jqyw | Branch: forge/Forge-jqyw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)