### PR TITLE
Worktree corruption: Smith can run on main checkout after worktree state gets broken (Forge-cn6x)

### DIFF
--- a/changelog.d/Forge-cn6x.md
+++ b/changelog.d/Forge-cn6x.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Worktree corruption guard** - Hardened worktree validation to check for .git file presence and gitdir integrity, preventing Smith from accidentally editing the main checkout when a worktree directory exists but lacks proper git linkage. Added retry-with-backoff for directory removal on Windows, post-creation verification, and a Smith-side pre-flight check that refuses to run in an invalid worktree. (Forge-cn6x)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4997,6 +4997,22 @@ func verifyAnvilOnMain(ctx context.Context, logger *slog.Logger, anvilPath strin
 	if recovered {
 		logger.Warn("anvil repo was not on main/master — performed recovery checkout",
 			"anvil", anvilPath, "original_branch", originalBranch)
+
+		// Invalidate any stale worktree directory that matches the recovered
+		// branch. If the previous run left a .workers/<bead-id>/ directory
+		// without a valid .git file, it must be removed so the next dispatch
+		// doesn't reuse it and accidentally edit the main checkout.
+		if strings.HasPrefix(originalBranch, "forge/") {
+			beadDir := strings.TrimPrefix(originalBranch, "forge/")
+			stalePath := filepath.Join(anvilPath, ".workers", beadDir)
+			if err := worktree.ValidateWorktreeDir(stalePath); err != nil {
+				if _, statErr := os.Stat(stalePath); statErr == nil {
+					logger.Warn("removing stale worktree directory after branch recovery",
+						"path", stalePath, "validation_error", err)
+					_ = os.RemoveAll(stalePath)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5009,7 +5009,10 @@ func verifyAnvilOnMain(ctx context.Context, logger *slog.Logger, anvilPath strin
 				if _, statErr := os.Stat(stalePath); statErr == nil {
 					logger.Warn("removing stale worktree directory after branch recovery",
 						"path", stalePath, "validation_error", err)
-					_ = os.RemoveAll(stalePath)
+					if rmErr := os.RemoveAll(stalePath); rmErr != nil {
+						logger.Error("failed to remove stale worktree directory",
+							"path", stalePath, "error", rmErr)
+					}
 				}
 			}
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5009,7 +5009,7 @@ func verifyAnvilOnMain(ctx context.Context, logger *slog.Logger, anvilPath strin
 				if _, statErr := os.Stat(stalePath); statErr == nil {
 					logger.Warn("removing stale worktree directory after branch recovery",
 						"path", stalePath, "validation_error", err)
-					if rmErr := os.RemoveAll(stalePath); rmErr != nil {
+					if rmErr := worktree.RemoveWithRetry(ctx, stalePath); rmErr != nil {
 						logger.Error("failed to remove stale worktree directory",
 							"path", stalePath, "error", rmErr)
 					}

--- a/internal/smith/smith.go
+++ b/internal/smith/smith.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Robin831/Forge/internal/cost"
 	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/provider"
+	"github.com/Robin831/Forge/internal/worktree"
 )
 
 // Result captures the outcome of a Smith session.
@@ -170,6 +171,10 @@ func Spawn(ctx context.Context, worktreePath, promptText, logDir string, extraFl
 //
 // logDir is where the session log file is written.
 func SpawnWithProvider(ctx context.Context, worktreePath, promptText, logDir string, pv provider.Provider, extraFlags []string) (*Process, error) {
+	if err := worktree.ValidateWorktreeDir(worktreePath); err != nil {
+		return nil, fmt.Errorf("smith pre-flight: working directory is not a valid worktree — refusing to run to prevent editing the main checkout: %w", err)
+	}
+
 	args := pv.BuildArgs(extraFlags)
 
 	cmd := exec.CommandContext(ctx, pv.Cmd(), args...)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -144,7 +146,9 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 			return &Worktree{Path: worktreePath, Branch: targetBranch}, nil
 		}
 		// Not a valid worktree — remove the stale directory.
-		_ = os.RemoveAll(worktreePath)
+		if err := removeWithRetry(worktreePath); err != nil {
+			return nil, fmt.Errorf("removing stale worktree directory %s: %w", worktreePath, err)
+		}
 	}
 
 	if !opts.LocalHead {
@@ -221,6 +225,14 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 		if err := git(anvilPath, "worktree", "add", "-f", "-b", targetBranch, worktreePath, baseRef); err != nil {
 			return nil, fmt.Errorf("git worktree add (new): %w", err)
 		}
+	}
+
+	// Post-creation safety: verify the new worktree has a valid .git file
+	// pointing to a real gitdir. Without this, a silent git failure could
+	// leave a directory that git operations resolve to the parent repo.
+	if err := verifyWorktreeGitFile(worktreePath); err != nil {
+		_ = os.RemoveAll(worktreePath)
+		return nil, fmt.Errorf("post-creation worktree verification failed: %w", err)
 	}
 
 	// Install .beads/redirect so bd can find the beads database
@@ -388,9 +400,39 @@ func resolveBaseRef(ctx context.Context, repoPath string) (string, error) {
 	return "", fmt.Errorf("neither origin/main nor origin/master found")
 }
 
-// isValidWorktree checks whether a directory is a valid git worktree by running
-// git rev-parse --is-inside-work-tree inside it.
+// isValidWorktree checks whether a directory is a valid git worktree.
+// It verifies: (1) a .git file (not directory) exists — worktrees use a .git
+// file pointing to the main repo, (2) the .git file content references a valid
+// gitdir path on disk, (3) git rev-parse succeeds inside the directory.
+// Without the .git file check, a directory that lost its worktree link (e.g.
+// due to locked-file cleanup failure on Windows) would pass git rev-parse by
+// walking up to the parent repo, causing Smith to edit the main checkout.
 func isValidWorktree(ctx context.Context, dir string) bool {
+	gitPath := filepath.Join(dir, ".git")
+	info, err := os.Lstat(gitPath)
+	if err != nil {
+		return false
+	}
+	// Worktrees have a .git *file* (not directory) containing "gitdir: <path>".
+	// A .git directory means this is a full repo clone, not a worktree.
+	if info.IsDir() {
+		return false
+	}
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return false
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return false
+	}
+	gitdir := strings.TrimPrefix(line, "gitdir: ")
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(dir, gitdir)
+	}
+	if _, err := os.Stat(gitdir); err != nil {
+		return false
+	}
 	return gitCmd(ctx, dir, "rev-parse", "--is-inside-work-tree") == nil
 }
 
@@ -503,6 +545,65 @@ func BranchName(beadID string) string {
 // create/reset cycle.
 func (m *Manager) FetchBranch(ctx context.Context, anvilPath, branchName string) error {
 	return gitCmd(ctx, anvilPath, "fetch", "origin", "--", branchName)
+}
+
+// removeWithRetry attempts os.RemoveAll with exponential backoff to handle
+// Windows file-locking and antivirus delays. On non-Windows platforms it
+// makes a single attempt.
+func removeWithRetry(path string) error {
+	delays := []time.Duration{0}
+	if runtime.GOOS == "windows" {
+		delays = []time.Duration{0, 1 * time.Second, 2 * time.Second, 4 * time.Second}
+	}
+	var lastErr error
+	for i, delay := range delays {
+		if delay > 0 {
+			log.Printf("[worktree] retrying removal of %s (attempt %d/%d, waiting %v)", path, i+1, len(delays), delay)
+			time.Sleep(delay)
+		}
+		lastErr = os.RemoveAll(path)
+		if lastErr == nil {
+			return nil
+		}
+		log.Printf("[worktree] os.RemoveAll(%s) failed (attempt %d/%d): %v", path, i+1, len(delays), lastErr)
+	}
+	return fmt.Errorf("failed after %d attempts: %w", len(delays), lastErr)
+}
+
+// verifyWorktreeGitFile checks that a worktree directory contains a valid .git
+// file (not directory) whose gitdir target exists on disk.
+func verifyWorktreeGitFile(worktreePath string) error {
+	gitPath := filepath.Join(worktreePath, ".git")
+	info, err := os.Lstat(gitPath)
+	if err != nil {
+		return fmt.Errorf(".git file missing in worktree %s: %w", worktreePath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf(".git is a directory (expected file) in worktree %s", worktreePath)
+	}
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return fmt.Errorf("reading .git file in worktree %s: %w", worktreePath, err)
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return fmt.Errorf(".git file in worktree %s has unexpected content: %q", worktreePath, line)
+	}
+	gitdir := strings.TrimPrefix(line, "gitdir: ")
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(worktreePath, gitdir)
+	}
+	if _, err := os.Stat(gitdir); err != nil {
+		return fmt.Errorf(".git file points to nonexistent gitdir %s: %w", gitdir, err)
+	}
+	return nil
+}
+
+// ValidateWorktreeDir checks that the given directory is a valid git worktree
+// (has a .git file, not directory, pointing to a valid gitdir). This is
+// exported for use as a pre-flight check before starting Smith.
+func ValidateWorktreeDir(worktreePath string) error {
+	return verifyWorktreeGitFile(worktreePath)
 }
 
 // sanitizePath converts a bead ID to a safe directory/branch name.

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -558,14 +558,16 @@ func removeWithRetry(path string) error {
 	var lastErr error
 	for i, delay := range delays {
 		if delay > 0 {
-			log.Printf("[worktree] retrying removal of %s (attempt %d/%d, waiting %v)", path, i+1, len(delays), delay)
+			slog.Warn("retrying worktree directory removal",
+				"path", path, "attempt", i+1, "total_attempts", len(delays), "backoff", delay)
 			time.Sleep(delay)
 		}
 		lastErr = os.RemoveAll(path)
 		if lastErr == nil {
 			return nil
 		}
-		log.Printf("[worktree] os.RemoveAll(%s) failed (attempt %d/%d): %v", path, i+1, len(delays), lastErr)
+		slog.Warn("worktree directory removal failed",
+			"path", path, "attempt", i+1, "total_attempts", len(delays), "error", lastErr)
 	}
 	return fmt.Errorf("failed after %d attempts: %w", len(delays), lastErr)
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -146,7 +146,7 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 			return &Worktree{Path: worktreePath, Branch: targetBranch}, nil
 		}
 		// Not a valid worktree — remove the stale directory.
-		if err := removeWithRetry(worktreePath); err != nil {
+		if err := removeWithRetry(ctx, worktreePath); err != nil {
 			return nil, fmt.Errorf("removing stale worktree directory %s: %w", worktreePath, err)
 		}
 	}
@@ -231,7 +231,7 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 	// pointing to a real gitdir. Without this, a silent git failure could
 	// leave a directory that git operations resolve to the parent repo.
 	if err := verifyWorktreeGitFile(worktreePath); err != nil {
-		_ = os.RemoveAll(worktreePath)
+		_ = removeWithRetry(ctx, worktreePath)
 		return nil, fmt.Errorf("post-creation worktree verification failed: %w", err)
 	}
 
@@ -400,6 +400,38 @@ func resolveBaseRef(ctx context.Context, repoPath string) (string, error) {
 	return "", fmt.Errorf("neither origin/main nor origin/master found")
 }
 
+// resolveValidatedGitDir reads and validates the .git file pointer in dir.
+// Worktrees have a .git *file* (not directory) containing "gitdir: <path>".
+// Returns the resolved, absolute gitdir path, or an error if the pointer is
+// missing, malformed, or points to a nonexistent directory.
+func resolveValidatedGitDir(dir string) (string, error) {
+	gitPath := filepath.Join(dir, ".git")
+	info, err := os.Lstat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	// A .git directory means this is a full repo clone, not a worktree.
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a directory", gitPath)
+	}
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return "", fmt.Errorf("%s does not contain a gitdir pointer", gitPath)
+	}
+	gitdir := strings.TrimPrefix(line, "gitdir: ")
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(dir, gitdir)
+	}
+	if _, err := os.Stat(gitdir); err != nil {
+		return "", err
+	}
+	return gitdir, nil
+}
+
 // isValidWorktree checks whether a directory is a valid git worktree.
 // It verifies: (1) a .git file (not directory) exists — worktrees use a .git
 // file pointing to the main repo, (2) the .git file content references a valid
@@ -408,29 +440,7 @@ func resolveBaseRef(ctx context.Context, repoPath string) (string, error) {
 // due to locked-file cleanup failure on Windows) would pass git rev-parse by
 // walking up to the parent repo, causing Smith to edit the main checkout.
 func isValidWorktree(ctx context.Context, dir string) bool {
-	gitPath := filepath.Join(dir, ".git")
-	info, err := os.Lstat(gitPath)
-	if err != nil {
-		return false
-	}
-	// Worktrees have a .git *file* (not directory) containing "gitdir: <path>".
-	// A .git directory means this is a full repo clone, not a worktree.
-	if info.IsDir() {
-		return false
-	}
-	content, err := os.ReadFile(gitPath)
-	if err != nil {
-		return false
-	}
-	line := strings.TrimSpace(string(content))
-	if !strings.HasPrefix(line, "gitdir: ") {
-		return false
-	}
-	gitdir := strings.TrimPrefix(line, "gitdir: ")
-	if !filepath.IsAbs(gitdir) {
-		gitdir = filepath.Join(dir, gitdir)
-	}
-	if _, err := os.Stat(gitdir); err != nil {
+	if _, err := resolveValidatedGitDir(dir); err != nil {
 		return false
 	}
 	return gitCmd(ctx, dir, "rev-parse", "--is-inside-work-tree") == nil
@@ -547,20 +557,37 @@ func (m *Manager) FetchBranch(ctx context.Context, anvilPath, branchName string)
 	return gitCmd(ctx, anvilPath, "fetch", "origin", "--", branchName)
 }
 
-// removeWithRetry attempts os.RemoveAll with exponential backoff to handle
-// Windows file-locking and antivirus delays. On non-Windows platforms it
-// makes a single attempt.
-func removeWithRetry(path string) error {
+// removeWithRetry attempts os.RemoveAll with exponential backoff and context
+// cancellation support to handle Windows file-locking and antivirus delays.
+// On non-Windows platforms it makes a single attempt.
+func removeWithRetry(ctx context.Context, path string) error {
 	delays := []time.Duration{0}
 	if runtime.GOOS == "windows" {
 		delays = []time.Duration{0, 1 * time.Second, 2 * time.Second, 4 * time.Second}
 	}
 	var lastErr error
 	for i, delay := range delays {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return fmt.Errorf("remove worktree %s canceled after %d attempts: %w", path, i, err)
+			}
+			return fmt.Errorf("remove worktree %s canceled: %w", path, err)
+		}
 		if delay > 0 {
 			slog.Warn("retrying worktree directory removal",
 				"path", path, "attempt", i+1, "total_attempts", len(delays), "backoff", delay)
-			time.Sleep(delay)
+			timer := time.NewTimer(delay)
+			select {
+			case <-timer.C:
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				if lastErr != nil {
+					return fmt.Errorf("remove worktree %s canceled after %d attempts: %w", path, i, ctx.Err())
+				}
+				return fmt.Errorf("remove worktree %s canceled: %w", path, ctx.Err())
+			}
 		}
 		lastErr = os.RemoveAll(path)
 		if lastErr == nil {
@@ -572,40 +599,46 @@ func removeWithRetry(path string) error {
 	return fmt.Errorf("failed after %d attempts: %w", len(delays), lastErr)
 }
 
+// RemoveWithRetry is the exported form of removeWithRetry for use by daemon-level
+// stale directory cleanup.
+func RemoveWithRetry(ctx context.Context, path string) error {
+	return removeWithRetry(ctx, path)
+}
+
 // verifyWorktreeGitFile checks that a worktree directory contains a valid .git
 // file (not directory) whose gitdir target exists on disk.
 func verifyWorktreeGitFile(worktreePath string) error {
-	gitPath := filepath.Join(worktreePath, ".git")
-	info, err := os.Lstat(gitPath)
-	if err != nil {
-		return fmt.Errorf(".git file missing in worktree %s: %w", worktreePath, err)
-	}
-	if info.IsDir() {
-		return fmt.Errorf(".git is a directory (expected file) in worktree %s", worktreePath)
-	}
-	content, err := os.ReadFile(gitPath)
-	if err != nil {
-		return fmt.Errorf("reading .git file in worktree %s: %w", worktreePath, err)
-	}
-	line := strings.TrimSpace(string(content))
-	if !strings.HasPrefix(line, "gitdir: ") {
-		return fmt.Errorf(".git file in worktree %s has unexpected content: %q", worktreePath, line)
-	}
-	gitdir := strings.TrimPrefix(line, "gitdir: ")
-	if !filepath.IsAbs(gitdir) {
-		gitdir = filepath.Join(worktreePath, gitdir)
-	}
-	if _, err := os.Stat(gitdir); err != nil {
-		return fmt.Errorf(".git file points to nonexistent gitdir %s: %w", gitdir, err)
+	if _, err := resolveValidatedGitDir(worktreePath); err != nil {
+		return fmt.Errorf("worktree %s has invalid .git file: %w", worktreePath, err)
 	}
 	return nil
 }
 
-// ValidateWorktreeDir checks that the given directory is a valid git worktree
-// (has a .git file, not directory, pointing to a valid gitdir). This is
-// exported for use as a pre-flight check before starting Smith.
+// ValidateWorktreeDir checks that the given directory is safe to run Smith in.
+// If the directory is not inside any git repository (e.g. an os.MkdirTemp dir
+// used by schematic or wicket), the check passes — there is no parent checkout
+// to accidentally inherit. If the directory is inside a git repo, it must have
+// a valid worktree .git file pointer to ensure isolation from the main checkout.
 func ValidateWorktreeDir(worktreePath string) error {
-	return verifyWorktreeGitFile(worktreePath)
+	_, gitFileErr := resolveValidatedGitDir(worktreePath)
+	if gitFileErr == nil {
+		// Has a valid .git file pointer — this is a proper worktree.
+		return nil
+	}
+	// No valid .git file. Check whether the directory is nonetheless inside a
+	// git repository (which would mean git commands resolve to the parent repo).
+	// If it is not inside any repo (e.g. an os.MkdirTemp dir), there is nothing
+	// to protect against and we allow the run.
+	cmdCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "rev-parse", "--git-dir"))
+	cmd.Dir = worktreePath
+	if err := cmd.Run(); err != nil {
+		// Not inside any git repository — safe to proceed.
+		return nil
+	}
+	// Inside a git repo without proper worktree isolation — refuse.
+	return fmt.Errorf("directory %s is inside a git repository but lacks a valid worktree .git file: %w", worktreePath, gitFileErr)
 }
 
 // sanitizePath converts a bead ID to a safe directory/branch name.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -342,6 +342,171 @@ func TestRemove_DoesNotDeleteRemoteBranch(t *testing.T) {
 	}
 }
 
+func TestIsValidWorktree_MissingGitFile(t *testing.T) {
+	dir := t.TempDir()
+	// Empty directory — no .git file at all.
+	if isValidWorktree(context.Background(), dir) {
+		t.Error("isValidWorktree should return false for directory without .git file")
+	}
+}
+
+func TestIsValidWorktree_GitDirectory(t *testing.T) {
+	dir := t.TempDir()
+	// Create a .git directory (like a full repo clone, not a worktree).
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if isValidWorktree(context.Background(), dir) {
+		t.Error("isValidWorktree should return false when .git is a directory")
+	}
+}
+
+func TestIsValidWorktree_BadGitFileContent(t *testing.T) {
+	dir := t.TempDir()
+	// Create a .git file with invalid content.
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("not a gitdir pointer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isValidWorktree(context.Background(), dir) {
+		t.Error("isValidWorktree should return false when .git file has bad content")
+	}
+}
+
+func TestIsValidWorktree_GitFilePointsToNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /nonexistent/path"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isValidWorktree(context.Background(), dir) {
+		t.Error("isValidWorktree should return false when .git file points to nonexistent gitdir")
+	}
+}
+
+func TestIsValidWorktree_RealWorktree(t *testing.T) {
+	// Set up a repo with a real worktree.
+	remoteDir := t.TempDir()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+	run(remoteDir, "init", "--bare", "--initial-branch=main")
+
+	anvilDir := t.TempDir()
+	run(anvilDir, "clone", remoteDir, ".")
+	run(anvilDir, "config", "user.email", "test@example.com")
+	run(anvilDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(anvilDir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(anvilDir, "add", "README")
+	run(anvilDir, "commit", "-m", "init")
+	run(anvilDir, "push", "origin", "main")
+
+	mgr := NewManager()
+	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "valid-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	if !isValidWorktree(context.Background(), wt.Path) {
+		t.Error("isValidWorktree should return true for a real worktree")
+	}
+}
+
+func TestValidateWorktreeDir_MissingGitFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := ValidateWorktreeDir(dir); err == nil {
+		t.Error("ValidateWorktreeDir should return error for directory without .git file")
+	}
+}
+
+func TestVerifyWorktreeGitFile_ValidWorktree(t *testing.T) {
+	remoteDir := t.TempDir()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+	run(remoteDir, "init", "--bare", "--initial-branch=main")
+
+	anvilDir := t.TempDir()
+	run(anvilDir, "clone", remoteDir, ".")
+	run(anvilDir, "config", "user.email", "test@example.com")
+	run(anvilDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(anvilDir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(anvilDir, "add", "README")
+	run(anvilDir, "commit", "-m", "init")
+	run(anvilDir, "push", "origin", "main")
+
+	mgr := NewManager()
+	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "verify-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	if err := ValidateWorktreeDir(wt.Path); err != nil {
+		t.Errorf("ValidateWorktreeDir should succeed for a real worktree, got: %v", err)
+	}
+}
+
+func TestCreateWithOptions_StaleDirectoryRemoved(t *testing.T) {
+	// Set up a repo with a remote.
+	remoteDir := t.TempDir()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+	run(remoteDir, "init", "--bare", "--initial-branch=main")
+
+	anvilDir := t.TempDir()
+	run(anvilDir, "clone", remoteDir, ".")
+	run(anvilDir, "config", "user.email", "test@example.com")
+	run(anvilDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(anvilDir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(anvilDir, "add", "README")
+	run(anvilDir, "commit", "-m", "init")
+	run(anvilDir, "push", "origin", "main")
+
+	// Create a stale .workers/stale-test/ directory without a .git file.
+	staleDir := filepath.Join(anvilDir, ".workers", "stale-test")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Add some junk files to simulate the bug scenario.
+	if err := os.MkdirAll(filepath.Join(staleDir, ".forge-logs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager()
+	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "stale-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions should succeed after removing stale dir: %v", err)
+	}
+
+	// Verify the new worktree is valid.
+	if err := ValidateWorktreeDir(wt.Path); err != nil {
+		t.Errorf("new worktree should be valid after stale directory removal: %v", err)
+	}
+}
+
 // gitOutput runs a git command and returns trimmed stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -29,30 +29,55 @@ func TestSanitizePath(t *testing.T) {
 	}
 }
 
+// runGit runs a git command in dir and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
+// initBareRemoteCloneWithInitialCommit creates a bare remote repository and a
+// clone of it with an initial commit pushed to origin/main. Returns the paths
+// of the bare remote and the clone (anvil) directory.
+func initBareRemoteCloneWithInitialCommit(t *testing.T) (remoteDir, cloneDir string) {
+	t.Helper()
+
+	remoteDir = t.TempDir()
+	runGit(t, remoteDir, "init", "--bare", "--initial-branch=main")
+
+	cloneDir = t.TempDir()
+	runGit(t, cloneDir, "clone", remoteDir, ".")
+	runGit(t, cloneDir, "config", "user.email", "test@example.com")
+	runGit(t, cloneDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(cloneDir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, cloneDir, "add", "README")
+	runGit(t, cloneDir, "commit", "-m", "init")
+	runGit(t, cloneDir, "push", "origin", "main")
+
+	return remoteDir, cloneDir
+}
+
 // initTestRepo creates a minimal git repository in dir with one commit on
 // the given branch. It configures a local user identity to avoid relying on
 // global git config (which may be absent in CI).
 func initTestRepo(t *testing.T, dir, branch string) {
 	t.Helper()
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
-	}
-	run("init", "--initial-branch="+branch)
-	run("config", "user.email", "test@example.com")
-	run("config", "user.name", "Test")
+	runGit(t, dir, "init", "--initial-branch="+branch)
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
 	// Create an initial commit so HEAD is resolvable.
 	readme := filepath.Join(dir, "README")
 	if err := os.WriteFile(readme, []byte("test\n"), 0o644); err != nil {
 		t.Fatalf("writing README: %v", err)
 	}
-	run("add", "README")
-	run("commit", "-m", "init")
+	runGit(t, dir, "add", "README")
+	runGit(t, dir, "commit", "-m", "init")
 }
 
 func TestCurrentBranch_OnMain(t *testing.T) {
@@ -203,31 +228,7 @@ func TestVerifyAndRecoverMain_RecoveryFails(t *testing.T) {
 // commits made by a previous pipeline run and resets the branch back to the
 // base ref (origin/main).
 func TestCreateWithOptions_ResetBranch(t *testing.T) {
-	// Set up a "remote" bare repo with one commit on main.
-	remoteDir := t.TempDir()
-	run := func(dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-		}
-	}
-	run(remoteDir, "init", "--bare", "--initial-branch=main")
-
-	// Clone the bare repo to serve as our "anvil".
-	anvilDir := t.TempDir()
-	run(anvilDir, "clone", remoteDir, ".")
-	run(anvilDir, "config", "user.email", "test@example.com")
-	run(anvilDir, "config", "user.name", "Test")
-	readme := filepath.Join(anvilDir, "README")
-	if err := os.WriteFile(readme, []byte("initial\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	run(anvilDir, "add", "README")
-	run(anvilDir, "commit", "-m", "init")
-	run(anvilDir, "push", "origin", "main")
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
 
 	// Record the base commit hash (this is origin/main).
 	baseHash := gitOutput(t, anvilDir, "rev-parse", "origin/main")
@@ -245,9 +246,9 @@ func TestCreateWithOptions_ResetBranch(t *testing.T) {
 	if err := os.WriteFile(badFile, []byte("junk\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	run(wt.Path, "add", "bad-change.txt")
-	run(wt.Path, "commit", "-m", "bad commit from failed smith")
-	run(wt.Path, "push", "origin", wt.Branch)
+	runGit(t, wt.Path, "add", "bad-change.txt")
+	runGit(t, wt.Path, "commit", "-m", "bad commit from failed smith")
+	runGit(t, wt.Path, "push", "origin", wt.Branch)
 
 	badHash := gitOutput(t, wt.Path, "rev-parse", "HEAD")
 	if badHash == baseHash {
@@ -287,31 +288,7 @@ func TestCreateWithOptions_ResetBranch(t *testing.T) {
 // the PR that was just created. Remote branch cleanup is handled by GitHub's
 // auto-delete setting or Bellows after merge.
 func TestRemove_DoesNotDeleteRemoteBranch(t *testing.T) {
-	// Set up a bare "remote" repo.
-	remoteDir := t.TempDir()
-	run := func(dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-		}
-	}
-	run(remoteDir, "init", "--bare", "--initial-branch=main")
-
-	// Clone the bare repo as our anvil.
-	anvilDir := t.TempDir()
-	run(anvilDir, "clone", remoteDir, ".")
-	run(anvilDir, "config", "user.email", "test@example.com")
-	run(anvilDir, "config", "user.name", "Test")
-	readme := filepath.Join(anvilDir, "README")
-	if err := os.WriteFile(readme, []byte("initial\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	run(anvilDir, "add", "README")
-	run(anvilDir, "commit", "-m", "init")
-	run(anvilDir, "push", "origin", "main")
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
 
 	// Create a worktree (simulates the pipeline creating the bead branch).
 	mgr := NewManager()
@@ -322,7 +299,7 @@ func TestRemove_DoesNotDeleteRemoteBranch(t *testing.T) {
 	}
 
 	// Push the branch to origin (simulates Smith pushing the implementation).
-	run(wt.Path, "push", "-u", "origin", wt.Branch)
+	runGit(t, wt.Path, "push", "-u", "origin", wt.Branch)
 
 	// Verify the remote branch exists before Remove().
 	remotesBefore := gitOutput(t, anvilDir, "ls-remote", "--heads", "origin", wt.Branch)
@@ -383,29 +360,7 @@ func TestIsValidWorktree_GitFilePointsToNonexistent(t *testing.T) {
 }
 
 func TestIsValidWorktree_RealWorktree(t *testing.T) {
-	// Set up a repo with a real worktree.
-	remoteDir := t.TempDir()
-	run := func(dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-		}
-	}
-	run(remoteDir, "init", "--bare", "--initial-branch=main")
-
-	anvilDir := t.TempDir()
-	run(anvilDir, "clone", remoteDir, ".")
-	run(anvilDir, "config", "user.email", "test@example.com")
-	run(anvilDir, "config", "user.name", "Test")
-	if err := os.WriteFile(filepath.Join(anvilDir, "README"), []byte("test\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	run(anvilDir, "add", "README")
-	run(anvilDir, "commit", "-m", "init")
-	run(anvilDir, "push", "origin", "main")
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
 
 	mgr := NewManager()
 	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "valid-test", CreateOptions{})
@@ -418,36 +373,32 @@ func TestIsValidWorktree_RealWorktree(t *testing.T) {
 	}
 }
 
-func TestValidateWorktreeDir_MissingGitFile(t *testing.T) {
+func TestValidateWorktreeDir_NonRepoTempDir(t *testing.T) {
+	// A temp dir outside any git repo should be allowed — schematic/wicket use
+	// os.MkdirTemp dirs for non-repo Smith runs.
 	dir := t.TempDir()
-	if err := ValidateWorktreeDir(dir); err == nil {
-		t.Error("ValidateWorktreeDir should return error for directory without .git file")
+	if err := ValidateWorktreeDir(dir); err != nil {
+		t.Errorf("ValidateWorktreeDir should pass for a temp dir outside any repo, got: %v", err)
+	}
+}
+
+func TestValidateWorktreeDir_InsideRepoMissingGitFile(t *testing.T) {
+	// A subdirectory inside a git repo (but without its own .git file) must be
+	// rejected — git commands would resolve to the parent repo's checkout.
+	repoDir := t.TempDir()
+	initTestRepo(t, repoDir, "main")
+
+	subDir := filepath.Join(repoDir, "subdir")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateWorktreeDir(subDir); err == nil {
+		t.Error("ValidateWorktreeDir should return error for a subdir inside a repo without a worktree .git file")
 	}
 }
 
 func TestVerifyWorktreeGitFile_ValidWorktree(t *testing.T) {
-	remoteDir := t.TempDir()
-	run := func(dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-		}
-	}
-	run(remoteDir, "init", "--bare", "--initial-branch=main")
-
-	anvilDir := t.TempDir()
-	run(anvilDir, "clone", remoteDir, ".")
-	run(anvilDir, "config", "user.email", "test@example.com")
-	run(anvilDir, "config", "user.name", "Test")
-	if err := os.WriteFile(filepath.Join(anvilDir, "README"), []byte("test\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	run(anvilDir, "add", "README")
-	run(anvilDir, "commit", "-m", "init")
-	run(anvilDir, "push", "origin", "main")
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
 
 	mgr := NewManager()
 	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "verify-test", CreateOptions{})
@@ -461,29 +412,7 @@ func TestVerifyWorktreeGitFile_ValidWorktree(t *testing.T) {
 }
 
 func TestCreateWithOptions_StaleDirectoryRemoved(t *testing.T) {
-	// Set up a repo with a remote.
-	remoteDir := t.TempDir()
-	run := func(dir string, args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-		}
-	}
-	run(remoteDir, "init", "--bare", "--initial-branch=main")
-
-	anvilDir := t.TempDir()
-	run(anvilDir, "clone", remoteDir, ".")
-	run(anvilDir, "config", "user.email", "test@example.com")
-	run(anvilDir, "config", "user.name", "Test")
-	if err := os.WriteFile(filepath.Join(anvilDir, "README"), []byte("test\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	run(anvilDir, "add", "README")
-	run(anvilDir, "commit", "-m", "init")
-	run(anvilDir, "push", "origin", "main")
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
 
 	// Create a stale .workers/stale-test/ directory without a .git file.
 	staleDir := filepath.Join(anvilDir, ".workers", "stale-test")


### PR DESCRIPTION
## Changes

- **Worktree corruption guard** - Hardened worktree validation to check for .git file presence and gitdir integrity, preventing Smith from accidentally editing the main checkout when a worktree directory exists but lacks proper git linkage. Added retry-with-backoff for directory removal on Windows, post-creation verification, and a Smith-side pre-flight check that refuses to run in an invalid worktree. (Forge-cn6x)

## Original Issue (bug): Worktree corruption: Smith can run on main checkout after worktree state gets broken

On Windows, Heimdall-lmxx's second dispatch resulted in Smith editing files in the MAIN Heimdall checkout instead of a worktree. 29 tracked files got modified on main before the run was killed manually. Evidence from daemon.log and filesystem: (1) At 12:55:47 the daemon logged 'anvil repo was not on main/master — performed recovery checkout, original_branch=forge/Heimdall-lmxx' meaning the PARENT Heimdall checkout was on the forge branch, not main. (2) The .workers/Heimdall-lmxx/ directory existed but had NO .git file — so it wasn't a valid git worktree. It contained only .forge-logs/ and client/node_modules (symlink). (3) Smith wrote Edit tool calls to absolute paths inside .workers/Heimdall-lmxx/client/... but since that dir was empty and had no .git, git parent-walk resolved operations to the main Heimdall checkout. (4) Smith.s 'file_path' JSON entries even included C:/source/fhigit/Heimdall/client/eslint.config.js directly — writing to main. Likely chain: first dispatch at 11:07 created a valid worktree, Smith or something ran git checkout in the main repo (corruption), bead went to needs-attention. On retry at 12:54, VerifyAndRecoverMain detected and recovered main but the stale .workers/Heimdall-lmxx/ directory was reused via isValidWorktree or os.RemoveAll failed silently on Windows due to locked files/antivirus. Fixes to investigate: (a) Tighten isValidWorktree to check for .git file presence and branch correctness, not just git worktree list registration. (b) On os.RemoveAll failure on Windows, retry with backoff or fail fast instead of silently proceeding. (c) After worktree creation, verify .git file exists and Path points to a real worktree before handing control to Smith. (d) Add a Smith-side guard: refuse to run if worktree's .git file missing. (e) Audit for what operation caused Smith to check out the forge branch in the parent repo (worktree.go comment at line 152-156 acknowledges this as a known hazard).

---
Bead: Forge-cn6x | Branch: forge/Forge-cn6x
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)