### PR TITLE
Temper: npm ci incompatible with node_modules junctions on Windows (Forge-bdqz)

### DIFF
--- a/changelog.d/Forge-bdqz.md
+++ b/changelog.d/Forge-bdqz.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Temper blocks npm ci when node_modules is a junction** - Detect when node_modules is a symlink/junction (from worktree linking) and skip destructive install commands like `npm ci` that would wipe the shared main checkout's dependencies. The step is skipped with a clear explanation instead of failing with EPERM. (Forge-bdqz)

--- a/internal/temper/nodemodules_unix.go
+++ b/internal/temper/nodemodules_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package temper
+
+import "os"
+
+// isReparsePoint returns false on Unix; directory links are symlinks and are
+// already detected via os.ModeSymlink.
+func isReparsePoint(_ os.FileInfo) bool {
+	return false
+}

--- a/internal/temper/nodemodules_windows.go
+++ b/internal/temper/nodemodules_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package temper
+
+import (
+	"os"
+	"syscall"
+)
+
+// isReparsePoint returns true if info has the FILE_ATTRIBUTE_REPARSE_POINT
+// Windows attribute set. NTFS junctions (created by mklink /J) are reparse
+// points but do NOT set os.ModeSymlink in Go's os.FileInfo, so this check
+// is needed in addition to the ModeSymlink bit.
+func isReparsePoint(info os.FileInfo) bool {
+	sys, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	if !ok {
+		return false
+	}
+	const fileAttributeReparsePoint = 0x400
+	return sys.FileAttributes&fileAttributeReparsePoint != 0
+}

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -318,6 +318,26 @@ func Run(ctx context.Context, worktreePath string, cfg Config, db *state.DB, bea
 			continue
 		}
 
+		// Block destructive npm install commands when node_modules is a
+		// junction/symlink — npm ci does rm -rf node_modules which would
+		// destroy the main checkout's dependencies or fail with EPERM.
+		if isDestructiveNpmInstall(step) {
+			stepDir := resolveStepDir(worktreePath, step.Dir)
+			if isNodeModulesLinked(stepDir) {
+				log.Printf("[temper] Blocking step %q: node_modules is a symlink/junction and %s %s would destroy the linked target", step.Name, step.Command, strings.Join(step.Args, " "))
+				result.Steps = append(result.Steps, StepResult{
+					Name:     step.Name,
+					Command:  fmt.Sprintf("%s %s", step.Command, strings.Join(step.Args, " ")),
+					ExitCode: -1,
+					Output:   fmt.Sprintf("Blocked: node_modules in %s is a symlink or junction pointing to the main checkout. Running %q would destroy the shared node_modules. Remove this step from your temper configuration — dependencies are already available via the junction.", stepDir, step.Command+" "+strings.Join(step.Args, " ")),
+					Passed:   true,
+					Skipped:  true,
+					Optional: step.Optional,
+				})
+				continue
+			}
+		}
+
 		stepResult := runStep(ctx, worktreePath, step)
 		result.Steps = append(result.Steps, stepResult)
 
