### PR TITLE
Include external_ref (GitHub issue number) in Smith prompt so PRs include Closes #N (Forge-pqrw)

### DIFF
--- a/changelog.d/Forge-pqrw.md
+++ b/changelog.d/Forge-pqrw.md
@@ -1,2 +1,2 @@
 category: Fixed
-- **Include external_ref in Smith prompt** - Pass the GitHub issue URL (external_ref) from bead metadata through to the Smith prompt so generated PRs can include `Closes #N` without Smith needing to run extra commands. (Forge-pqrw)
+- **Include external_ref in Smith prompt** - Pass the external reference (`external_ref`) from bead metadata through to the Smith prompt so generated PRs can include closing references without Smith needing to run extra commands. (Forge-pqrw)

--- a/changelog.d/Forge-pqrw.md
+++ b/changelog.d/Forge-pqrw.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Include external_ref in Smith prompt** - Pass the GitHub issue URL (external_ref) from bead metadata through to the Smith prompt so generated PRs can include `Closes #N` without Smith needing to run extra commands. (Forge-pqrw)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -647,6 +647,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 		IssueType:           p.Bead.IssueType,
 		Priority:            p.Bead.Priority,
 		Parent:              p.Bead.Parent,
+		ExternalRef:         p.Bead.ExternalRef,
 		Branch:              wt.Branch,
 		AnvilName:           p.AnvilName,
 		AnvilPath:           p.AnvilConfig.Path,

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -34,6 +34,7 @@ type Bead struct {
 	DependsOn      []string  `json:"depends_on"`     // Bead IDs that this bead depends on
 	Dependencies   []BeadDep `json:"dependencies"`   // Detailed dependency info from bd
 	DependentCount int       `json:"dependent_count"` // Number of beads that depend on this bead
+	ExternalRef    string    `json:"external_ref"`    // GitHub issue URL (e.g. https://github.com/org/repo/issues/42)
 
 	// Forge-injected: which anvil this bead belongs to
 	Anvil string `json:"-"`

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -34,7 +34,7 @@ type Bead struct {
 	DependsOn      []string  `json:"depends_on"`     // Bead IDs that this bead depends on
 	Dependencies   []BeadDep `json:"dependencies"`   // Detailed dependency info from bd
 	DependentCount int       `json:"dependent_count"` // Number of beads that depend on this bead
-	ExternalRef    string    `json:"external_ref"`    // GitHub issue URL (e.g. https://github.com/org/repo/issues/42)
+	ExternalRef    string    `json:"external_ref"`    // External tracker reference from bd (for example "gh-42", a full URL, or another non-GitHub ref)
 
 	// Forge-injected: which anvil this bead belongs to
 	Anvil string `json:"-"`

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -53,8 +53,11 @@ type BeadContext struct {
 	// Included in the prompt on iteration 2+ so Smith can see what it
 	// already implemented without re-exploring the codebase.
 	PriorDiff string
-	// ExternalRef is the GitHub issue URL (e.g. https://github.com/org/repo/issues/42).
-	// When set, Smith is instructed to include "Closes #N" in the PR body.
+	// ExternalRef is an optional external issue/tracker reference for the bead.
+	// Accepted formats may include GitHub shorthand like "gh-42", a full issue URL
+	// such as "https://github.com/org/repo/issues/42", or non-GitHub references
+	// like "jira-123". Prompt/template guidance should only use GitHub closing
+	// keywords when the reference is explicitly a GitHub issue.
 	ExternalRef string
 	// CopilotCombinedMode, when true, appends a self-review checklist to
 	// the prompt so Smith reviews its own diff against Warden criteria.
@@ -195,7 +198,7 @@ implementation is correct. Focus only on fixing the specific issues above.
 **Parent**: {{.Bead.Parent}}
 {{- end}}
 {{- if .Bead.ExternalRef}}
-**GitHub Issue**: {{.Bead.ExternalRef}} — include ` + "`" + `Closes #N` + "`" + ` in your PR body (where N is the issue number from this URL)
+**External Reference**: {{.Bead.ExternalRef}} — if this is a GitHub issue (e.g. a URL like https://github.com/org/repo/issues/42 or a shorthand like "gh-42"), include ` + "`" + `Closes #N` + "`" + ` in your PR body with the issue number. For non-GitHub references (e.g. "jira-123"), omit the closing keyword.
 {{- end}}
 
 ### Description

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -53,6 +53,9 @@ type BeadContext struct {
 	// Included in the prompt on iteration 2+ so Smith can see what it
 	// already implemented without re-exploring the codebase.
 	PriorDiff string
+	// ExternalRef is the GitHub issue URL (e.g. https://github.com/org/repo/issues/42).
+	// When set, Smith is instructed to include "Closes #N" in the PR body.
+	ExternalRef string
 	// CopilotCombinedMode, when true, appends a self-review checklist to
 	// the prompt so Smith reviews its own diff against Warden criteria.
 	CopilotCombinedMode bool
@@ -190,6 +193,9 @@ implementation is correct. Focus only on fixing the specific issues above.
 **Type**: {{.Bead.IssueType}} | **Priority**: {{.Bead.Priority}}
 {{- if .Bead.Parent}}
 **Parent**: {{.Bead.Parent}}
+{{- end}}
+{{- if .Bead.ExternalRef}}
+**GitHub Issue**: {{.Bead.ExternalRef}} — include ` + "`" + `Closes #N` + "`" + ` in your PR body (where N is the issue number from this URL)
 {{- end}}
 
 ### Description

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -241,3 +241,68 @@ func TestBuild_CombinedModeWithLoadedWardenRules(t *testing.T) {
 	assert.Contains(t, result, "No unresolved TODOs in production code")
 	assert.Contains(t, result, "pattern: password|secret")
 }
+
+func TestBuild_ExternalRefRenderedWhenSet(t *testing.T) {
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-extref",
+		Title:        "Test bead with external ref",
+		Description:  "Do the thing",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-extref",
+		AnvilName:    "test-anvil",
+		AnvilPath:    t.TempDir(),
+		WorktreePath: t.TempDir(),
+		ExternalRef:  "https://github.com/org/repo/issues/42",
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "**External Reference**")
+	assert.Contains(t, result, "https://github.com/org/repo/issues/42")
+}
+
+func TestBuild_ExternalRefGhShorthandRendered(t *testing.T) {
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-extref-gh",
+		Title:        "Test bead with gh shorthand",
+		Description:  "Do the thing",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-extref-gh",
+		AnvilName:    "test-anvil",
+		AnvilPath:    t.TempDir(),
+		WorktreePath: t.TempDir(),
+		ExternalRef:  "gh-42",
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "**External Reference**")
+	assert.Contains(t, result, "gh-42")
+}
+
+func TestBuild_ExternalRefOmittedWhenEmpty(t *testing.T) {
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-no-extref",
+		Title:        "Test bead without external ref",
+		Description:  "Do the thing",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-no-extref",
+		AnvilName:    "test-anvil",
+		AnvilPath:    t.TempDir(),
+		WorktreePath: t.TempDir(),
+		ExternalRef:  "",
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	assert.NotContains(t, result, "**External Reference**")
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -132,6 +132,7 @@ func (w *Worker) Run(ctx context.Context, extraFlags []string) (*smith.Result, e
 		IssueType:    w.Bead.IssueType,
 		Priority:     w.Bead.Priority,
 		Parent:       w.Bead.Parent,
+		ExternalRef:  w.Bead.ExternalRef,
 		Branch:       wt.Branch,
 		AnvilName:    w.AnvilName,
 		AnvilPath:    w.AnvilConfig.Path,


### PR DESCRIPTION
## Changes

- **Include external_ref in Smith prompt** - Pass the GitHub issue URL (external_ref) from bead metadata through to the Smith prompt so generated PRs can include `Closes #N` without Smith needing to run extra commands. (Forge-pqrw)

## Original Issue (bug): Include external_ref (GitHub issue number) in Smith prompt so PRs include Closes #N

## Problem

Smith-generated PRs don't include 'Closes #N' in the body, even though CLAUDE.md and AGENTS.md both say it's CRITICAL. The instruction tells Smith to run 'bd show --json | jq .external_ref' to find the issue number, but Smith skips this extra step in practice.

Root cause: forge never passes the external_ref to Smith at all. The data is available in 'bd ready --json' output but is discarded at two points:

1. poller.Bead struct (internal/poller/poller.go:22) — no ExternalRef field
2. prompt.BeadContext struct (internal/prompt/prompt.go:17) — no ExternalRef field

## Fix

1. Add ExternalRef string to poller.Bead with json tag "external_ref"
2. Add ExternalRef string to prompt.BeadContext
3. In the pipeline, copy bead.ExternalRef to the BeadContext when building the prompt
4. In the default prompt template, add a line like:
   {{- if .Bead.ExternalRef}}
   **GitHub Issue**: {{.Bead.ExternalRef}} — include 'Closes #N' in your PR body (where N is the issue number from this URL)
   {{- end}}
5. Smith sees the issue URL in its prompt and includes the Closes line automatically — no extra tool call needed

---
Bead: Forge-pqrw | Branch: forge/Forge-pqrw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)