### PR TITLE
Async ack protocol: IPC response types and request tracking (Forge-7v4u)

### DIFF
--- a/changelog.d/Forge-7v4u.md
+++ b/changelog.d/Forge-7v4u.md
@@ -1,2 +1,3 @@
 category: Added
 - **Async ack IPC protocol** - Added "queued" response type with request_id correlation and RequestTracker for async command handling in the IPC layer. (Forge-7v4u)
+

--- a/changelog.d/Forge-7v4u.md
+++ b/changelog.d/Forge-7v4u.md
@@ -1,0 +1,2 @@
+category: Added
+- **Async ack IPC protocol** - Added "queued" response type with request_id correlation and RequestTracker for async command handling in the IPC layer. (Forge-7v4u)

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -37,8 +37,9 @@ type Command struct {
 
 // Response is a message sent from the daemon to a client.
 type Response struct {
-	Type    string          `json:"type"`    // "ok", "error", "status", "event"
-	Payload json.RawMessage `json:"payload"` // Type-specific data
+	Type      string          `json:"type"`                 // "ok", "error", "status", "event", "queued"
+	Payload   json.RawMessage `json:"payload"`              // Type-specific data
+	RequestID string          `json:"request_id,omitempty"` // Set when Type is "queued"; correlates async completion
 }
 
 // Event is a push notification from daemon to subscribed clients.
@@ -256,6 +257,98 @@ type WicketStatusPayload struct {
 	DerivedAnvils  int            `json:"derived_anvils"`   // anvil count deriving repo from git remote at runtime
 	IssueCounts    map[string]int `json:"issue_counts"`     // state -> count
 	LastScanAt     *time.Time     `json:"last_scan_at,omitempty"`
+}
+
+// QueuedPayload is the payload for a "queued" response, indicating the
+// command was accepted and will be processed asynchronously.
+type QueuedPayload struct {
+	RequestID string `json:"request_id"`
+	Message   string `json:"message,omitempty"`
+}
+
+// CompletionResult is the outcome delivered when an async request finishes.
+type CompletionResult struct {
+	Response Response
+	Err      error
+}
+
+// NewQueuedResponse builds a Response of type "queued" for the given request ID.
+func NewQueuedResponse(requestID string, message string) Response {
+	payload := QueuedPayload{RequestID: requestID, Message: message}
+	data, _ := json.Marshal(payload)
+	return Response{
+		Type:      "queued",
+		Payload:   data,
+		RequestID: requestID,
+	}
+}
+
+// RequestTracker maps request IDs to completion channels so the daemon can
+// deliver results for asynchronously queued commands.
+type RequestTracker struct {
+	mu       sync.Mutex
+	pending  map[string]chan CompletionResult
+	idSeq    uint64
+	idPrefix string
+}
+
+// NewRequestTracker creates a tracker. The prefix is prepended to generated
+// request IDs (e.g. "forge-") for easy identification in logs.
+func NewRequestTracker(prefix string) *RequestTracker {
+	return &RequestTracker{
+		pending:  make(map[string]chan CompletionResult),
+		idPrefix: prefix,
+	}
+}
+
+// Track registers a new async request and returns its ID and a channel that
+// will receive exactly one CompletionResult when the work finishes.
+func (rt *RequestTracker) Track() (string, <-chan CompletionResult) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	rt.idSeq++
+	id := fmt.Sprintf("%s%d-%d", rt.idPrefix, time.Now().UnixMilli(), rt.idSeq)
+	ch := make(chan CompletionResult, 1)
+	rt.pending[id] = ch
+	return id, ch
+}
+
+// Complete delivers a result for the given request ID and removes it from the
+// tracker. Returns false if the ID is not found (already completed or unknown).
+func (rt *RequestTracker) Complete(requestID string, result CompletionResult) bool {
+	rt.mu.Lock()
+	ch, ok := rt.pending[requestID]
+	if ok {
+		delete(rt.pending, requestID)
+	}
+	rt.mu.Unlock()
+	if !ok {
+		return false
+	}
+	ch <- result
+	close(ch)
+	return true
+}
+
+// Cancel removes a pending request without delivering a result, closing its
+// channel so any waiter unblocks.
+func (rt *RequestTracker) Cancel(requestID string) {
+	rt.mu.Lock()
+	ch, ok := rt.pending[requestID]
+	if ok {
+		delete(rt.pending, requestID)
+	}
+	rt.mu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+// Pending returns the number of in-flight requests.
+func (rt *RequestTracker) Pending() int {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return len(rt.pending)
 }
 
 // CommandHandler is called by the server for each incoming command.
@@ -483,6 +576,13 @@ func (c *Client) Subscribe(ctx context.Context) <-chan Event {
 		}
 	}()
 	return ch
