### PR TITLE
TUI: correlate async ack events and update status line (Forge-pkkq)

### DIFF
--- a/changelog.d/Forge-pkkq.md
+++ b/changelog.d/Forge-pkkq.md
@@ -1,0 +1,2 @@
+category: Changed
+- **TUI async IPC correlation** - Hearth TUI now handles async "queued" IPC responses by subscribing to daemon completion events, correlating by request_id, and updating the status line with success or error messages. IPC read deadline reduced from 10s to 3s since only the fast initial ack needs to arrive. (Forge-pkkq)

--- a/cmd/forge/hearth.go
+++ b/cmd/forge/hearth.go
@@ -86,10 +86,10 @@ var hearthCmd = &cobra.Command{
 				Payload: json.RawMessage(payload),
 			})
 		}
-		model.OnRetryBead = func(beadID, anvil string, prID int) error {
+		model.OnRetryBead = func(beadID, anvil string, prID int) (string, error) {
 			client, err := ipc.NewClient()
 			if err != nil {
-				return err
+				return "", err
 			}
 			defer client.Close()
 			payload, _ := json.Marshal(ipc.RetryBeadPayload{
@@ -102,12 +102,15 @@ var hearthCmd = &cobra.Command{
 				Payload: json.RawMessage(payload),
 			})
 			if err != nil {
-				return err
+				return "", err
+			}
+			if resp.IsQueued() {
+				return resp.RequestID, nil
 			}
 			if resp.Type != "ok" {
-				return ipcError(resp)
+				return "", ipcError(resp)
 			}
-			return nil
+			return "", nil
 		}
 		model.OnDismissBead = func(beadID, anvil string, prID int) error {
 			client, err := ipc.NewClient()
@@ -209,10 +212,10 @@ var hearthCmd = &cobra.Command{
 				return nil
 			}
 		}
-		model.OnPRAction = func(prID, prNumber int, anvil, beadID, branch, action string) error {
+		model.OnPRAction = func(prID, prNumber int, anvil, beadID, branch, action string) (string, error) {
 			client, err := ipc.NewClient()
 			if err != nil {
-				return err
+				return "", err
 			}
 			defer client.Close()
 			payload, _ := json.Marshal(ipc.PRActionPayload{
@@ -228,22 +231,23 @@ var hearthCmd = &cobra.Command{
 				Payload: json.RawMessage(payload),
 			})
 			if err != nil {
-				return err
+				return "", err
+			}
+			if resp.IsQueued() {
+				return resp.RequestID, nil
 			}
 			if resp.Type != "ok" {
-				return ipcError(resp)
+				return "", ipcError(resp)
 			}
-			return nil
+			return "", nil
 		}
-		model.OnTagBead = func(beadID, anvil string) error {
+		model.OnTagBead = func(beadID, anvil string) (string, error) {
 			client, err := ipc.NewClient()
 			if err != nil {
-				return err
+				return "", err
 			}
 			defer client.Close()
 
-			// The daemon derives the tag from its own (hot-reloaded) config, so
-			// the client only needs to send the bead identity.
 			payload, _ := json.Marshal(ipc.TagBeadPayload{
 				BeadID: beadID,
 				Anvil:  anvil,
@@ -253,18 +257,21 @@ var hearthCmd = &cobra.Command{
 				Payload: json.RawMessage(payload),
 			})
 			if err != nil {
-				return err
+				return "", err
+			}
+			if resp.IsQueued() {
+				return resp.RequestID, nil
 			}
 			if resp.Type != "ok" {
-				return ipcError(resp)
+				return "", ipcError(resp)
 			}
-			return nil
+			return "", nil
 		}
 
-		model.OnCloseBead = func(beadID, anvil string) error {
+		model.OnCloseBead = func(beadID, anvil string) (string, error) {
 			client, err := ipc.NewClient()
 			if err != nil {
-				return err
+				return "", err
 			}
 			defer client.Close()
 
@@ -277,12 +284,15 @@ var hearthCmd = &cobra.Command{
 				Payload: json.RawMessage(payload),
 			})
 			if err != nil {
-				return err
+				return "", err
+			}
+			if resp.IsQueued() {
+				return resp.RequestID, nil
 			}
 			if resp.Type != "ok" {
-				return ipcError(resp)
+				return "", ipcError(resp)
 			}
-			return nil
+			return "", nil
 		}
 
 		model.OnForceRunBead = func(beadID, anvil string) error {
@@ -310,10 +320,10 @@ var hearthCmd = &cobra.Command{
 			return nil
 		}
 
-		model.OnStopBead = func(beadID, anvil string) error {
+		model.OnStopBead = func(beadID, anvil string) (string, error) {
 			client, err := ipc.NewClient()
 			if err != nil {
-				return err
+				return "", err
 			}
 			defer client.Close()
 
@@ -326,12 +336,15 @@ var hearthCmd = &cobra.Command{
 				Payload: json.RawMessage(payload),
 			})
 			if err != nil {
-				return err
+				return "", err
+			}
+			if resp.IsQueued() {
+				return resp.RequestID, nil
 			}
 			if resp.Type != "ok" {
-				return ipcError(resp)
+				return "", ipcError(resp)
 			}
-			return nil
+			return "", nil
 		}
 
 		model.OnCrucibleAction = func(parentID, anvil, action string) error {
@@ -463,10 +476,10 @@ var hearthCmd = &cobra.Command{
 			return nil
 		}
 
-		model.OnAppendNotes = func(beadID, anvil, notes string) error {
+		model.OnAppendNotes = func(beadID, anvil, notes string) (string, error) {
 			client, err := ipc.NewClient()
 			if err != nil {
-				return fmt.Errorf("connecting to daemon: %w", err)
+				return "", fmt.Errorf("connecting to daemon: %w", err)
 			}
 			defer client.Close()
 
@@ -480,14 +493,17 @@ var hearthCmd = &cobra.Command{
 				Payload: payload,
 			})
 			if err != nil {
-				return fmt.Errorf("sending append_notes command: %w", err)
+				return "", fmt.Errorf("sending append_notes command: %w", err)
+			}
+			if resp.IsQueued() {
+				return resp.RequestID, nil
 			}
 			if resp.Type == "error" {
 				var msg map[string]string
 				_ = json.Unmarshal(resp.Payload, &msg)
-				return fmt.Errorf("daemon error: %s", msg["message"])
+				return "", fmt.Errorf("daemon error: %s", msg["message"])
 			}
-			return nil
+			return "", nil
 		}
 
 		noMouse, _ := cmd.Flags().GetBool("no-mouse")

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -10,6 +10,8 @@
 package hearth
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -30,6 +32,7 @@ import (
 	"github.com/mattn/go-runewidth"
 
 	"github.com/Robin831/Forge/internal/ingot"
+	"github.com/Robin831/Forge/internal/ipc"
 )
 
 // Panel identifies a TUI panel.
@@ -298,6 +301,25 @@ type OrphanResolveResultMsg struct {
 	Err    error
 }
 
+// pendingOp describes an in-flight async IPC operation awaiting completion.
+type pendingOp struct {
+	Description string    // e.g. "Tagging Forge-abc1"
+	StartedAt   time.Time // for timeout detection
+}
+
+// AsyncCompletionMsg is delivered when a daemon async_complete event is received.
+type AsyncCompletionMsg struct {
+	RequestID string
+	Success   bool
+	Message   string
+}
+
+// asyncSubscriptionStartedMsg signals that the event subscription is ready.
+type asyncSubscriptionStartedMsg struct {
+	events <-chan ipc.Event
+	cancel context.CancelFunc
+}
+
 // Model is the Bubbletea model for the Hearth TUI.
 type Model struct {
 	// Panels
@@ -320,10 +342,12 @@ type Model struct {
 
 	// Callback for stopping a bead entirely: kills worker, sets clarification,
 	// releases to open (set by the caller).
-	OnStopBead func(beadID, anvil string) error
+	// Returns (requestID, error) — requestID is non-empty when the daemon queued
+	// the operation for async processing.
+	OnStopBead func(beadID, anvil string) (string, error)
 
 	// Callbacks for Needs Attention actions (set by the caller)
-	OnRetryBead     func(beadID, anvil string, prID int) error
+	OnRetryBead     func(beadID, anvil string, prID int) (string, error)
 	OnDismissBead   func(beadID, anvil string, prID int) error
 	OnViewLogs      func(beadID string) (logPath string, lines []string)
 	OnWardenRerun   func(beadID, anvil string) error
@@ -332,10 +356,10 @@ type Model struct {
 
 	// Callback for tagging a bead (set by the caller).
 	// Called with (beadID, anvil) when user presses 'l' on an unlabeled bead.
-	OnTagBead func(beadID, anvil string) error
+	OnTagBead func(beadID, anvil string) (string, error)
 
 	// Callback for closing a bead (set by the caller).
-	OnCloseBead func(beadID, anvil string) error
+	OnCloseBead func(beadID, anvil string) (string, error)
 
 	// Callback for force-running a bead independently (set by the caller).
 	// Dispatches via bd show, bypassing bd ready and crucible/parent checks.
@@ -346,7 +370,7 @@ type Model struct {
 
 	// Callback for PR panel actions (set by the caller).
 	// Called with (prID, prNumber, anvil, beadID, branch, action).
-	OnPRAction func(prID, prNumber int, anvil, beadID, branch, action string) error
+	OnPRAction func(prID, prNumber int, anvil, beadID, branch, action string) (string, error)
 
 	// Callback for triggering PR reconciliation with GitHub (set by the caller).
 	OnReconcilePRs func() error
@@ -365,7 +389,7 @@ type Model struct {
 
 	// Callback for appending notes to a bead via bd update --append-notes (set by caller).
 	// Called with (beadID, anvil, notes).
-	OnAppendNotes func(beadID, anvil, notes string) error
+	OnAppendNotes func(beadID, anvil, notes string) (string, error)
 
 	// State
 	focused          Panel
@@ -451,6 +475,12 @@ type Model struct {
 	statusMsg        string
 	statusMsgTime    time.Time
 	statusMsgIsError bool
+
+	// Async IPC tracking — maps request IDs to pending operation descriptions
+	// so completion events can update the status line.
+	pendingAsync    map[string]pendingOp
+	asyncEvents     <-chan ipc.Event
+	asyncCancelFunc context.CancelFunc
 
 	// Cooldown for manual Wicket scans — prevents rapid repeated triggers.
 	wicketScanCooldownUntil time.Time
@@ -572,6 +602,7 @@ func (m *Model) Init() tea.Cmd {
 		cmds = append(cmds, Tick())
 		cmds = append(cmds, FetchAll(m.data, m.logCache))
 		cmds = append(cmds, FetchDaemonHealth())
+		cmds = append(cmds, startAsyncSubscription())
 	}
 
 	return tea.Batch(cmds...)
@@ -888,6 +919,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.String() {
 		case "q", "ctrl+c":
+			m.cleanupAsyncSubscription()
 			return m, tea.Quit
 
 		case "tab":
@@ -959,8 +991,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.workerTable.Cursor() < len(m.workers) {
 				w := m.workers[m.workerTable.Cursor()]
 				if m.OnStopBead != nil {
-					if err := m.OnStopBead(w.BeadID, w.Anvil); err != nil {
+					reqID, err := m.OnStopBead(w.BeadID, w.Anvil)
+					if err != nil {
 						m.setStatus(fmt.Sprintf("Stop failed: %v", err), true)
+					} else if reqID != "" {
+						m.setStatus(fmt.Sprintf("Stopping %s…", w.BeadID), false)
+						m.trackPending(reqID, fmt.Sprintf("Stopping %s", w.BeadID))
 					} else {
 						m.setStatus(fmt.Sprintf("Stopped bead %s", w.BeadID), false)
 					}
@@ -1612,6 +1648,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			default:
 				m.setStatus(fmt.Sprintf("Failed to close %s: %v", msg.BeadID, msg.Err), true)
 			}
+		} else if msg.RequestID != "" {
+			var desc string
+			switch msg.Action {
+			case "tag":
+				desc = fmt.Sprintf("Tagging %s", msg.BeadID)
+			case "stop":
+				desc = fmt.Sprintf("Stopping %s", msg.BeadID)
+			case "close":
+				desc = fmt.Sprintf("Closing %s", msg.BeadID)
+			default:
+				desc = fmt.Sprintf("%s %s", msg.Action, msg.BeadID)
+			}
+			m.trackPending(msg.RequestID, desc)
 		} else {
 			switch msg.Action {
 			case "tag":
@@ -1661,6 +1710,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Err != nil {
 			errSummary := strings.SplitN(msg.Err.Error(), "\n", 2)[0]
 			m.setStatus(fmt.Sprintf("PR #%d %s failed: %s", msg.PRNumber, msg.Action, errSummary), true)
+		} else if msg.RequestID != "" {
+			m.trackPending(msg.RequestID, fmt.Sprintf("PR #%d: %s", msg.PRNumber, msg.Action))
 		} else {
 			m.setStatus(fmt.Sprintf("PR #%d: %s dispatched", msg.PRNumber, msg.Action), false)
 		}
@@ -1668,14 +1719,46 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case NotesResultMsg:
 		if msg.Err != nil {
 			m.setStatus(fmt.Sprintf("Failed to save notes for %s: %v", msg.BeadID, msg.Err), true)
-		} else {
-			m.setStatus(fmt.Sprintf("Notes saved for %s", msg.BeadID), false)
-			// Success: hide and clear the notes overlay ONLY if it matches the current target.
+		} else if msg.RequestID != "" {
+			m.trackPending(msg.RequestID, fmt.Sprintf("Saving notes for %s", msg.BeadID))
 			if m.notesTarget != nil && m.notesTarget.BeadID == msg.BeadID && m.notesTarget.Anvil == msg.Anvil {
 				m.showNotesOverlay = false
 				m.notesTarget = nil
 				m.notesTA = textarea.Model{}
 			}
+		} else {
+			m.setStatus(fmt.Sprintf("Notes saved for %s", msg.BeadID), false)
+			if m.notesTarget != nil && m.notesTarget.BeadID == msg.BeadID && m.notesTarget.Anvil == msg.Anvil {
+				m.showNotesOverlay = false
+				m.notesTarget = nil
+				m.notesTA = textarea.Model{}
+			}
+		}
+
+	case asyncSubscriptionStartedMsg:
+		m.asyncEvents = msg.events
+		m.asyncCancelFunc = msg.cancel
+		return m, waitForAsyncEvent(msg.events)
+
+	case AsyncCompletionMsg:
+		if op, ok := m.pendingAsync[msg.RequestID]; ok {
+			delete(m.pendingAsync, msg.RequestID)
+			if msg.Success {
+				detail := msg.Message
+				if detail == "" {
+					detail = "done"
+				}
+				m.setStatus(fmt.Sprintf("%s: %s", op.Description, detail), false)
+			} else {
+				detail := msg.Message
+				if detail == "" {
+					detail = "unknown error"
+				}
+				m.setStatus(fmt.Sprintf("%s failed: %s", op.Description, detail), true)
+			}
+		}
+		if m.asyncEvents != nil {
+			return m, waitForAsyncEvent(m.asyncEvents)
 		}
 
 	case TickMsg:
@@ -1686,6 +1769,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// previous refresh is still in flight.
 		if m.data != nil {
 			m.healthTickCount++
+			m.expirePendingOps()
 			cmds := []tea.Cmd{Tick()}
 			if !m.refreshing {
 				m.refreshing = true
@@ -1810,6 +1894,12 @@ func (m *Model) View() string {
 		} else {
 			footerText = statusMsgStyle.Render(m.statusMsg)
 		}
+	} else if len(m.pendingAsync) > 0 {
+		var parts []string
+		for _, op := range m.pendingAsync {
+			parts = append(parts, op.Description+"…")
+		}
+		footerText = statusMsgStyle.Render(strings.Join(parts, " | "))
 	}
 	footer := footerStyle.Width(m.width).Render(footerText)
 	footerH := lipgloss.Height(footer)
@@ -2249,8 +2339,16 @@ func (m *Model) executeAction(choice ActionMenuChoice) tea.Cmd {
 	switch choice {
 	case ActionRetry:
 		if m.OnRetryBead != nil {
-			if err := m.OnRetryBead(bead.BeadID, bead.Anvil, bead.PRID); err != nil {
+			reqID, err := m.OnRetryBead(bead.BeadID, bead.Anvil, bead.PRID)
+			if err != nil {
 				m.setStatus(fmt.Sprintf("Failed to retry %s: %v", label, err), true)
+			} else if reqID != "" {
+				m.trackPending(reqID, fmt.Sprintf("Retrying %s", label))
+				m.removeNeedsAttentionItem(bead.BeadID, bead.Anvil, bead.PRID)
+				if m.data != nil {
+					return FetchNeedsAttention(m.data)
+				}
+				return nil
 			} else {
 				m.setStatus(fmt.Sprintf("Retry queued for %s", label), false)
 				m.removeNeedsAttentionItem(bead.BeadID, bead.Anvil, bead.PRID)
@@ -2491,9 +2589,10 @@ type notesTarget struct {
 
 // NotesResultMsg is delivered asynchronously when an append-notes action completes.
 type NotesResultMsg struct {
-	BeadID string
-	Anvil  string
-	Err    error
+	BeadID    string
+	Anvil     string
+	Err       error
+	RequestID string
 }
 
 // CrucibleActionResultMsg is delivered asynchronously when a crucible action completes.
@@ -2579,9 +2678,10 @@ func (m *Model) executeCrucibleAction(choice CrucibleActionMenuChoice) tea.Cmd {
 
 // QueueActionResultMsg is delivered asynchronously when a queue action completes.
 type QueueActionResultMsg struct {
-	BeadID string
-	Action string // "tag", "force_run", "close", or "stop"
-	Err    error
+	BeadID    string
+	Action    string // "tag", "force_run", "close", or "stop"
+	Err       error
+	RequestID string // non-empty when the action was queued for async processing
 }
 
 // executeQueueAction returns a tea.Cmd that runs the queue action asynchronously,
@@ -2618,7 +2718,8 @@ func (m *Model) tagSelectedQueueItem() tea.Cmd {
 	beadID, anvil := item.BeadID, item.Anvil
 	cb := m.OnTagBead
 	return func() tea.Msg {
-		return QueueActionResultMsg{BeadID: beadID, Action: "tag", Err: cb(beadID, anvil)}
+		reqID, err := cb(beadID, anvil)
+		return QueueActionResultMsg{BeadID: beadID, Action: "tag", Err: err, RequestID: reqID}
 	}
 }
 
@@ -2636,7 +2737,8 @@ func (m *Model) closeSelectedQueueItem() tea.Cmd {
 	beadID, anvil := item.BeadID, item.Anvil
 	cb := m.OnCloseBead
 	return func() tea.Msg {
-		return QueueActionResultMsg{BeadID: beadID, Action: "close", Err: cb(beadID, anvil)}
+		reqID, err := cb(beadID, anvil)
+		return QueueActionResultMsg{BeadID: beadID, Action: "close", Err: err, RequestID: reqID}
 	}
 }
 // stopSelectedQueueItem stops all processing of the bead stored in queueActionTarget.
@@ -2653,7 +2755,8 @@ func (m *Model) stopSelectedQueueItem() tea.Cmd {
 	beadID, anvil := item.BeadID, item.Anvil
 	cb := m.OnStopBead
 	return func() tea.Msg {
-		return QueueActionResultMsg{BeadID: beadID, Action: "stop", Err: cb(beadID, anvil)}
+		reqID, err := cb(beadID, anvil)
+		return QueueActionResultMsg{BeadID: beadID, Action: "stop", Err: err, RequestID: reqID}
 	}
 }
 
@@ -2864,9 +2967,10 @@ func (m *Model) buildPRActionForm(item *PRItem, choice *PRActionMenuChoice) *huh
 
 // PRActionResultMsg is delivered asynchronously when a PR action IPC call completes.
 type PRActionResultMsg struct {
-	PRNumber int
-	Action   string
-	Err      error
+	PRNumber  int
+	Action    string
+	Err       error
+	RequestID string
 }
 
 // executePRAction dispatches the selected PR action.
@@ -2904,8 +3008,8 @@ func (m *Model) executePRAction(choice PRActionMenuChoice) tea.Cmd {
 	m.setStatus(fmt.Sprintf("PR #%d: %s...", item.PRNumber, action), false)
 
 	return func() tea.Msg {
-		err := m.OnPRAction(item.PRID, item.PRNumber, item.Anvil, item.BeadID, item.Branch, action)
-		return PRActionResultMsg{PRNumber: item.PRNumber, Action: action, Err: err}
+		reqID, err := m.OnPRAction(item.PRID, item.PRNumber, item.Anvil, item.BeadID, item.Branch, action)
+		return PRActionResultMsg{PRNumber: item.PRNumber, Action: action, Err: err, RequestID: reqID}
 	}
 }
 // The choice pointer is bound to the form's value so huh updates it on selection.
@@ -3134,7 +3238,8 @@ func (m *Model) submitNotes() tea.Cmd {
 	cb := m.OnAppendNotes
 	// We do NOT clear showNotesOverlay/notesTA here; we wait for success in Update.
 	return func() tea.Msg {
-		return NotesResultMsg{BeadID: target.BeadID, Anvil: target.Anvil, Err: cb(target.BeadID, target.Anvil, notes)}
+		reqID, err := cb(target.BeadID, target.Anvil, notes)
+		return NotesResultMsg{BeadID: target.BeadID, Anvil: target.Anvil, Err: err, RequestID: reqID}
 	}
 }
 
@@ -5102,4 +5207,85 @@ func isTerminalMsg(msg tea.Msg) bool {
 		return true
 	}
 	return false
+}
+
+// startAsyncSubscription returns a Cmd that connects to the daemon's event
+// stream. On success it delivers an asyncSubscriptionStartedMsg.
+func startAsyncSubscription() tea.Cmd {
+	return func() tea.Msg {
+		client, err := ipc.NewClient()
+		if err != nil {
+			return nil
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		events := client.Subscribe(ctx)
+		return asyncSubscriptionStartedMsg{events: events, cancel: cancel}
+	}
+}
+
+// waitForAsyncEvent blocks until the next async_complete event arrives on the
+// subscription channel and returns it as an AsyncCompletionMsg.
+func waitForAsyncEvent(events <-chan ipc.Event) tea.Cmd {
+	return func() tea.Msg {
+		for evt := range events {
+			if evt.Type != "async_complete" {
+				continue
+			}
+			var data struct {
+				RequestID string `json:"request_id"`
+				Type      string `json:"type"`
+				Response  struct {
+					Type    string          `json:"type"`
+					Payload json.RawMessage `json:"payload"`
+				} `json:"response"`
+			}
+			if json.Unmarshal(evt.Data, &data) != nil {
+				continue
+			}
+			msg := AsyncCompletionMsg{
+				RequestID: data.RequestID,
+				Success:   data.Response.Type == "ok",
+			}
+			var payload struct{ Message string }
+			if json.Unmarshal(data.Response.Payload, &payload) == nil && payload.Message != "" {
+				msg.Message = payload.Message
+			}
+			return msg
+		}
+		return nil
+	}
+}
+
+// trackPending registers an async operation for status-line correlation.
+func (m *Model) trackPending(requestID, description string) {
+	if requestID == "" {
+		return
+	}
+	if m.pendingAsync == nil {
+		m.pendingAsync = make(map[string]pendingOp)
+	}
+	m.pendingAsync[requestID] = pendingOp{
+		Description: description,
+		StartedAt:   time.Now(),
+	}
+}
+
+const asyncTimeout = 60 * time.Second
+
+// expirePendingOps removes stale pending operations older than asyncTimeout.
+func (m *Model) expirePendingOps() {
+	for id, op := range m.pendingAsync {
+		if time.Since(op.StartedAt) > asyncTimeout {
+			m.setStatus(fmt.Sprintf("%s: timed out", op.Description), true)
+			delete(m.pendingAsync, id)
+		}
+	}
+}
+
+// cleanupAsyncSubscription cancels the event subscription if active.
+func (m *Model) cleanupAsyncSubscription() {
+	if m.asyncCancelFunc != nil {
+		m.asyncCancelFunc()
+		m.asyncCancelFunc = nil
+	}
 }

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -617,6 +617,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.orphanDialogForm != nil {
 		if k, ok := msg.(tea.KeyMsg); ok {
 			if k.Type == tea.KeyCtrlC || k.String() == "ctrl+c" {
+				m.cleanupAsyncSubscription()
 				return m, tea.Quit
 			}
 			if k.Type == tea.KeyEsc {
@@ -783,6 +784,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showLogViewer {
 			switch msg.String() {
 			case "ctrl+c":
+				m.cleanupAsyncSubscription()
 				return m, tea.Quit
 			case "q", "esc":
 				m.showLogViewer = false
@@ -798,6 +800,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showDescriptionViewer {
 			switch msg.String() {
 			case "ctrl+c":
+				m.cleanupAsyncSubscription()
 				return m, tea.Quit
 			case "q", "esc":
 				m.showDescriptionViewer = false
@@ -813,6 +816,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.showNotesOverlay {
 			switch msg.String() {
 			case "ctrl+c":
+				m.cleanupAsyncSubscription()
 				return m, tea.Quit
 			case "esc":
 				m.showNotesOverlay = false
@@ -856,6 +860,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			switch msg.String() {
 			case "ctrl+c":
+				m.cleanupAsyncSubscription()
 				return m, tea.Quit
 			case "p", "q", "esc":
 				m.showPRPanel = false
@@ -887,6 +892,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.eventFilterActive {
 			switch msg.String() {
 			case "ctrl+c":
+				m.cleanupAsyncSubscription()
 				return m, tea.Quit
 			case "esc":
 				m.eventFilterActive = false

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 	"unicode"
@@ -318,6 +319,7 @@ type AsyncCompletionMsg struct {
 type asyncSubscriptionStartedMsg struct {
 	events <-chan ipc.Event
 	cancel context.CancelFunc
+	client *ipc.Client
 }
 
 // Model is the Bubbletea model for the Hearth TUI.
@@ -481,6 +483,7 @@ type Model struct {
 	pendingAsync    map[string]pendingOp
 	asyncEvents     <-chan ipc.Event
 	asyncCancelFunc context.CancelFunc
+	asyncClient     *ipc.Client
 
 	// Cooldown for manual Wicket scans — prevents rapid repeated triggers.
 	wicketScanCooldownUntil time.Time
@@ -1738,6 +1741,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case asyncSubscriptionStartedMsg:
 		m.asyncEvents = msg.events
 		m.asyncCancelFunc = msg.cancel
+		m.asyncClient = msg.client
 		return m, waitForAsyncEvent(msg.events)
 
 	case AsyncCompletionMsg:
@@ -1895,8 +1899,15 @@ func (m *Model) View() string {
 			footerText = statusMsgStyle.Render(m.statusMsg)
 		}
 	} else if len(m.pendingAsync) > 0 {
-		var parts []string
+		ops := make([]pendingOp, 0, len(m.pendingAsync))
 		for _, op := range m.pendingAsync {
+			ops = append(ops, op)
+		}
+		slices.SortFunc(ops, func(a, b pendingOp) int {
+			return a.StartedAt.Compare(b.StartedAt)
+		})
+		var parts []string
+		for _, op := range ops {
 			parts = append(parts, op.Description+"…")
 		}
 		footerText = statusMsgStyle.Render(strings.Join(parts, " | "))
@@ -5219,7 +5230,7 @@ func startAsyncSubscription() tea.Cmd {
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		events := client.Subscribe(ctx)
-		return asyncSubscriptionStartedMsg{events: events, cancel: cancel}
+		return asyncSubscriptionStartedMsg{events: events, cancel: cancel, client: client}
 	}
 }
 
@@ -5287,5 +5298,9 @@ func (m *Model) cleanupAsyncSubscription() {
 	if m.asyncCancelFunc != nil {
 		m.asyncCancelFunc()
 		m.asyncCancelFunc = nil
+	}
+	if m.asyncClient != nil {
+		m.asyncClient.Close()
+		m.asyncClient = nil
 	}
 }

--- a/internal/hearth/hearth_test.go
+++ b/internal/hearth/hearth_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Robin831/Forge/internal/ingot"
 	"github.com/Robin831/Forge/internal/state"
@@ -3581,5 +3582,121 @@ func TestRenderUsagePanelHidesIngotsWhenZero(t *testing.T) {
 	rendered := m.renderUsagePanel(80, 15)
 	if strings.Contains(rendered, "Ingots") {
 		t.Errorf("expected usage panel to hide ingots when total is 0, got: %s", rendered)
+	}
+}
+
+func TestTrackPending(t *testing.T) {
+	m := NewModel(nil)
+
+	m.trackPending("", "should be ignored")
+	if m.pendingAsync != nil {
+		t.Fatal("empty requestID should not create map")
+	}
+
+	m.trackPending("req-1", "Tagging bead")
+	if len(m.pendingAsync) != 1 {
+		t.Fatalf("expected 1 pending op, got %d", len(m.pendingAsync))
+	}
+	op := m.pendingAsync["req-1"]
+	if op.Description != "Tagging bead" {
+		t.Errorf("expected description 'Tagging bead', got %q", op.Description)
+	}
+	if op.StartedAt.IsZero() {
+		t.Error("expected non-zero StartedAt")
+	}
+}
+
+func TestExpirePendingOps(t *testing.T) {
+	m := NewModel(nil)
+	m.pendingAsync = map[string]pendingOp{
+		"old": {Description: "Stale op", StartedAt: time.Now().Add(-2 * asyncTimeout)},
+		"new": {Description: "Fresh op", StartedAt: time.Now()},
+	}
+
+	m.expirePendingOps()
+
+	if _, ok := m.pendingAsync["old"]; ok {
+		t.Error("expected stale op to be expired")
+	}
+	if _, ok := m.pendingAsync["new"]; !ok {
+		t.Error("expected fresh op to remain")
+	}
+	if m.statusMsg == "" {
+		t.Error("expected status message for expired op")
+	}
+}
+
+func TestAsyncCompletionMsgSuccess(t *testing.T) {
+	m := NewModel(nil)
+	m.pendingAsync = map[string]pendingOp{
+		"req-1": {Description: "Tagging bead", StartedAt: time.Now()},
+	}
+
+	msg := AsyncCompletionMsg{RequestID: "req-1", Success: true, Message: "tagged"}
+	mTmp, _ := m.Update(msg)
+	m = *mTmp.(*Model)
+
+	if len(m.pendingAsync) != 0 {
+		t.Error("expected pending op to be removed after completion")
+	}
+	if !strings.Contains(m.statusMsg, "Tagging bead") || !strings.Contains(m.statusMsg, "tagged") {
+		t.Errorf("expected status to contain op description and message, got %q", m.statusMsg)
+	}
+	if m.statusMsgIsError {
+		t.Error("expected non-error status for success")
+	}
+}
+
+func TestAsyncCompletionMsgError(t *testing.T) {
+	m := NewModel(nil)
+	m.pendingAsync = map[string]pendingOp{
+		"req-2": {Description: "Closing bead", StartedAt: time.Now()},
+	}
+
+	msg := AsyncCompletionMsg{RequestID: "req-2", Success: false, Message: "permission denied"}
+	mTmp, _ := m.Update(msg)
+	m = *mTmp.(*Model)
+
+	if len(m.pendingAsync) != 0 {
+		t.Error("expected pending op to be removed after error completion")
+	}
+	if !strings.Contains(m.statusMsg, "failed") {
+		t.Errorf("expected 'failed' in status, got %q", m.statusMsg)
+	}
+	if !m.statusMsgIsError {
+		t.Error("expected error status for failure")
+	}
+}
+
+func TestAsyncCompletionMsgUnknownRequestID(t *testing.T) {
+	m := NewModel(nil)
+	m.pendingAsync = map[string]pendingOp{
+		"req-1": {Description: "Tagging bead", StartedAt: time.Now()},
+	}
+
+	msg := AsyncCompletionMsg{RequestID: "unknown", Success: true}
+	mTmp, _ := m.Update(msg)
+	m = *mTmp.(*Model)
+
+	if len(m.pendingAsync) != 1 {
+		t.Error("expected unrelated pending op to remain")
+	}
+}
+
+func TestCleanupAsyncSubscription(t *testing.T) {
+	m := NewModel(nil)
+	cancelled := false
+	m.asyncCancelFunc = func() { cancelled = true }
+
+	m.cleanupAsyncSubscription()
+
+	if !cancelled {
+		t.Error("expected cancel func to be called")
+	}
+	if m.asyncCancelFunc != nil {
+		t.Error("expected cancel func to be nil after cleanup")
+	}
+	if m.asyncClient != nil {
+		t.Error("expected client to be nil after cleanup")
 	}
 }

--- a/internal/hearth/hearth_test.go
+++ b/internal/hearth/hearth_test.go
@@ -1176,10 +1176,10 @@ func TestQueueActionMenuLabelCallsOnTagBead(t *testing.T) {
 		{BeadID: "bd-3", Anvil: "forge", Section: "unlabeled"},
 	}
 	m.queueVP = scrollViewport{cursor: 0}
-	m.OnTagBead = func(beadID, anvil string) error {
+	m.OnTagBead = func(beadID, anvil string) (string, error) {
 		taggedBead = beadID
 		taggedAnvil = anvil
-		return nil
+		return "", nil
 	}
 	m.rebuildQueueNav()
 	// Open the menu
@@ -1218,8 +1218,8 @@ func TestQueueActionMenuLabelOnTagBeadError(t *testing.T) {
 		{BeadID: "bd-4", Anvil: "forge", Section: "unlabeled"},
 	}
 	m.queueVP = scrollViewport{cursor: 0}
-	m.OnTagBead = func(beadID, anvil string) error {
-		return errors.New("network error")
+	m.OnTagBead = func(beadID, anvil string) (string, error) {
+		return "", errors.New("network error")
 	}
 	m.rebuildQueueNav()
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -1245,10 +1245,10 @@ func TestQueueActionMenuCloseCallsOnCloseBead(t *testing.T) {
 		{BeadID: "bd-close-1", Anvil: "forge", Section: "unlabeled"},
 	}
 	m.queueVP = scrollViewport{cursor: 0}
-	m.OnCloseBead = func(beadID, anvil string) error {
+	m.OnCloseBead = func(beadID, anvil string) (string, error) {
 		closedBead = beadID
 		closedAnvil = anvil
-		return nil
+		return "", nil
 	}
 	m.rebuildQueueNav()
 	// Open the menu
@@ -1288,8 +1288,8 @@ func TestQueueActionMenuCloseOnCloseBeadError(t *testing.T) {
 		{BeadID: "bd-close-2", Anvil: "forge", Section: "unlabeled"},
 	}
 	m.queueVP = scrollViewport{cursor: 0}
-	m.OnCloseBead = func(beadID, anvil string) error {
-		return errors.New("bd close failed")
+	m.OnCloseBead = func(beadID, anvil string) (string, error) {
+		return "", errors.New("bd close failed")
 	}
 	m.rebuildQueueNav()
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -1551,7 +1551,7 @@ func TestExecuteAction_RetrySuccess_DataNil_ReturnsNil(t *testing.T) {
 	target := NeedsAttentionItem{BeadID: "forge-1", Anvil: "test"}
 	m.actionTarget = &target
 	m.needsAttention = []NeedsAttentionItem{target}
-	m.OnRetryBead = func(_, _ string, _ int) error { return nil }
+	m.OnRetryBead = func(_, _ string, _ int) (string, error) { return "", nil }
 
 	cmd := m.executeAction(ActionRetry)
 	if cmd != nil {
@@ -1583,7 +1583,7 @@ func TestExecuteAction_RetryError_ItemNotRemoved(t *testing.T) {
 	target := NeedsAttentionItem{BeadID: "forge-3", Anvil: "test"}
 	m.actionTarget = &target
 	m.needsAttention = []NeedsAttentionItem{target}
-	m.OnRetryBead = func(_, _ string, _ int) error { return errors.New("retry failed") }
+	m.OnRetryBead = func(_, _ string, _ int) (string, error) { return "", errors.New("retry failed") }
 
 	m.executeAction(ActionRetry)
 	if len(m.needsAttention) != 1 {
@@ -1612,7 +1612,7 @@ func TestExecuteAction_NonBeadPR_RetryStatusUsesTitle(t *testing.T) {
 	target := NeedsAttentionItem{BeadID: "", Anvil: "test", PRID: 5, Title: "warden-learn/forge"}
 	m.actionTarget = &target
 	m.needsAttention = []NeedsAttentionItem{target}
-	m.OnRetryBead = func(_, _ string, _ int) error { return nil }
+	m.OnRetryBead = func(_, _ string, _ int) (string, error) { return "", nil }
 
 	m.executeAction(ActionRetry)
 
@@ -1647,7 +1647,7 @@ func TestExecuteAction_NonBeadPR_RetryErrorStatusUsesTitle(t *testing.T) {
 	target := NeedsAttentionItem{BeadID: "", Anvil: "test", PRID: 7, Title: "warden-learn/forge"}
 	m.actionTarget = &target
 	m.needsAttention = []NeedsAttentionItem{target}
-	m.OnRetryBead = func(_, _ string, _ int) error { return errors.New("reset failed") }
+	m.OnRetryBead = func(_, _ string, _ int) (string, error) { return "", errors.New("reset failed") }
 
 	m.executeAction(ActionRetry)
 
@@ -3099,11 +3099,11 @@ func TestOpenNotesOverlayFromNeedsAttention(t *testing.T) {
 func TestSubmitNotes(t *testing.T) {
 	var capturedID, capturedAnvil, capturedNotes string
 	m := NewModel(nil)
-	m.OnAppendNotes = func(beadID, anvil, notes string) error {
+	m.OnAppendNotes = func(beadID, anvil, notes string) (string, error) {
 		capturedID = beadID
 		capturedAnvil = anvil
 		capturedNotes = notes
-		return nil
+		return "", nil
 	}
 	m.openNotesOverlay("Forge-1", "test-anvil", "Title")
 	m.notesTA.SetValue("These are my notes")

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -560,6 +560,14 @@ func (c *Client) Subscribe(ctx context.Context) <-chan Event {
 		// block indefinitely waiting for the next pushed event.
 		_ = c.conn.SetReadDeadline(time.Time{})
 
+		// When ctx is cancelled, close the connection to unblock scanner.Scan().
+		// Without this, the goroutine would only check ctx.Done() after a line
+		// is read, which may never happen if no events arrive.
+		go func() {
+			<-ctx.Done()
+			c.conn.Close()
+		}()
+
 		scanner := bufio.NewScanner(c.conn)
 		scanner.Buffer(make([]byte, 64*1024), 64*1024)
 

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -529,7 +529,7 @@ func (c *Client) Send(cmd Command) (*Response, error) {
 		return nil, fmt.Errorf("sending command: %w", err)
 	}
 
-	_ = c.conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	_ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
 	scanner := bufio.NewScanner(c.conn)
 	scanner.Buffer(make([]byte, 64*1024), 64*1024)
 	if !scanner.Scan() {
@@ -555,6 +555,10 @@ func (c *Client) Subscribe(ctx context.Context) <-chan Event {
 
 		// Send subscribe command
 		_, _ = c.Send(Command{Type: "subscribe"})
+
+		// Clear the read deadline set by Send so the event stream can
+		// block indefinitely waiting for the next pushed event.
+		_ = c.conn.SetReadDeadline(time.Time{})
 
 		scanner := bufio.NewScanner(c.conn)
 		scanner.Buffer(make([]byte, 64*1024), 64*1024)


### PR DESCRIPTION
## Changes

- **TUI async IPC correlation** - Hearth TUI now handles async "queued" IPC responses by subscribing to daemon completion events, correlating by request_id, and updating the status line with success or error messages. IPC read deadline reduced from 10s to 3s since only the fast initial ack needs to arrive. (Forge-pkkq)

## Original Issue (task): TUI: correlate async ack events and update status line

Update the Hearth TUI to handle the new async flow. When the TUI receives a 'queued' response, show a pending/in-progress indicator on the status line (e.g., 'Tagging bead...'). Subscribe to daemon completion events, correlate by request_id, and update the status line to success or show the actual error message. Remove or increase the 10-second IPC read deadline for commands that now use async ack (the initial 'queued' response should arrive quickly, so a short deadline is fine for that part). Files to modify: TUI components that issue IPC calls and display results, plus the IPC client timeout logic in internal/ipc/ipc.go:428. Depends on sub-tasks 1 and 2.

---
Bead: Forge-pkkq | Branch: forge/Forge-pkkq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)