### PR TITLE
Worktree removal must unlink node_modules junctions before os.RemoveAll on Windows (Forge-17gt)

### DIFF
--- a/changelog.d/Forge-17gt.md
+++ b/changelog.d/Forge-17gt.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Worktree removal unlinks junctions before recursive delete** - On Windows, os.RemoveAll follows reparse points (junctions/symlinks) into the target directory, causing failures when locked files are encountered. Worktree removal now walks the tree and unlinks all reparse points first, preventing recursive deletion from entering junctioned directories like node_modules. (Forge-17gt)

--- a/internal/worktree/reparse_notwindows.go
+++ b/internal/worktree/reparse_notwindows.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package worktree
+
+import (
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// unlinkReparsePoints walks root and removes any symlinks so that a subsequent
+// os.RemoveAll does not follow them into the target directory. On non-Windows
+// platforms this handles symlinks; junctions are a Windows-only concept.
+func unlinkReparsePoints(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+
+		if d.Type()&fs.ModeSymlink == 0 {
+			return nil
+		}
+
+		slog.Debug("unlinking symlink before worktree removal", "path", path)
+		if rmErr := os.Remove(path); rmErr != nil {
+			slog.Warn("failed to unlink symlink", "path", path, "error", rmErr)
+			return nil
+		}
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+}

--- a/internal/worktree/reparse_windows.go
+++ b/internal/worktree/reparse_windows.go
@@ -1,0 +1,61 @@
+//go:build windows
+
+package worktree
+
+import (
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// unlinkReparsePoints walks root and removes any reparse points (junctions or
+// symlinks) so that a subsequent os.RemoveAll does not follow them into the
+// target directory. This prevents failures on Windows where locked files inside
+// a junctioned node_modules cause os.RemoveAll to fail repeatedly.
+func unlinkReparsePoints(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // best-effort: skip entries we cannot stat
+		}
+		if path == root {
+			return nil
+		}
+		if !d.IsDir() && d.Type()&fs.ModeSymlink == 0 {
+			return nil // regular file, skip
+		}
+
+		isReparse, rpErr := isReparsePoint(path)
+		if rpErr != nil {
+			return nil // best-effort
+		}
+		if !isReparse {
+			return nil
+		}
+
+		slog.Debug("unlinking reparse point before worktree removal", "path", path)
+		if rmErr := os.Remove(path); rmErr != nil {
+			slog.Warn("failed to unlink reparse point", "path", path, "error", rmErr)
+			return nil // best-effort
+		}
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+}
+
+// isReparsePoint checks the FILE_ATTRIBUTE_REPARSE_POINT flag via the Windows
+// syscall. This covers both junctions and symlinks.
+func isReparsePoint(path string) (bool, error) {
+	p, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return false, err
+	}
+	attrs, err := syscall.GetFileAttributes(p)
+	if err != nil {
+		return false, err
+	}
+	return attrs&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0, nil
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -565,6 +565,10 @@ func removeWithRetry(ctx context.Context, path string) error {
 	if runtime.GOOS == "windows" {
 		delays = []time.Duration{0, 1 * time.Second, 2 * time.Second, 4 * time.Second}
 	}
+	if err := unlinkReparsePoints(path); err != nil {
+		slog.Warn("unlinking reparse points before removal", "path", path, "error", err)
+	}
+
 	var lastErr error
 	for i, delay := range delays {
 		if err := ctx.Err(); err != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -565,9 +565,7 @@ func removeWithRetry(ctx context.Context, path string) error {
 	if runtime.GOOS == "windows" {
 		delays = []time.Duration{0, 1 * time.Second, 2 * time.Second, 4 * time.Second}
 	}
-	if err := unlinkReparsePoints(path); err != nil {
-		slog.Warn("unlinking reparse points before removal", "path", path, "error", err)
-	}
+	unlinkReparsePoints(path)
 
 	var lastErr error
 	for i, delay := range delays {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -454,19 +454,16 @@ func TestUnlinkReparsePoints(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a symlink inside root pointing to target (proxy for a junction).
+	// Create a directory link inside root pointing to target.
+	// On Windows this should use a junction/reparse point; on other platforms, a symlink.
 	symlinkPath := filepath.Join(root, "node_modules")
-	if err := os.Symlink(target, symlinkPath); err != nil {
-		t.Skipf("cannot create symlink (permissions?): %v", err)
+	if err := createDirLink(target, symlinkPath); err != nil {
+		t.Skipf("cannot create directory link: %v", err)
 	}
 
-	// Verify symlink exists.
-	fi, err := os.Lstat(symlinkPath)
-	if err != nil {
+	// Verify the directory link entry exists.
+	if _, err := os.Lstat(symlinkPath); err != nil {
 		t.Fatal(err)
-	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Fatal("expected symlink")
 	}
 
 	// Run unlinkReparsePoints.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -436,6 +436,65 @@ func TestCreateWithOptions_StaleDirectoryRemoved(t *testing.T) {
 	}
 }
 
+func TestUnlinkReparsePoints(t *testing.T) {
+	root := t.TempDir()
+
+	// Create regular files and directories.
+	regularDir := filepath.Join(root, "src")
+	if err := os.MkdirAll(regularDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(regularDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a target directory that should NOT be deleted.
+	target := t.TempDir()
+	if err := os.WriteFile(filepath.Join(target, "keep.txt"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink inside root pointing to target (proxy for a junction).
+	symlinkPath := filepath.Join(root, "node_modules")
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		t.Skipf("cannot create symlink (permissions?): %v", err)
+	}
+
+	// Verify symlink exists.
+	fi, err := os.Lstat(symlinkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected symlink")
+	}
+
+	// Run unlinkReparsePoints.
+	if err := unlinkReparsePoints(root); err != nil {
+		t.Fatalf("unlinkReparsePoints: %v", err)
+	}
+
+	// Symlink should be removed.
+	if _, err := os.Lstat(symlinkPath); !os.IsNotExist(err) {
+		t.Error("symlink should have been removed")
+	}
+
+	// Regular files should still exist.
+	if _, err := os.Stat(filepath.Join(regularDir, "main.go")); err != nil {
+		t.Errorf("regular file should still exist: %v", err)
+	}
+
+	// Target directory should be untouched.
+	if _, err := os.Stat(filepath.Join(target, "keep.txt")); err != nil {
+		t.Errorf("target directory should be untouched: %v", err)
+	}
+
+	// os.RemoveAll should now succeed on root.
+	if err := os.RemoveAll(root); err != nil {
+		t.Errorf("os.RemoveAll should succeed after unlinking: %v", err)
+	}
+}
+
 // gitOutput runs a git command and returns trimmed stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()


### PR DESCRIPTION
## Changes

- **Worktree removal unlinks junctions before recursive delete** - On Windows, os.RemoveAll follows reparse points (junctions/symlinks) into the target directory, causing failures when locked files are encountered. Worktree removal now walks the tree and unlinks all reparse points first, preventing recursive deletion from entering junctioned directories like node_modules. (Forge-17gt)

## Original Issue (bug): Worktree removal must unlink node_modules junctions before os.RemoveAll on Windows

removeWithRetry in internal/worktree/worktree.go (line 560) calls os.RemoveAll which recurses INTO reparse points (junctions/symlinks). For forge worktrees with client/node_modules junctioned to the main checkout, os.RemoveAll walks into main node_modules and tries to delete every file there. On Windows, any long-held OS file lock on a native .node binary (IDE, antivirus, dev server) causes the remove to fail repeatedly. The existing exponential backoff (0s/1s/2s/4s = 7s total) cannot win against a sticky OS lock. Real-world impact: bellows cannot dispatch burnish for PRs needing review fix, because burnish rebuilds the worktree and removal fails. Seen today on 3 PRs stuck in needs_fix for hours: Heimdall l8xt (#224), Munin s52lp (#2166), yp171 (#2167). Daemon log shows: removing stale worktree directory ...: failed after 4 attempts: unlinkat ...client/node_modules/@tailwindcss/oxide-win32-x64-msvc/tailwindcss-oxide.win32-x64-msvc.node. This is a different symptom from Forge-cn6x (which fixed creation robustness) but same root cause: junctions plus os.RemoveAll on Windows plus locked native binaries. Fix: before calling os.RemoveAll, walk the worktree path and unlink any reparse points (junctions) using os.Remove or syscall.DeleteFileW so the subsequent recursive remove does not follow them. On Windows the simplest robust option is cmd /c rmdir worktreePath/client/node_modules first (rmdir on a junction removes the link without following). Known hotspot: client/node_modules, but generalize via filepath.WalkDir with a reparse-point check so future subdirectories are covered too.

---
Bead: Forge-17gt | Branch: forge/Forge-17gt
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)