+}
+
+// IsQueued reports whether the response indicates the command was accepted
+// for asynchronous processing. Callers can use resp.RequestID to correlate
+// the eventual completion.
+func (r *Response) IsQueued() bool {
+	return r != nil && r.Type == "queued"
 }
 
 // Close closes the client connection.

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -273,14 +273,17 @@ type CompletionResult struct {
 }
 
 // NewQueuedResponse builds a Response of type "queued" for the given request ID.
-func NewQueuedResponse(requestID string, message string) Response {
+func NewQueuedResponse(requestID string, message string) (Response, error) {
 	payload := QueuedPayload{RequestID: requestID, Message: message}
-	data, _ := json.Marshal(payload)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return Response{}, fmt.Errorf("marshal queued payload: %w", err)
+	}
 	return Response{
 		Type:      "queued",
 		Payload:   data,
 		RequestID: requestID,
-	}
+	}, nil
 }
 
 // RequestTracker maps request IDs to completion channels so the daemon can

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -260,10 +260,11 @@ type WicketStatusPayload struct {
 }
 
 // QueuedPayload is the payload for a "queued" response, indicating the
-// command was accepted and will be processed asynchronously.
+// command was accepted and will be processed asynchronously. The request ID is
+// carried only at the top-level Response.RequestID field; it is not duplicated
+// here to avoid diverging sources of truth.
 type QueuedPayload struct {
-	RequestID string `json:"request_id"`
-	Message   string `json:"message,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // CompletionResult is the outcome delivered when an async request finishes.
@@ -273,8 +274,12 @@ type CompletionResult struct {
 }
 
 // NewQueuedResponse builds a Response of type "queued" for the given request ID.
+// Returns an error if requestID is empty, since an empty ID breaks correlation.
 func NewQueuedResponse(requestID string, message string) (Response, error) {
-	payload := QueuedPayload{RequestID: requestID, Message: message}
+	if requestID == "" {
+		return Response{}, fmt.Errorf("requestID must not be empty")
+	}
+	payload := QueuedPayload{Message: message}
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return Response{}, fmt.Errorf("marshal queued payload: %w", err)

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -145,7 +145,10 @@ func TestRequestTracker_Concurrent(t *testing.T) {
 }
 
 func TestQueuedResponseJSON(t *testing.T) {
-	resp := NewQueuedResponse("abc", "queued for processing")
+	resp, err := NewQueuedResponse("abc", "queued for processing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	data, err := json.Marshal(resp)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -23,9 +23,6 @@ func TestNewQueuedResponse(t *testing.T) {
 	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
 		t.Fatalf("unmarshal payload: %v", err)
 	}
-	if payload.RequestID != "req-123" {
-		t.Fatalf("payload request_id mismatch: %s", payload.RequestID)
-	}
 	if payload.Message != "accepted" {
 		t.Fatalf("payload message mismatch: %s", payload.Message)
 	}
@@ -135,12 +132,23 @@ func TestRequestTracker_Concurrent(t *testing.T) {
 			go func() {
 				rt.Complete(id, CompletionResult{Response: Response{Type: "ok"}})
 			}()
-			<-ch
+			select {
+			case <-ch:
+			case <-time.After(5 * time.Second):
+				t.Errorf("timed out waiting for completion of request %s", id)
+			}
 		}()
 	}
 	wg.Wait()
 	if rt.Pending() != 0 {
 		t.Fatalf("expected 0 pending, got %d", rt.Pending())
+	}
+}
+
+func TestQueuedResponse_EmptyID(t *testing.T) {
+	_, err := NewQueuedResponse("", "msg")
+	if err == nil {
+		t.Fatal("expected error for empty requestID, got nil")
 	}
 }
 

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestNewQueuedResponse(t *testing.T) {
-	resp := NewQueuedResponse("req-123", "accepted")
+	resp, err := NewQueuedResponse("req-123", "accepted")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if resp.Type != "queued" {
 		t.Fatalf("expected type queued, got %s", resp.Type)
 	}

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -1,0 +1,161 @@
+package ipc
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewQueuedResponse(t *testing.T) {
+	resp := NewQueuedResponse("req-123", "accepted")
+	if resp.Type != "queued" {
+		t.Fatalf("expected type queued, got %s", resp.Type)
+	}
+	if resp.RequestID != "req-123" {
+		t.Fatalf("expected request_id req-123, got %s", resp.RequestID)
+	}
+
+	var payload QueuedPayload
+	if err := json.Unmarshal(resp.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.RequestID != "req-123" {
+		t.Fatalf("payload request_id mismatch: %s", payload.RequestID)
+	}
+	if payload.Message != "accepted" {
+		t.Fatalf("payload message mismatch: %s", payload.Message)
+	}
+}
+
+func TestResponse_IsQueued(t *testing.T) {
+	queued := &Response{Type: "queued"}
+	if !queued.IsQueued() {
+		t.Fatal("expected IsQueued true for type=queued")
+	}
+
+	ok := &Response{Type: "ok"}
+	if ok.IsQueued() {
+		t.Fatal("expected IsQueued false for type=ok")
+	}
+
+	var nilResp *Response
+	if nilResp.IsQueued() {
+		t.Fatal("expected IsQueued false for nil response")
+	}
+}
+
+func TestRequestTracker_TrackAndComplete(t *testing.T) {
+	rt := NewRequestTracker("test-")
+
+	id, ch := rt.Track()
+	if id == "" {
+		t.Fatal("expected non-empty request ID")
+	}
+	if rt.Pending() != 1 {
+		t.Fatalf("expected 1 pending, got %d", rt.Pending())
+	}
+
+	result := CompletionResult{
+		Response: Response{Type: "ok"},
+	}
+	if !rt.Complete(id, result) {
+		t.Fatal("Complete returned false for tracked ID")
+	}
+
+	select {
+	case got := <-ch:
+		if got.Response.Type != "ok" {
+			t.Fatalf("expected ok, got %s", got.Response.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion")
+	}
+
+	if rt.Pending() != 0 {
+		t.Fatalf("expected 0 pending after completion, got %d", rt.Pending())
+	}
+}
+
+func TestRequestTracker_CompleteUnknown(t *testing.T) {
+	rt := NewRequestTracker("test-")
+	if rt.Complete("nonexistent", CompletionResult{}) {
+		t.Fatal("Complete should return false for unknown ID")
+	}
+}
+
+func TestRequestTracker_Cancel(t *testing.T) {
+	rt := NewRequestTracker("test-")
+	id, ch := rt.Track()
+
+	rt.Cancel(id)
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected channel to be closed without value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out; channel should be closed")
+	}
+
+	if rt.Pending() != 0 {
+		t.Fatalf("expected 0 pending after cancel, got %d", rt.Pending())
+	}
+}
+
+func TestRequestTracker_CancelUnknown(t *testing.T) {
+	rt := NewRequestTracker("test-")
+	rt.Cancel("nonexistent") // should not panic
+}
+
+func TestRequestTracker_UniqueIDs(t *testing.T) {
+	rt := NewRequestTracker("u-")
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id, _ := rt.Track()
+		if seen[id] {
+			t.Fatalf("duplicate ID: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestRequestTracker_Concurrent(t *testing.T) {
+	rt := NewRequestTracker("c-")
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id, ch := rt.Track()
+			go func() {
+				rt.Complete(id, CompletionResult{Response: Response{Type: "ok"}})
+			}()
+			<-ch
+		}()
+	}
+	wg.Wait()
+	if rt.Pending() != 0 {
+		t.Fatalf("expected 0 pending, got %d", rt.Pending())
+	}
+}
+
+func TestQueuedResponseJSON(t *testing.T) {
+	resp := NewQueuedResponse("abc", "queued for processing")
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded Response
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Type != "queued" {
+		t.Fatalf("expected type queued, got %s", decoded.Type)
+	}
+	if decoded.RequestID != "abc" {
+		t.Fatalf("expected request_id abc, got %s", decoded.RequestID)
+	}
+}


### PR DESCRIPTION
## Changes

- **Async ack IPC protocol** - Added "queued" response type with request_id correlation and RequestTracker for async command handling in the IPC layer. (Forge-7v4u)

## Original Issue (task): Async ack protocol: IPC response types and request tracking

Introduce the async ack pattern in the IPC layer. Modify internal/ipc/ipc.go to define a new Response type 'queued' with a request_id field. Add a RequestTracker (or similar) struct in the daemon that maps request_id → completion channel/callback. Update the IPC message types/structs to support the new response variant. The IPC client side should recognize 'queued' responses and return them without treating them as errors. This is the foundation sub-task — all other sub-tasks depend on these types and the tracker being in place.

---
Bead: Forge-7v4u | Branch: forge/Forge-7v4u
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)