### PR TITLE
Worktree: skip node_modules junction for depcheck dependency-update beads (Forge-0e0v)

### DIFF
--- a/changelog.d/Forge-0e0v.md
+++ b/changelog.d/Forge-0e0v.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Skip node_modules junction for dependency-update beads** - Depcheck beads now get a `deps-update` label, and worktree setup skips the node_modules junction for these beads so npm install writes to a fresh local directory instead of corrupting the main checkout. (Forge-0e0v)

--- a/internal/depcheck/dedup.go
+++ b/internal/depcheck/dedup.go
@@ -22,12 +22,13 @@ func BeadTitle(ecosystem, packageName, oldVersion, newVersion string) string {
 
 // bdBead is a minimal struct for parsing bd list --json output.
 type bdBead struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Status      string `json:"status"`
-	ClosedAt    string `json:"closed_at"`
-	UpdatedAt   string `json:"updated_at"`
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Status      string   `json:"status"`
+	Labels      []string `json:"labels"`
+	ClosedAt    string   `json:"closed_at"`
+	UpdatedAt   string   `json:"updated_at"`
 }
 
 // DedupCheck returns true if a bead for the given package already exists

--- a/internal/depcheck/depcheck.go
+++ b/internal/depcheck/depcheck.go
@@ -377,8 +377,17 @@ func (s *Scanner) updateConsolidatedBead(ctx context.Context, existing *bdBead, 
 	mergedAuto, mergedMajor := mergeConsolidatedPackages(existingAuto, existingMajor, allResults)
 	newDesc := buildDescriptionFromMaps(anvilName, mergedAuto, mergedMajor)
 
-	// Skip update if description is unchanged.
-	if newDesc == existing.Description {
+	// Check whether the label is already present on the bead.
+	hasLabel := false
+	for _, l := range existing.Labels {
+		if strings.EqualFold(l, DepsUpdateLabel) {
+			hasLabel = true
+			break
+		}
+	}
+
+	// Skip update if both description and label are already correct.
+	if newDesc == existing.Description && hasLabel {
 		log.Printf("[depcheck] %s: consolidated bead %s already up to date", anvilName, existing.ID)
 		return
 	}
@@ -386,12 +395,11 @@ func (s *Scanner) updateConsolidatedBead(ctx context.Context, existing *bdBead, 
 	cmdCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
 
-	cmd := executil.HideWindow(exec.CommandContext(cmdCtx,
-		"bd", "update", existing.ID,
-		fmt.Sprintf("--description=%s", newDesc),
-		"--add-label", DepsUpdateLabel,
-		"--json",
-	))
+	args := []string{"update", existing.ID, "--add-label", DepsUpdateLabel, "--json"}
+	if newDesc != existing.Description {
+		args = append(args, fmt.Sprintf("--description=%s", newDesc))
+	}
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", args...))
 	cmd.Dir = anvilPath
 
 	var stderr bytes.Buffer

--- a/internal/depcheck/depcheck.go
+++ b/internal/depcheck/depcheck.go
@@ -20,6 +20,11 @@ import (
 	"github.com/Robin831/Forge/internal/state"
 )
 
+// DepsUpdateLabel is the label applied to dependency-update beads so that
+// downstream consumers (e.g. worktree setup) can identify them and skip
+// behaviours that conflict with npm install (such as node_modules junctions).
+const DepsUpdateLabel = "deps-update"
+
 // ModuleUpdate describes a single outdated dependency.
 type ModuleUpdate struct {
 	Path      string // module/package path
@@ -332,6 +337,7 @@ func (s *Scanner) createConsolidatedBead(ctx context.Context, allResults []*Chec
 		fmt.Sprintf("--description=%s", desc),
 		"--type=chore",
 		fmt.Sprintf("--priority=%s", priority),
+		fmt.Sprintf("--labels=%s", DepsUpdateLabel),
 		"--json",
 	))
 	cmd.Dir = anvilPath
@@ -383,6 +389,7 @@ func (s *Scanner) updateConsolidatedBead(ctx context.Context, existing *bdBead, 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx,
 		"bd", "update", existing.ID,
 		fmt.Sprintf("--description=%s", newDesc),
+		"--add-label", DepsUpdateLabel,
 		"--json",
 	))
 	cmd.Dir = anvilPath

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Robin831/Forge/internal/changelog"
 	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/depcheck"
 	"github.com/Robin831/Forge/internal/cost"
 	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/ingot"
@@ -420,6 +421,15 @@ func releaseBead(beadID, anvilPath string) error {
 //
 // It returns (run, reason) so the caller can log a single accurate message
 // with its workerID context prefix.
+func hasDepsUpdateLabel(labels []string) bool {
+	for _, l := range labels {
+		if strings.EqualFold(l, depcheck.DepsUpdateLabel) {
+			return true
+		}
+	}
+	return false
+}
+
 func shouldRunSchematic(cfg schematic.Config, bead poller.Bead, providers []provider.Provider) (bool, string) {
 	if !cfg.Enabled {
 		return false, "schematic disabled in config"
@@ -527,8 +537,9 @@ func Run(ctx context.Context, p Params) *Outcome {
 	if createWorktree == nil {
 		createWorktree = func(ctx context.Context, anvilPath, beadID string) (*worktree.Worktree, error) {
 			return p.WorktreeManager.CreateWithOptions(ctx, anvilPath, beadID, worktree.CreateOptions{
-				BaseBranch:  p.BaseBranch,
-				ResetBranch: p.ResetBranch,
+				BaseBranch:              p.BaseBranch,
+				ResetBranch:             p.ResetBranch,
+				SkipNodeModulesJunction: hasDepsUpdateLabel(p.Bead.Labels),
 			})
 		}
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -411,6 +411,15 @@ func releaseBead(beadID, anvilPath string) error {
 	return nil
 }
 
+func hasDepsUpdateLabel(labels []string) bool {
+	for _, l := range labels {
+		if strings.EqualFold(l, depcheck.DepsUpdateLabel) {
+			return true
+		}
+	}
+	return false
+}
+
 // shouldRunSchematic determines whether the Schematic pre-worker should run
 // for the given bead and provider chain.
 //
@@ -421,15 +430,6 @@ func releaseBead(beadID, anvilPath string) error {
 //
 // It returns (run, reason) so the caller can log a single accurate message
 // with its workerID context prefix.
-func hasDepsUpdateLabel(labels []string) bool {
-	for _, l := range labels {
-		if strings.EqualFold(l, depcheck.DepsUpdateLabel) {
-			return true
-		}
-	}
-	return false
-}
-
 func shouldRunSchematic(cfg schematic.Config, bead poller.Bead, providers []provider.Provider) (bool, string) {
 	if !cfg.Enabled {
 		return false, "schematic disabled in config"

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -58,6 +58,11 @@ type CreateOptions struct {
 	// working tree as-is" semantics are required and remote state should not
 	// be fetched.
 	LocalHead bool
+	// SkipNodeModulesJunction, when true, skips linking node_modules from
+	// the main checkout. Used for dependency-update beads where npm install
+	// must write to a local node_modules to avoid corrupting the main
+	// checkout's dependencies.
+	SkipNodeModulesJunction bool
 }
 
 // Manager handles creating and tearing down worktrees.
@@ -138,7 +143,7 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 			_ = git(worktreePath, "checkout", "--force", "HEAD")
 			_ = git(worktreePath, "clean", "-fd")
 			// Re-link node_modules — git clean -fd removes untracked symlinks.
-			if !opts.LocalHead {
+			if !opts.LocalHead && !opts.SkipNodeModulesJunction {
 				if err := linkNodeModules(anvilPath, worktreePath); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to link node_modules: %v\n", err)
 				}
@@ -243,8 +248,9 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 
 	// Link node_modules from the main checkout so Smiths can run npm scripts
 	// without a fresh npm ci. Skip for LocalHead (scan-only) worktrees where
-	// the anvil path IS the worktree and linking would be circular.
-	if !opts.LocalHead {
+	// the anvil path IS the worktree and linking would be circular. Also skip
+	// for dependency-update beads that need a fresh local node_modules.
+	if !opts.LocalHead && !opts.SkipNodeModulesJunction {
 		if err := linkNodeModules(anvilPath, worktreePath); err != nil {
 			// Non-fatal: later temper Node steps may fail if dependencies are not
 			// already present or installed by another component/user.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -492,6 +492,76 @@ func TestUnlinkReparsePoints(t *testing.T) {
 	}
 }
 
+// TestCreateWithOptions_SkipNodeModulesJunction_FreshCreate verifies that when
+// SkipNodeModulesJunction is true, node_modules is NOT linked into the worktree
+// on a fresh creation even when the anvil has a node_modules directory.
+func TestCreateWithOptions_SkipNodeModulesJunction_FreshCreate(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	// Place a node_modules directory in the anvil to simulate a real repo.
+	anvilNM := filepath.Join(anvilDir, "node_modules")
+	if err := os.Mkdir(anvilNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(anvilNM, "marker.txt"), []byte("anvil"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager()
+	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "skip-nm-fresh", CreateOptions{
+		SkipNodeModulesJunction: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	// node_modules must NOT be linked (or created) in the worktree.
+	if _, err := os.Lstat(filepath.Join(wt.Path, "node_modules")); !os.IsNotExist(err) {
+		t.Error("node_modules should not exist in worktree when SkipNodeModulesJunction=true (fresh create)")
+	}
+}
+
+// TestCreateWithOptions_SkipNodeModulesJunction_ReuseClean verifies that when
+// SkipNodeModulesJunction is true, node_modules is NOT re-linked on the
+// reuse/clean path (when the worktree already exists and is valid).
+func TestCreateWithOptions_SkipNodeModulesJunction_ReuseClean(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	// Place a node_modules directory in the anvil.
+	anvilNM := filepath.Join(anvilDir, "node_modules")
+	if err := os.Mkdir(anvilNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(anvilNM, "marker.txt"), []byte("anvil"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager()
+	ctx := context.Background()
+
+	// First call without SkipNodeModulesJunction — link should be created.
+	wt, err := mgr.CreateWithOptions(ctx, anvilDir, "skip-nm-reuse", CreateOptions{})
+	if err != nil {
+		t.Fatalf("first CreateWithOptions: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(wt.Path, "node_modules")); err != nil {
+		t.Skipf("node_modules link was not created (platform may not support it): %v", err)
+	}
+
+	// Second call with SkipNodeModulesJunction=true on the reuse path.
+	// git clean -fd removes the symlink; it must not be re-linked.
+	wt2, err := mgr.CreateWithOptions(ctx, anvilDir, "skip-nm-reuse", CreateOptions{
+		SkipNodeModulesJunction: true,
+	})
+	if err != nil {
+		t.Fatalf("second CreateWithOptions: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(wt2.Path, "node_modules")); !os.IsNotExist(err) {
+		t.Error("node_modules should not exist in worktree when SkipNodeModulesJunction=true (reuse/clean path)")
+	}
+}
+
 // gitOutput runs a git command and returns trimmed stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()


### PR DESCRIPTION
## Changes

- **Skip node_modules junction for dependency-update beads** - Depcheck beads now get a `deps-update` label, and worktree setup skips the node_modules junction for these beads so npm install writes to a fresh local directory instead of corrupting the main checkout. (Forge-0e0v)

## Original Issue (bug): Worktree: skip node_modules junction for depcheck dependency-update beads

Depcheck-generated package-update beads (title prefix 'Package updates' per consolidate.go:19) need to run npm install / npm ci to refresh node_modules and update package-lock.json. With the current junction setup (Forge-jqyw), client/node_modules in the worktree is a junction to main's node_modules. Running npm install against the junction has three failure modes: (1) succeeds but mutates main's node_modules transparently, corrupting any other concurrent worker that relies on main's deps; (2) hits Windows EPERM on locked .node binaries (same failure pattern as Heimdall-lmxx, Heimdall-l8xt, Fhi.Metadata-s52lp/yp171); (3) partially installs and Smith pushes a half-broken state where temper's lint passes (junction has eslint) but other deps are stale. Fix: in internal/worktree/worktree.go around line 232-241 where linkNodeModules is called, check whether the bead is a deps-update bead and skip the junction. Detection options: (a) bead title prefix matches consolidatedBeadTitlePrefix from depcheck/consolidate.go, (b) bead has a label like deps-update added by depcheck on creation, (c) bead has a metadata flag. Option (b) is cleanest — depcheck adds the label when creating the bead, worktree creator checks for it. Without the junction, npm install runs against a fresh local node_modules, no main contamination, no concurrent-worker risk. Tradeoff: deps-update beads do a full npm install (~30-60s extra) instead of inheriting the junction. That's acceptable for a deps bead — the install IS the work. Bead Fhi.Metadata-edvt is the immediate trigger and waiting for this fix.

---
Bead: Forge-0e0v | Branch: forge/Forge-0e0v
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)