### PR TITLE
Pipeline: last-chance bd show lookup for external_ref before PR creation (Forge-xz3d)

### DIFF
--- a/changelog.d/Forge-xz3d.md
+++ b/changelog.d/Forge-xz3d.md
@@ -1,0 +1,2 @@
+category: Added
+- **Last-chance external_ref lookup before PR creation** - Pipeline now fetches the latest external_ref from bd right before creating a PR, ensuring Closes #N is included even when the reference was unavailable at dispatch time. (Forge-xz3d)

--- a/internal/crucible/crucible.go
+++ b/internal/crucible/crucible.go
@@ -215,6 +215,7 @@ func Run(ctx context.Context, p Params) *Result {
 					BeadDescription: p.ParentBead.Description,
 					BeadType:        p.ParentBead.IssueType,
 					ChangeSummary:   changeSummary,
+					ExternalRef:     p.ParentBead.ExternalRef,
 				})
 				if err != nil {
 					log.Error("failed to create parent PR", "error", err)
@@ -429,6 +430,7 @@ func Run(ctx context.Context, p Params) *Result {
 			BeadDescription: child.Description,
 			BeadType:        child.IssueType,
 			ChangeSummary:   childChangeSummary,
+			ExternalRef:     child.ExternalRef,
 		})
 		if err != nil {
 			log.Error("failed to create child PR", "child", child.ID, "error", err)
@@ -499,6 +501,7 @@ func Run(ctx context.Context, p Params) *Result {
 		BeadTitle:       p.ParentBead.Title,
 		BeadDescription: p.ParentBead.Description,
 		BeadType:        p.ParentBead.IssueType,
+		ExternalRef:     p.ParentBead.ExternalRef,
 	})
 	if err != nil {
 		return &Result{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2291,6 +2291,13 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 		changeSummary = outcome.ReviewResult.Summary
 	}
 
+	// Last-chance lookup: fetch the latest external_ref from bd in case it
+	// was empty at dispatch time (e.g. GitHub auto-sync hadn't run yet).
+	externalRef := bead.ExternalRef
+	if externalRef == "" {
+		externalRef = d.fetchExternalRef(anvilPath, bead.ID)
+	}
+
 	pr, err := d.vcsForAnvil(bead.Anvil).CreatePR(ctx, vcs.CreateParams{
 		WorktreePath:    anvilPath,
 		BeadID:          bead.ID,
@@ -2302,6 +2309,7 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 		BeadDescription: bead.Description,
 		BeadType:        bead.IssueType,
 		ChangeSummary:   changeSummary,
+		ExternalRef:     externalRef,
 	})
 	if err != nil {
 		// If a PR already exists for this branch (duplicate run), log a warning
@@ -2453,6 +2461,11 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 		// causes of the orphaned-branch scenario in the first place.
 		prCtx, prCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer prCancel()
+		// Last-chance external_ref lookup for orphaned branch PR creation.
+		orphanExtRef := bead.ExternalRef
+		if orphanExtRef == "" {
+			orphanExtRef = d.fetchExternalRef(anvilPath, bead.ID)
+		}
 		pr, prErr := d.vcsForAnvil(bead.Anvil).CreatePR(prCtx, vcs.CreateParams{
 			WorktreePath:    anvilPath,
 			BeadID:          bead.ID,
@@ -2463,6 +2476,7 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 			BeadTitle:       bead.Title,
 			BeadDescription: bead.Description,
 			BeadType:        bead.IssueType,
+			ExternalRef:     orphanExtRef,
 		})
 		if prErr != nil {
 			if errors.Is(prErr, vcs.ErrPRAlreadyExists) {
@@ -4400,6 +4414,39 @@ func (d *Daemon) applyDecomposedOutcome(bead poller.Bead, anvilCfg config.AnvilC
 	d.recordDispatchFailure(beadID, anvil, reason)
 }
 
+// fetchExternalRef does a one-shot bd show lookup for the bead's external_ref.
+// Returns the external_ref value, or "" if the lookup fails or the field is empty.
+func (d *Daemon) fetchExternalRef(anvilPath, beadID string) string {
+	output, stderrStr, err := d.beadShower(anvilPath, beadID)
+	if err != nil {
+		d.logger.Debug("last-chance external_ref lookup failed", "bead", beadID, "error", err, "stderr", stderrStr)
+		return ""
+	}
+
+	// bd show --json may return [{...}]; unwrap.
+	output = bytes.TrimSpace(output)
+	if len(output) > 1 && output[0] == '[' {
+		start := bytes.IndexByte(output, '{')
+		end := bytes.LastIndexByte(output, '}')
+		if start >= 0 && end > start {
+			output = output[start : end+1]
+		}
+	}
+
+	var resp struct {
+		ExternalRef string `json:"external_ref"`
+	}
+	if err := json.Unmarshal(output, &resp); err != nil {
+		d.logger.Debug("failed to parse external_ref from bd show", "bead", beadID, "error", err)
+		return ""
+	}
+
+	if resp.ExternalRef != "" {
+		d.logger.Info("last-chance lookup found external_ref", "bead", beadID, "external_ref", resp.ExternalRef)
+	}
+	return resp.ExternalRef
+}
+
 // maybeCloseDecomposedParent auto-closes a decomposed parent bead when it has
 // no dependents (nothing has depends_on pointing to it). If the parent has
 // dependents those beads stay blocked until someone closes the parent manually.
@@ -4966,8 +5013,10 @@ func (d *Daemon) handleWardenRerun(beadID, anvil, branch string, anvilCfg config
 	title := d.db.BeadTitle(beadID, anvil)
 	var description string
 	var baseBranch string
+	var rerunExternalRef string
 	if bead, err := crucible.FetchBead(ctx, beadID, anvilCfg.Path); err == nil {
 		description = bead.Description
+		rerunExternalRef = bead.ExternalRef
 		// Resolve epic branch so PRs target the correct base for crucible children.
 		beads := []poller.Bead{bead}
 		poller.ResolveEpicBranches(ctx, beads, map[string]string{anvil: anvilCfg.Path})
@@ -5007,6 +5056,7 @@ func (d *Daemon) handleWardenRerun(beadID, anvil, branch string, anvilCfg config
 			BeadTitle:       title,
 			BeadDescription: description,
 			ChangeSummary:   changeSummary,
+			ExternalRef:     rerunExternalRef,
 		})
 		if err != nil {
 			d.logger.Error("warden_rerun: PR creation failed", "bead", beadID, "error", err)
@@ -5066,8 +5116,10 @@ func (d *Daemon) handleApproveAsIs(beadID, anvil, branch string, anvilCfg config
 	title := d.db.BeadTitle(beadID, anvil)
 	var description string
 	var baseBranch string
+	var approveExtRef string
 	if bead, err := crucible.FetchBead(ctx, beadID, anvilCfg.Path); err == nil {
 		description = bead.Description
+		approveExtRef = bead.ExternalRef
 		// Resolve epic branch so PRs target the correct base for crucible children.
 		beads := []poller.Bead{bead}
 		poller.ResolveEpicBranches(ctx, beads, map[string]string{anvil: anvilCfg.Path})
@@ -5084,6 +5136,7 @@ func (d *Daemon) handleApproveAsIs(beadID, anvil, branch string, anvilCfg config
 		BeadTitle:       title,
 		BeadDescription: description,
 		ChangeSummary:   "Approved as-is (manual bypass)",
+		ExternalRef:     approveExtRef,
 	})
 	if err != nil {
 		d.logger.Error("approve_as_is: PR creation failed", "bead", beadID, "error", err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4417,6 +4417,9 @@ func (d *Daemon) applyDecomposedOutcome(bead poller.Bead, anvilCfg config.AnvilC
 // fetchExternalRef does a one-shot bd show lookup for the bead's external_ref.
 // Returns the external_ref value, or "" if the lookup fails or the field is empty.
 func (d *Daemon) fetchExternalRef(anvilPath, beadID string) string {
+	if d.beadShower == nil {
+		return ""
+	}
 	output, stderrStr, err := d.beadShower(anvilPath, beadID)
 	if err != nil {
 		d.logger.Debug("last-chance external_ref lookup failed", "bead", beadID, "error", err, "stderr", stderrStr)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4426,22 +4426,22 @@ func (d *Daemon) fetchExternalRef(anvilPath, beadID string) string {
 		return ""
 	}
 
-	// bd show --json may return [{...}]; unwrap.
-	output = bytes.TrimSpace(output)
-	if len(output) > 1 && output[0] == '[' {
-		start := bytes.IndexByte(output, '{')
-		end := bytes.LastIndexByte(output, '}')
-		if start >= 0 && end > start {
-			output = output[start : end+1]
-		}
-	}
-
-	var resp struct {
+	type beadShowResponse struct {
 		ExternalRef string `json:"external_ref"`
 	}
-	if err := json.Unmarshal(output, &resp); err != nil {
-		d.logger.Debug("failed to parse external_ref from bd show", "bead", beadID, "error", err)
-		return ""
+
+	// Try object form first (tolerates leading/trailing diagnostic noise).
+	var resp beadShowResponse
+	if err := executil.DecodeJSON(output, &resp); err != nil {
+		// Fall back to array form.
+		var resps []beadShowResponse
+		if arrayErr := executil.DecodeJSON(output, &resps); arrayErr != nil {
+			d.logger.Debug("failed to parse external_ref from bd show", "bead", beadID, "error", err)
+			return ""
+		}
+		if len(resps) > 0 {
+			resp = resps[0]
+		}
 	}
 
 	if resp.ExternalRef != "" {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2912,3 +2912,49 @@ func TestResolveTemperConfig_StepsOverridesSlots(t *testing.T) {
 		assert.Nil(t, cfg)
 	})
 }
+
+func TestFetchExternalRef(t *testing.T) {
+	t.Run("returns external_ref from bd show", func(t *testing.T) {
+		d := &Daemon{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		d.beadShower = func(anvilPath, beadID string) ([]byte, string, error) {
+			return []byte(`{"id":"Forge-test","external_ref":"gh-42"}`), "", nil
+		}
+		got := d.fetchExternalRef("/tmp/anvil", "Forge-test")
+		assert.Equal(t, "gh-42", got)
+	})
+
+	t.Run("returns empty when external_ref absent", func(t *testing.T) {
+		d := &Daemon{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		d.beadShower = func(anvilPath, beadID string) ([]byte, string, error) {
+			return []byte(`{"id":"Forge-test"}`), "", nil
+		}
+		got := d.fetchExternalRef("/tmp/anvil", "Forge-test")
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("returns empty when bd show fails", func(t *testing.T) {
+		d := &Daemon{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		d.beadShower = func(anvilPath, beadID string) ([]byte, string, error) {
+			return nil, "command not found", fmt.Errorf("exec: bd: not found")
+		}
+		got := d.fetchExternalRef("/tmp/anvil", "Forge-test")
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("unwraps JSON array", func(t *testing.T) {
+		d := &Daemon{
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		d.beadShower = func(anvilPath, beadID string) ([]byte, string, error) {
+			return []byte(`[{"id":"Forge-test","external_ref":"gh-99"}]`), "", nil
+		}
+		got := d.fetchExternalRef("/tmp/anvil", "Forge-test")
+		assert.Equal(t, "gh-99", got)
+	})
+}

--- a/internal/vcs/gitea.go
+++ b/internal/vcs/gitea.go
@@ -82,6 +82,8 @@ func (g *GiteaProvider) CreatePR(ctx context.Context, params CreateParams) (*PR,
 	}
 	if params.Body == "" {
 		params.Body = buildPRBody(params)
+	} else {
+		params.Body = InjectClosesLine(params.Body, params.ExternalRef)
 	}
 
 	baseURL, owner, repo, err := g.resolveRepo(ctx, params.WorktreePath)

--- a/internal/vcs/github/github.go
+++ b/internal/vcs/github/github.go
@@ -50,6 +50,10 @@ func (p *Provider) CreatePR(ctx context.Context, params vcs.CreateParams) (*vcs.
 
 	if params.Body == "" {
 		params.Body = buildDefaultBody(params)
+	} else {
+		// When a body is already set (e.g. from Smith), inject Closes #N
+		// if external_ref identifies a GitHub issue and it's not already present.
+		params.Body = vcs.InjectClosesLine(params.Body, params.ExternalRef)
 	}
 
 	args := []string{
@@ -836,6 +840,12 @@ func buildDefaultBody(p vcs.CreateParams) string {
 		}
 		b.WriteString(p.BeadDescription)
 		b.WriteString("\n\n")
+	}
+
+	// Inject Closes #N for GitHub issue references before the footer,
+	// but only if the body doesn't already contain one.
+	if num := vcs.GitHubIssueNumber(p.ExternalRef); num != "" && !vcs.ClosesPattern().MatchString(b.String()) {
+		fmt.Fprintf(&b, "Closes #%s\n\n", num)
 	}
 
 	b.WriteString("---\n")

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -41,6 +41,8 @@ func (g *GitLabProvider) CreatePR(ctx context.Context, params CreateParams) (*PR
 
 	if params.Body == "" {
 		params.Body = buildPRBody(params)
+	} else {
+		params.Body = InjectClosesLine(params.Body, params.ExternalRef)
 	}
 
 	args := []string{

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -18,6 +19,59 @@ import (
 // ErrPRAlreadyExists is returned by CreatePR when a PR already exists for
 // the given branch. Callers should use errors.Is to check for this sentinel.
 var ErrPRAlreadyExists = errors.New("pull request already exists for branch")
+
+// ghIssueURLPattern matches GitHub issue URLs like
+// https://github.com/org/repo/issues/42
+var ghIssueURLPattern = regexp.MustCompile(`/issues/(\d+)\b`)
+
+// GitHubIssueNumber extracts a GitHub issue number from an external_ref value.
+// Recognised formats:
+//   - "gh-42"                                     → "42"
+//   - "https://github.com/org/repo/issues/42"     → "42"
+//
+// Returns "" for non-GitHub references (e.g. "jira-123"), empty strings, or
+// malformed values.
+func GitHubIssueNumber(externalRef string) string {
+	if externalRef == "" {
+		return ""
+	}
+	// Shorthand: gh-<number>
+	if num, ok := strings.CutPrefix(externalRef, "gh-"); ok && num != "" {
+		// Validate it's all digits.
+		for _, c := range num {
+			if c < '0' || c > '9' {
+				return ""
+			}
+		}
+		return num
+	}
+	// Full URL: .../issues/<number>
+	if m := ghIssueURLPattern.FindStringSubmatch(externalRef); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// closesRe matches existing "Closes #N" lines (case-insensitive) to
+// avoid injecting duplicates.
+var closesRe = regexp.MustCompile(`(?i)\bCloses\s+#\d+`)
+
+// ClosesPattern returns the compiled regexp for matching "Closes #N" lines.
+func ClosesPattern() *regexp.Regexp { return closesRe }
+
+// InjectClosesLine appends a "Closes #N" line to body if the externalRef
+// identifies a GitHub issue and the body does not already contain one.
+// Returns the (possibly modified) body.
+func InjectClosesLine(body, externalRef string) string {
+	num := GitHubIssueNumber(externalRef)
+	if num == "" {
+		return body
+	}
+	if closesRe.MatchString(body) {
+		return body
+	}
+	return body + "\n\nCloses #" + num
+}
 
 // buildPRBody creates a structured PR/MR description from bead metadata.
 // This is the canonical body builder for all vcs providers; it mirrors the
@@ -46,6 +100,13 @@ func buildPRBody(p CreateParams) string {
 		}
 		b.WriteString(p.BeadDescription)
 		b.WriteString("\n\n")
+	}
+
+	// Inject Closes #N for GitHub issue references before the footer,
+	// but only if the body doesn't already contain one (e.g. from Smith's
+	// change summary).
+	if num := GitHubIssueNumber(p.ExternalRef); num != "" && !closesRe.MatchString(b.String()) {
+		fmt.Fprintf(&b, "Closes #%s\n\n", num)
 	}
 
 	// Footer
@@ -175,6 +236,10 @@ type CreateParams struct {
 	BeadType string
 	// ChangeSummary is a summary of what changed (from warden review or diff stat).
 	ChangeSummary string
+	// ExternalRef is an optional external tracker reference (e.g. "gh-42" or a
+	// GitHub issue URL). When it identifies a GitHub issue, buildPRBody injects
+	// a "Closes #N" line so the PR auto-closes the issue on merge.
+	ExternalRef string
 }
 
 // PRStatus represents the platform-agnostic state of a pull/merge request.

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -20,17 +20,17 @@ import (
 // the given branch. Callers should use errors.Is to check for this sentinel.
 var ErrPRAlreadyExists = errors.New("pull request already exists for branch")
 
-// ghIssueURLPattern matches GitHub issue URLs like
-// https://github.com/org/repo/issues/42
-var ghIssueURLPattern = regexp.MustCompile(`/issues/(\d+)\b`)
+// ghIssuePathPattern matches the path portion of a GitHub issue URL like
+// /org/repo/issues/42
+var ghIssuePathPattern = regexp.MustCompile(`^/.+/.+/issues/(\d+)$`)
 
 // GitHubIssueNumber extracts a GitHub issue number from an external_ref value.
 // Recognised formats:
 //   - "gh-42"                                     → "42"
 //   - "https://github.com/org/repo/issues/42"     → "42"
 //
-// Returns "" for non-GitHub references (e.g. "jira-123"), empty strings, or
-// malformed values.
+// Returns "" for non-GitHub references (e.g. "jira-123", GitLab URLs, or any
+// URL whose host is not github.com), empty strings, or malformed values.
 func GitHubIssueNumber(externalRef string) string {
 	if externalRef == "" {
 		return ""
@@ -45,8 +45,12 @@ func GitHubIssueNumber(externalRef string) string {
 		}
 		return num
 	}
-	// Full URL: .../issues/<number>
-	if m := ghIssueURLPattern.FindStringSubmatch(externalRef); len(m) == 2 {
+	// Full URL: must be a github.com URL with path /org/repo/issues/<number>.
+	u, err := url.Parse(externalRef)
+	if err != nil || u.Hostname() != "github.com" {
+		return ""
+	}
+	if m := ghIssuePathPattern.FindStringSubmatch(u.Path); len(m) == 2 {
 		return m[1]
 	}
 	return ""

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -292,6 +292,108 @@ func TestErrPRAlreadyExists(t *testing.T) {
 	})
 }
 
+func TestGitHubIssueNumber(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gh-42", "42"},
+		{"gh-1", "1"},
+		{"gh-", ""},
+		{"", ""},
+		{"jira-123", ""},
+		{"https://github.com/org/repo/issues/42", "42"},
+		{"https://github.com/org/repo/issues/7", "7"},
+		{"https://github.com/org/repo/pull/42", ""},
+		{"gh-abc", ""},
+		{"https://example.com/issues/42", "42"}, // generic /issues/ URL
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, GitHubIssueNumber(tt.input))
+		})
+	}
+}
+
+func TestInjectClosesLine(t *testing.T) {
+	t.Run("injects when external_ref is gh shorthand", func(t *testing.T) {
+		body := "Some PR body"
+		got := InjectClosesLine(body, "gh-42")
+		assert.Contains(t, got, "Closes #42")
+	})
+
+	t.Run("injects when external_ref is GitHub URL", func(t *testing.T) {
+		body := "Some PR body"
+		got := InjectClosesLine(body, "https://github.com/org/repo/issues/7")
+		assert.Contains(t, got, "Closes #7")
+	})
+
+	t.Run("no injection for non-GitHub ref", func(t *testing.T) {
+		body := "Some PR body"
+		got := InjectClosesLine(body, "jira-123")
+		assert.Equal(t, body, got)
+	})
+
+	t.Run("no injection for empty ref", func(t *testing.T) {
+		body := "Some PR body"
+		got := InjectClosesLine(body, "")
+		assert.Equal(t, body, got)
+	})
+
+	t.Run("no duplicate when body already has Closes", func(t *testing.T) {
+		body := "Some PR body\n\nCloses #42"
+		got := InjectClosesLine(body, "gh-42")
+		assert.Equal(t, body, got)
+	})
+
+	t.Run("no duplicate case insensitive", func(t *testing.T) {
+		body := "Some PR body\n\ncloses #42"
+		got := InjectClosesLine(body, "gh-42")
+		assert.Equal(t, body, got)
+	})
+}
+
+func TestBuildPRBody_ExternalRef(t *testing.T) {
+	t.Run("includes Closes line when external_ref is set", func(t *testing.T) {
+		body := buildPRBody(CreateParams{
+			BeadID:      "Forge-test",
+			Branch:      "forge/test",
+			ExternalRef: "gh-42",
+		})
+		assert.Contains(t, body, "Closes #42")
+	})
+
+	t.Run("no Closes line for non-GitHub ref", func(t *testing.T) {
+		body := buildPRBody(CreateParams{
+			BeadID:      "Forge-test",
+			Branch:      "forge/test",
+			ExternalRef: "jira-123",
+		})
+		assert.NotContains(t, body, "Closes #")
+	})
+
+	t.Run("no Closes line when external_ref empty", func(t *testing.T) {
+		body := buildPRBody(CreateParams{
+			BeadID:      "Forge-test",
+			Branch:      "forge/test",
+			ExternalRef: "",
+		})
+		assert.NotContains(t, body, "Closes #")
+	})
+
+	t.Run("no duplicate Closes when already in change summary", func(t *testing.T) {
+		body := buildPRBody(CreateParams{
+			BeadID:        "Forge-test",
+			Branch:        "forge/test",
+			ExternalRef:   "gh-42",
+			ChangeSummary: "Fixed the bug.\n\nCloses #42",
+		})
+		// Count occurrences — should be exactly 1
+		count := len(ClosesPattern().FindAllString(body, -1))
+		assert.Equal(t, 1, count, "should not duplicate Closes #42")
+	})
+}
+
 func TestMergeabilityFromStatus(t *testing.T) {
 	s := &PRStatus{
 		Mergeable:         "CONFLICTING",

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -306,7 +306,8 @@ func TestGitHubIssueNumber(t *testing.T) {
 		{"https://github.com/org/repo/issues/7", "7"},
 		{"https://github.com/org/repo/pull/42", ""},
 		{"gh-abc", ""},
-		{"https://example.com/issues/42", "42"}, // generic /issues/ URL
+		{"https://example.com/issues/42", ""},
+		{"https://gitlab.com/org/repo/issues/42", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
## Changes

- **Last-chance external_ref lookup before PR creation** - Pipeline now fetches the latest external_ref from bd right before creating a PR, ensuring Closes #N is included even when the reference was unavailable at dispatch time. (Forge-xz3d)

## Original Issue (feature): Pipeline: last-chance bd show lookup for external_ref before PR creation

Follow-up to Forge-pqrw (PR #522, merged). The current fix passes external_ref from the poller through to the Smith prompt template, so Smith can include Closes #N in the PR body. But if external_ref is empty at dispatch time (e.g. github autosync hasn't run yet, or bead was created locally), the template line is suppressed and Smith creates a PR without Closes #N.

Fix: in the pipeline's PR creation step (after Smith and Warden approve, right before gh pr create), do a one-shot bd show <bead-id> --json to fetch the latest external_ref. If present, inject Closes #N into the PR body. This costs ~1 second and guarantees the freshest data is used regardless of what was available at dispatch time.

This is defense in depth — the primary path (external_ref in prompt) handles 99% of cases, but this catch-all ensures no PR ships without Closes #N when a GitHub issue exists.

---
Bead: Forge-xz3d | Branch: forge/Forge-xz3d
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)