@@ -589,4 +609,46 @@ func fileExists(dir, name string) bool {
 func hasGlob(dir, pattern string) bool {
 	matches, _ := filepath.Glob(filepath.Join(dir, pattern))
 	return len(matches) > 0
+}
+
+// resolveStepDir returns the absolute working directory for a step.
+func resolveStepDir(worktreePath, stepDir string) string {
+	if stepDir == "" {
+		return worktreePath
+	}
+	if strings.HasPrefix(stepDir, "/") || strings.HasPrefix(stepDir, "\\") || (len(stepDir) >= 2 && stepDir[1] == ':') {
+		return stepDir
+	}
+	return filepath.Join(worktreePath, stepDir)
+}
+
+// isNodeModulesLinked returns true if the node_modules directory in dir is a
+// symlink or junction rather than a real directory.
+func isNodeModulesLinked(dir string) bool {
+	info, err := os.Lstat(filepath.Join(dir, "node_modules"))
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink != 0
+}
+
+// isDestructiveNpmInstall returns true if the step would run a command that
+// wipes node_modules before installing (npm ci, npm clean-install, pnpm setup
+// with --force, etc.). These are dangerous when node_modules is a junction.
+func isDestructiveNpmInstall(step Step) bool {
+	base := filepath.Base(step.Command)
+	base = strings.TrimSuffix(base, ".cmd")
+	base = strings.TrimSuffix(base, ".exe")
+
+	if base != "npm" {
+		return false
+	}
+	if len(step.Args) == 0 {
+		return false
+	}
+	switch step.Args[0] {
+	case "ci", "clean-install":
+		return true
+	}
+	return false
 }

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -629,12 +629,12 @@ func isNodeModulesLinked(dir string) bool {
 	if err != nil {
 		return false
 	}
-	return info.Mode()&os.ModeSymlink != 0
+	return info.Mode()&os.ModeSymlink != 0 || isReparsePoint(info)
 }
 
-// isDestructiveNpmInstall returns true if the step would run a command that
-// wipes node_modules before installing (npm ci, npm clean-install, pnpm setup
-// with --force, etc.). These are dangerous when node_modules is a junction.
+// isDestructiveNpmInstall returns true if the step would run an npm command
+// that wipes node_modules before installing (currently npm ci and
+// npm clean-install). These are dangerous when node_modules is a junction.
 func isDestructiveNpmInstall(step Step) bool {
 	base := filepath.Base(step.Command)
 	base = strings.TrimSuffix(base, ".cmd")

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -530,6 +530,97 @@ func TestRun_SkipsStepWhenPathsDontMatch(t *testing.T) {
 	assert.True(t, result.Passed)
 }
 
+func TestIsDestructiveNpmInstall_Matches(t *testing.T) {
+	tests := []struct {
+		command string
+		args    []string
+		want    bool
+	}{
+		{"npm", []string{"ci"}, true},
+		{"npm", []string{"clean-install"}, true},
+		{"npm.cmd", []string{"ci"}, true},
+		{"npm.exe", []string{"ci"}, true},
+		{"/usr/bin/npm", []string{"ci"}, true},
+		{"npm", []string{"install"}, false},
+		{"npm", []string{"run", "build"}, false},
+		{"npm", []string{}, false},
+		{"node", []string{"ci"}, false},
+		{"yarn", []string{"install"}, false},
+		{"npx", []string{"ci"}, false},
+	}
+	for _, tt := range tests {
+		step := Step{Command: tt.command, Args: tt.args}
+		got := isDestructiveNpmInstall(step)
+		assert.Equal(t, tt.want, got, "isDestructiveNpmInstall(%q, %v)", tt.command, tt.args)
+	}
+}
+
+func TestIsNodeModulesLinked_RealDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755))
+
+	assert.False(t, isNodeModulesLinked(dir), "real directory should not be detected as linked")
+}
+
+func TestIsNodeModulesLinked_Symlink(t *testing.T) {
+	dir := t.TempDir()
+	target := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(target, "node_modules"), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(target, "node_modules"), filepath.Join(dir, "node_modules")))
+
+	assert.True(t, isNodeModulesLinked(dir), "symlink should be detected as linked")
+}
+
+func TestIsNodeModulesLinked_Missing(t *testing.T) {
+	dir := t.TempDir()
+	assert.False(t, isNodeModulesLinked(dir), "missing node_modules should return false")
+}
+
+func TestResolveStepDir(t *testing.T) {
+	assert.Equal(t, "/work", resolveStepDir("/work", ""))
+	assert.Equal(t, filepath.Join("/work", "web"), resolveStepDir("/work", "web"))
+	assert.Equal(t, "/absolute/path", resolveStepDir("/work", "/absolute/path"))
+}
+
+func TestRun_BlocksDestructiveNpmWithJunction(t *testing.T) {
+	dir := t.TempDir()
+	target := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(target, "node_modules"), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(target, "node_modules"), filepath.Join(dir, "node_modules")))
+
+	cfg := Config{
+		Steps: []Step{
+			{Name: "install", Command: "npm", Args: []string{"ci"}, Timeout: 5 * time.Second},
+			{Name: "build", Command: "echo", Args: []string{"ok"}, Timeout: 5 * time.Second},
+		},
+	}
+
+	result := Run(context.Background(), dir, cfg, nil, "test-bead", "test-anvil")
+
+	require.Len(t, result.Steps, 2)
+	assert.True(t, result.Steps[0].Skipped, "npm ci should be skipped when node_modules is a symlink")
+	assert.True(t, result.Steps[0].Passed, "skipped step should count as passed")
+	assert.Contains(t, result.Steps[0].Output, "Blocked")
+	assert.False(t, result.Steps[1].Skipped, "subsequent steps should still run")
+	assert.True(t, result.Passed)
+}
+
+func TestRun_AllowsNpmCiWithRealNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755))
+
+	cfg := Config{
+		Steps: []Step{
+			{Name: "install", Command: "npm", Args: []string{"ci"}, Timeout: 5 * time.Second},
+		},
+	}
+
+	result := Run(context.Background(), dir, cfg, nil, "test-bead", "test-anvil")
+
+	require.Len(t, result.Steps, 1)
+	assert.False(t, result.Steps[0].Skipped, "npm ci should not be skipped with real node_modules")
+}
+
 func TestRun_NilChangedFiles_NeverSkips(t *testing.T) {
 	cfg := Config{
 		Steps: []Step{

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -562,13 +562,13 @@ func TestIsNodeModulesLinked_RealDir(t *testing.T) {
 	assert.False(t, isNodeModulesLinked(dir), "real directory should not be detected as linked")
 }
 
-func TestIsNodeModulesLinked_Symlink(t *testing.T) {
+func TestIsNodeModulesLinked_Linked(t *testing.T) {
 	dir := t.TempDir()
 	target := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(target, "node_modules"), 0o755))
-	require.NoError(t, os.Symlink(filepath.Join(target, "node_modules"), filepath.Join(dir, "node_modules")))
+	createTestDirLink(t, filepath.Join(target, "node_modules"), filepath.Join(dir, "node_modules"))
 
-	assert.True(t, isNodeModulesLinked(dir), "symlink should be detected as linked")
+	assert.True(t, isNodeModulesLinked(dir), "symlink/junction should be detected as linked")
 }
 
 func TestIsNodeModulesLinked_Missing(t *testing.T) {
@@ -586,7 +586,7 @@ func TestRun_BlocksDestructiveNpmWithJunction(t *testing.T) {
 	dir := t.TempDir()
 	target := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(target, "node_modules"), 0o755))
-	require.NoError(t, os.Symlink(filepath.Join(target, "node_modules"), filepath.Join(dir, "node_modules")))
+	createTestDirLink(t, filepath.Join(target, "node_modules"), filepath.Join(dir, "node_modules"))
 
 	cfg := Config{
 		Steps: []Step{

--- a/internal/temper/testhelpers_unix_test.go
+++ b/internal/temper/testhelpers_unix_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package temper
+
+import (
+	"os"
+	"testing"
+)
+
+// createTestDirLink creates a symlink from dst pointing to src for use in
+// tests. On Unix, production code also uses symlinks, so this matches real
+// behavior exactly.
+func createTestDirLink(t *testing.T, src, dst string) {
+	t.Helper()
+	if err := os.Symlink(src, dst); err != nil {
+		t.Fatalf("os.Symlink(%s, %s): %v", src, dst, err)
+	}
+}

--- a/internal/temper/testhelpers_windows_test.go
+++ b/internal/temper/testhelpers_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package temper
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// createTestDirLink creates an NTFS junction from dst pointing to src for use
+// in tests. On Windows, production code uses mklink /J junctions (not
+// symlinks) because symlinks require elevated privileges. This matches real
+// behavior so the junction-detection path in isNodeModulesLinked is exercised.
+func createTestDirLink(t *testing.T, src, dst string) {
+	t.Helper()
+	cmd := exec.Command("cmd", "/C", "mklink", "/J", dst, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("mklink /J %s %s: %s: %v", dst, src, out, err)
+	}
+}


### PR DESCRIPTION
## Changes

- **Temper blocks npm ci when node_modules is a junction** - Detect when node_modules is a symlink/junction (from worktree linking) and skip destructive install commands like `npm ci` that would wipe the shared main checkout's dependencies. The step is skipped with a clear explanation instead of failing with EPERM. (Forge-bdqz)

## Original Issue (bug): Temper: npm ci incompatible with node_modules junctions on Windows

After Forge-jqyw (node_modules junction) shipped, temper steps running npm ci in a worktree fail intermittently with Windows EPERM. The junction resolves to the main checkout's node_modules and npm ci does rm -rf node_modules which locks on native .node binaries held by IDE/antivirus/dev-server. Seen on Heimdall-lmxx retry: client-install failed 4.2s with EPERM on tailwindcss-oxide.win32-x64-msvc.node. Even when rm succeeds, outcome is wiping main node_modules or creating worktree-local node_modules (redundant with junction). Forge could detect junction at temper step start and refuse destructive install commands, or warn in docs that npm ci should not be used in temper when worktree junctions are active. Primary guidance: npm ci redundant, don't add to temper steps when using forge worktrees.

---
Bead: Forge-bdqz | Branch: forge/Forge-bdqz
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)