### PR TITLE
Track consecutive recovery failures and flag as needs-human (Forge-y04i)

### DIFF
--- a/changelog.d/Forge-y04i.md
+++ b/changelog.d/Forge-y04i.md
@@ -1,0 +1,2 @@
+category: Added
+- **Recovery failure tracking** - Track consecutive orphan recovery failures and flag beads as needs-human after 3 consecutive failures or 30 minutes of failing, preventing infinite recovery loops. (Forge-y04i)

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -192,7 +192,11 @@ func (m *Manager) CleanupOrphans() (cleaned int) {
 				} else {
 					if err := m.resetBead(w.BeadID, anvilPath); err != nil {
 						m.logger.Warn("failed to reset bead status", "bead", w.BeadID, "error", err)
+						if _, _, dbErr := m.db.IncrementRecoveryFailures(w.BeadID, w.Anvil, err.Error()); dbErr != nil {
+							m.logger.Warn("failed to track recovery failure", "bead", w.BeadID, "error", dbErr)
+						}
 					} else {
+						_ = m.db.ResetRecoveryFailures(w.BeadID, w.Anvil)
 						m.logger.Info("reset bead status to open", "bead", w.BeadID, "anvil", w.Anvil)
 					}
 				}
@@ -383,8 +387,18 @@ func (m *Manager) RecoverOrphanedBeads() (recovered int) {
 			// Fall through to auto-recovery (headless/CI mode or no Hearth client).
 			if err := m.resetBead(beadID, anvilPath); err != nil {
 				m.logger.Warn("failed to reset orphaned bead", "bead", beadID, "error", err)
+				failures, tripped, dbErr := m.db.IncrementRecoveryFailures(beadID, anvilName, err.Error())
+				if dbErr != nil {
+					m.logger.Warn("failed to track recovery failure", "bead", beadID, "error", dbErr)
+				} else if tripped {
+					m.logger.Warn("orphan recovery flagged as needs-human after repeated failures", "bead", beadID, "anvil", anvilName, "failures", failures)
+					m.db.LogEvent(state.EventBeadRecovered,
+						fmt.Sprintf("Orphaned bead %s flagged needs-human after %d recovery failures", beadID, failures),
+						beadID, anvilName)
+				}
 				continue
 			}
+			_ = m.db.ResetRecoveryFailures(beadID, anvilName)
 			m.logger.Info("recovered orphaned bead to open", "bead", beadID, "anvil", anvilName)
 			m.db.LogEvent(state.EventBeadRecovered,
 				fmt.Sprintf("Orphaned in-progress bead %s recovered to open", beadID),

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -392,7 +392,7 @@ func (m *Manager) RecoverOrphanedBeads() (recovered int) {
 					m.logger.Warn("failed to track recovery failure", "bead", beadID, "error", dbErr)
 				} else if tripped {
 					m.logger.Warn("orphan recovery flagged as needs-human after repeated failures", "bead", beadID, "anvil", anvilName, "failures", failures)
-					m.db.LogEvent(state.EventBeadRecovered,
+					m.db.LogEvent(state.EventError,
 						fmt.Sprintf("Orphaned bead %s flagged needs-human after %d recovery failures", beadID, failures),
 						beadID, anvilName)
 				}

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -123,6 +123,8 @@ func (db *DB) migrate() error {
 		{"wicket_issues", "pr_url", `ALTER TABLE wicket_issues ADD COLUMN pr_url TEXT NOT NULL DEFAULT ''`},
 		{"wicket_issues", "comment_count", `ALTER TABLE wicket_issues ADD COLUMN comment_count INTEGER NOT NULL DEFAULT 0`},
 		{"wicket_issues", "author_replied_at", `ALTER TABLE wicket_issues ADD COLUMN author_replied_at TEXT`},
+		{"retries", "recovery_failures", `ALTER TABLE retries ADD COLUMN recovery_failures INTEGER NOT NULL DEFAULT 0`},
+		{"retries", "first_recovery_failure_at", `ALTER TABLE retries ADD COLUMN first_recovery_failure_at TEXT`},
 	}
 	for _, m := range migrations {
 		exists, err := db.columnExists(m.table, m.column)
@@ -1723,28 +1725,30 @@ func (db *DB) LastPollAllAnvils() ([]AnvilPollStatus, error) {
 
 // RetryRecord tracks retry state for a bead.
 type RetryRecord struct {
-	BeadID              string
-	Anvil               string
-	RetryCount          int
-	NextRetry           *time.Time
-	NeedsHuman          bool
-	ClarificationNeeded bool
-	DispatchFailures    int
-	LastError           string
-	UpdatedAt           time.Time
+	BeadID                string
+	Anvil                 string
+	RetryCount            int
+	NextRetry             *time.Time
+	NeedsHuman            bool
+	ClarificationNeeded   bool
+	DispatchFailures      int
+	RecoveryFailures      int
+	FirstRecoveryFailure  *time.Time
+	LastError             string
+	UpdatedAt             time.Time
 }
 
 // GetRetry returns the retry record for a bead, or nil if none exists.
 func (db *DB) GetRetry(beadID, anvil string) (*RetryRecord, error) {
 	row := db.conn.QueryRow(
-		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, last_error, updated_at
+		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at
 		 FROM retries WHERE bead_id = ? AND anvil = ?`, beadID, anvil)
 
 	var r RetryRecord
-	var nextRetry sql.NullString
+	var nextRetry, firstRecovFailure sql.NullString
 	var updatedAt string
 	var needsHuman, clarNeeded int
-	err := row.Scan(&r.BeadID, &r.Anvil, &r.RetryCount, &nextRetry, &needsHuman, &clarNeeded, &r.DispatchFailures, &r.LastError, &updatedAt)
+	err := row.Scan(&r.BeadID, &r.Anvil, &r.RetryCount, &nextRetry, &needsHuman, &clarNeeded, &r.DispatchFailures, &r.RecoveryFailures, &firstRecovFailure, &r.LastError, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -1758,6 +1762,10 @@ func (db *DB) GetRetry(beadID, anvil string) (*RetryRecord, error) {
 		t := parseTime(nextRetry.String)
 		r.NextRetry = &t
 	}
+	if firstRecovFailure.Valid {
+		t := parseTime(firstRecovFailure.String)
+		r.FirstRecoveryFailure = &t
+	}
 	return &r, nil
 }
 
@@ -1768,6 +1776,11 @@ func (db *DB) UpsertRetry(r *RetryRecord) error {
 		s := r.NextRetry.Format(dbTimeLayout)
 		nextRetry = &s
 	}
+	var firstRecovFailure *string
+	if r.FirstRecoveryFailure != nil {
+		s := r.FirstRecoveryFailure.Format(dbTimeLayout)
+		firstRecovFailure = &s
+	}
 	needsHuman := 0
 	if r.NeedsHuman {
 		needsHuman = 1
@@ -1777,18 +1790,20 @@ func (db *DB) UpsertRetry(r *RetryRecord) error {
 		clarNeeded = 1
 	}
 	_, err := db.conn.Exec(
-		`INSERT INTO retries (bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, last_error, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO retries (bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(bead_id, anvil) DO UPDATE SET
 			retry_count = excluded.retry_count,
 			next_retry = excluded.next_retry,
 			needs_human = excluded.needs_human,
 			clarification_needed = excluded.clarification_needed,
 			dispatch_failures = excluded.dispatch_failures,
+			recovery_failures = excluded.recovery_failures,
+			first_recovery_failure_at = excluded.first_recovery_failure_at,
 			last_error = excluded.last_error,
 			updated_at = excluded.updated_at`,
 		r.BeadID, r.Anvil, r.RetryCount, nextRetry, needsHuman, clarNeeded,
-		r.DispatchFailures, r.LastError, time.Now().Format(dbTimeLayout),
+		r.DispatchFailures, r.RecoveryFailures, firstRecovFailure, r.LastError, time.Now().Format(dbTimeLayout),
 	)
 	return err
 }
@@ -1797,7 +1812,7 @@ func (db *DB) UpsertRetry(r *RetryRecord) error {
 func (db *DB) PendingRetries() ([]RetryRecord, error) {
 	now := time.Now().Format(dbTimeLayout)
 	rows, err := db.conn.Query(
-		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, last_error, updated_at
+		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at
 		 FROM retries WHERE needs_human = 0 AND clarification_needed = 0 AND (next_retry IS NULL OR next_retry <= ?)
 		 ORDER BY next_retry`, now)
 	if err != nil {
@@ -1810,7 +1825,7 @@ func (db *DB) PendingRetries() ([]RetryRecord, error) {
 // NeedsHumanBeads returns all beads that have exhausted retries.
 func (db *DB) NeedsHumanBeads() ([]RetryRecord, error) {
 	rows, err := db.conn.Query(
-		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, last_error, updated_at
+		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at
 		 FROM retries WHERE needs_human = 1 ORDER BY updated_at DESC`)
 	if err != nil {
 		return nil, err
@@ -1822,7 +1837,7 @@ func (db *DB) NeedsHumanBeads() ([]RetryRecord, error) {
 // ClarificationNeededBeads returns all beads that need human clarification before work can start.
 func (db *DB) ClarificationNeededBeads() ([]RetryRecord, error) {
 	rows, err := db.conn.Query(
-		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, last_error, updated_at
+		`SELECT bead_id, anvil, retry_count, next_retry, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at
 		 FROM retries WHERE clarification_needed = 1 AND needs_human = 0 ORDER BY updated_at DESC`)
 	if err != nil {
 		return nil, err
@@ -1900,11 +1915,11 @@ func scanRetryRows(rows *sql.Rows) ([]RetryRecord, error) {
 	var records []RetryRecord
 	for rows.Next() {
 		var r RetryRecord
-		var nextRetry sql.NullString
+		var nextRetry, firstRecovFailure sql.NullString
 		var updatedAt string
 		var needsHuman, clarNeeded int
 		if err := rows.Scan(&r.BeadID, &r.Anvil, &r.RetryCount, &nextRetry,
-			&needsHuman, &clarNeeded, &r.DispatchFailures, &r.LastError, &updatedAt); err != nil {
+			&needsHuman, &clarNeeded, &r.DispatchFailures, &r.RecoveryFailures, &firstRecovFailure, &r.LastError, &updatedAt); err != nil {
 			return nil, err
 		}
 		r.NeedsHuman = needsHuman != 0
@@ -1913,6 +1928,10 @@ func scanRetryRows(rows *sql.Rows) ([]RetryRecord, error) {
 		if nextRetry.Valid {
 			t := parseTime(nextRetry.String)
 			r.NextRetry = &t
+		}
+		if firstRecovFailure.Valid {
+			t := parseTime(firstRecovFailure.String)
+			r.FirstRecoveryFailure = &t
 		}
 		records = append(records, r)
 	}
@@ -1996,6 +2015,97 @@ func (db *DB) ResetDispatchFailures(beadID, anvil string) error {
 	return err
 }
 
+const (
+	maxRecoveryFailures   = 3
+	recoveryFailureWindow = 30 * time.Minute
+)
+
+// IncrementRecoveryFailures atomically increments the recovery_failures counter
+// for a bead. If the counter reaches maxRecoveryFailures or the first failure
+// was more than 30 minutes ago, sets needs_human=1. Returns the new failure
+// count and whether needs_human was set.
+func (db *DB) IncrementRecoveryFailures(beadID, anvil, reason string) (int, bool, error) {
+	now := time.Now()
+	nowStr := now.Format(dbTimeLayout)
+
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return 0, false, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Upsert: increment recovery_failures, set first_recovery_failure_at if NULL.
+	_, err = tx.Exec(
+		`INSERT INTO retries (bead_id, anvil, retry_count, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at)
+		 VALUES (?, ?, 0, 0, 0, 0, 1, ?, ?, ?)
+		 ON CONFLICT(bead_id, anvil) DO UPDATE SET
+			recovery_failures = recovery_failures + 1,
+			first_recovery_failure_at = COALESCE(first_recovery_failure_at, excluded.first_recovery_failure_at),
+			last_error = excluded.last_error,
+			updated_at = excluded.updated_at`,
+		beadID, anvil, nowStr, reason, nowStr,
+	)
+	if err != nil {
+		return 0, false, fmt.Errorf("incrementing recovery failures: %w", err)
+	}
+
+	var failures int
+	var firstFailureStr sql.NullString
+	err = tx.QueryRow(
+		`SELECT recovery_failures, first_recovery_failure_at FROM retries WHERE bead_id = ? AND anvil = ?`,
+		beadID, anvil,
+	).Scan(&failures, &firstFailureStr)
+	if err != nil {
+		return 0, false, fmt.Errorf("reading recovery failures: %w", err)
+	}
+
+	tripped := false
+	if failures >= maxRecoveryFailures {
+		tripped = true
+	} else if firstFailureStr.Valid {
+		firstFailure := parseTime(firstFailureStr.String)
+		if now.Sub(firstFailure) >= recoveryFailureWindow {
+			tripped = true
+		}
+	}
+
+	if tripped {
+		_, err = tx.Exec(
+			`UPDATE retries SET needs_human = 1, last_error = ?, updated_at = ?
+			 WHERE bead_id = ? AND anvil = ?`,
+			fmt.Sprintf("recovery failed: %d consecutive failures (%s)", failures, reason),
+			nowStr, beadID, anvil,
+		)
+		if err != nil {
+			return failures, false, fmt.Errorf("setting needs_human after recovery failures: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, false, fmt.Errorf("committing recovery failure increment: %w", err)
+	}
+	return failures, tripped, nil
+}
+
+// ResetRecoveryFailures clears the recovery failure counter and timestamp for
+// a bead after a successful recovery. Only resets rows that were tripped by
+// recovery failures, preserving unrelated needs_human states.
+func (db *DB) ResetRecoveryFailures(beadID, anvil string) error {
+	_, err := db.conn.Exec(
+		`UPDATE retries
+		 SET recovery_failures = 0,
+		     first_recovery_failure_at = NULL,
+		     needs_human = 0,
+		     last_error = '',
+		     updated_at = ?
+		 WHERE bead_id = ? AND anvil = ?
+		   AND recovery_failures > 0
+		   AND last_error LIKE 'recovery failed:%'`,
+		time.Now().Format(dbTimeLayout), beadID, anvil,
+	)
+	return err
+}
+
 // MarkNeedsHuman immediately sets needs_human=1 for a bead, creating the
 // retries row if it doesn't exist. Use this when a pipeline outcome
 // definitively requires human attention (e.g. no-diff hard reject) without
@@ -2053,7 +2163,7 @@ func (db *DB) ResetRetry(beadID, anvil string) error {
 	now := time.Now().Format(dbTimeLayout)
 	res, err := db.conn.Exec(
 		`UPDATE retries SET needs_human = 0, clarification_needed = 0, retry_count = 0, dispatch_failures = 0,
-		        next_retry = NULL, last_error = '', updated_at = ?
+		        recovery_failures = 0, first_recovery_failure_at = NULL, next_retry = NULL, last_error = '', updated_at = ?
 		 WHERE bead_id = ? AND anvil = ?`,
 		now, beadID, anvil,
 	)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1910,7 +1910,8 @@ func (db *DB) ClarificationNeededBeadIDSet() (map[string]struct{}, error) {
 
 // scanRetryRows scans rows from a retries query into RetryRecords.
 // The SELECT must include: bead_id, anvil, retry_count, next_retry,
-// needs_human, clarification_needed, dispatch_failures, last_error, updated_at.
+// needs_human, clarification_needed, dispatch_failures, recovery_failures,
+// first_recovery_failure_at, last_error, updated_at.
 func scanRetryRows(rows *sql.Rows) ([]RetryRecord, error) {
 	var records []RetryRecord
 	for rows.Next() {
@@ -2060,12 +2061,15 @@ func (db *DB) IncrementRecoveryFailures(beadID, anvil, reason string) (int, bool
 	}
 
 	tripped := false
+	tripReason := ""
 	if failures >= maxRecoveryFailures {
 		tripped = true
+		tripReason = fmt.Sprintf("%d consecutive failures", failures)
 	} else if firstFailureStr.Valid {
 		firstFailure := parseTime(firstFailureStr.String)
-		if now.Sub(firstFailure) >= recoveryFailureWindow {
+		if age := now.Sub(firstFailure); age >= recoveryFailureWindow {
 			tripped = true
+			tripReason = fmt.Sprintf("%d failures over %s", failures, age.Round(time.Minute))
 		}
 	}
 
@@ -2073,7 +2077,7 @@ func (db *DB) IncrementRecoveryFailures(beadID, anvil, reason string) (int, bool
 		_, err = tx.Exec(
 			`UPDATE retries SET needs_human = 1, last_error = ?, updated_at = ?
 			 WHERE bead_id = ? AND anvil = ?`,
-			fmt.Sprintf("recovery failed: %d consecutive failures (%s)", failures, reason),
+			fmt.Sprintf("recovery failed: %s (%s)", tripReason, reason),
 			nowStr, beadID, anvil,
 		)
 		if err != nil {
@@ -2088,19 +2092,25 @@ func (db *DB) IncrementRecoveryFailures(beadID, anvil, reason string) (int, bool
 }
 
 // ResetRecoveryFailures clears the recovery failure counter and timestamp for
-// a bead after a successful recovery. Only resets rows that were tripped by
-// recovery failures, preserving unrelated needs_human states.
+// a bead after a successful recovery. If the row was marked needs_human by a
+// tripped recovery circuit breaker, it also clears that recovery-specific
+// state while preserving unrelated needs_human reasons.
 func (db *DB) ResetRecoveryFailures(beadID, anvil string) error {
 	_, err := db.conn.Exec(
 		`UPDATE retries
 		 SET recovery_failures = 0,
 		     first_recovery_failure_at = NULL,
-		     needs_human = 0,
-		     last_error = '',
+		     needs_human = CASE
+		     	WHEN last_error LIKE 'recovery failed:%' THEN 0
+		     	ELSE needs_human
+		     END,
+		     last_error = CASE
+		     	WHEN last_error LIKE 'recovery failed:%' THEN ''
+		     	ELSE last_error
+		     END,
 		     updated_at = ?
 		 WHERE bead_id = ? AND anvil = ?
-		   AND recovery_failures > 0
-		   AND last_error LIKE 'recovery failed:%'`,
+		   AND recovery_failures > 0`,
 		time.Now().Format(dbTimeLayout), beadID, anvil,
 	)
 	return err

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -2540,9 +2540,14 @@ func TestDB_ResetRecoveryFailures_ClearsOnSuccess(t *testing.T) {
 
 	// Trip the recovery failure circuit breaker.
 	for i := 0; i < 3; i++ {
-		_, _, _ = db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+		if _, _, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout"); err != nil {
+			t.Fatalf("IncrementRecoveryFailures iteration %d: %v", i, err)
+		}
 	}
-	r, _ := db.GetRetry(bead, anvil)
+	r, err := db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatalf("GetRetry: %v", err)
+	}
 	if !r.NeedsHuman {
 		t.Fatal("expected NeedsHuman=true after 3 failures")
 	}
@@ -2552,7 +2557,10 @@ func TestDB_ResetRecoveryFailures_ClearsOnSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ = db.GetRetry(bead, anvil)
+	r, err = db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatalf("GetRetry after reset: %v", err)
+	}
 	if r.NeedsHuman {
 		t.Error("expected NeedsHuman=false after reset")
 	}
@@ -2588,9 +2596,69 @@ func TestDB_ResetRecoveryFailures_PreservesUnrelatedNeedsHuman(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := db.GetRetry(bead, anvil)
+	r, err := db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatalf("GetRetry: %v", err)
+	}
 	if !r.NeedsHuman {
 		t.Error("expected NeedsHuman=true to be preserved (unrelated to recovery)")
+	}
+}
+
+func TestDB_ResetRecoveryFailures_ClearsBeforeCircuitTrips(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC7", "anvil-1"
+
+	// Record 2 failures — not enough to trip the circuit.
+	for i := 0; i < 2; i++ {
+		_, tripped, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+		if err != nil {
+			t.Fatalf("IncrementRecoveryFailures iteration %d: %v", i, err)
+		}
+		if tripped {
+			t.Fatalf("circuit should not trip after %d failures", i+1)
+		}
+	}
+
+	r, err := db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatalf("GetRetry: %v", err)
+	}
+	if r.RecoveryFailures != 2 {
+		t.Errorf("expected RecoveryFailures=2, got %d", r.RecoveryFailures)
+	}
+	if r.FirstRecoveryFailure == nil {
+		t.Error("expected FirstRecoveryFailure to be set")
+	}
+
+	// A successful recovery should clear the counter and timestamp even though
+	// needs_human was never set.
+	if err := db.ResetRecoveryFailures(bead, anvil); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err = db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatalf("GetRetry after reset: %v", err)
+	}
+	if r.RecoveryFailures != 0 {
+		t.Errorf("expected RecoveryFailures=0 after reset, got %d", r.RecoveryFailures)
+	}
+	if r.FirstRecoveryFailure != nil {
+		t.Error("expected FirstRecoveryFailure=nil after reset")
+	}
+	if r.NeedsHuman {
+		t.Error("expected NeedsHuman=false (was never set)")
 	}
 }
 
@@ -2610,7 +2678,9 @@ func TestDB_ResetRetry_ClearsRecoveryFailures(t *testing.T) {
 
 	// Trip recovery failures.
 	for i := 0; i < 3; i++ {
-		_, _, _ = db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+		if _, _, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout"); err != nil {
+			t.Fatalf("IncrementRecoveryFailures iteration %d: %v", i, err)
+		}
 	}
 
 	// Full reset should clear everything.
@@ -2618,7 +2688,10 @@ func TestDB_ResetRetry_ClearsRecoveryFailures(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := db.GetRetry(bead, anvil)
+	r, err := db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatalf("GetRetry: %v", err)
+	}
 	if r.RecoveryFailures != 0 {
 		t.Errorf("expected RecoveryFailures=0 after full reset, got %d", r.RecoveryFailures)
 	}

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -2389,3 +2389,243 @@ func TestDB_GetWicketSummary(t *testing.T) {
 		t.Errorf("repo-b: expected 0 needs_human, got %d", summaries[1].NeedsHumanCount)
 	}
 }
+
+func TestDB_IncrementRecoveryFailures_TripsAfterThree(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC1", "anvil-1"
+
+	// First two failures should not trip.
+	for i := 1; i <= 2; i++ {
+		failures, tripped, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+		if err != nil {
+			t.Fatalf("failure %d: %v", i, err)
+		}
+		if failures != i {
+			t.Errorf("failure %d: expected count=%d, got %d", i, i, failures)
+		}
+		if tripped {
+			t.Errorf("failure %d: should not trip yet", i)
+		}
+	}
+
+	// Third failure should trip.
+	failures, tripped, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failures != 3 {
+		t.Errorf("expected 3 failures, got %d", failures)
+	}
+	if !tripped {
+		t.Error("expected needs_human to be set after 3 failures")
+	}
+
+	// Verify via GetRetry.
+	r, err := db.GetRetry(bead, anvil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.NeedsHuman {
+		t.Error("expected NeedsHuman=true")
+	}
+	if r.RecoveryFailures != 3 {
+		t.Errorf("expected RecoveryFailures=3, got %d", r.RecoveryFailures)
+	}
+	if r.FirstRecoveryFailure == nil {
+		t.Error("expected FirstRecoveryFailure to be set")
+	}
+}
+
+func TestDB_IncrementRecoveryFailures_TripsAfterTimeWindow(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC2", "anvil-1"
+
+	// Insert a record with first_recovery_failure_at 31 minutes ago.
+	oldTime := time.Now().Add(-31 * time.Minute).Format(dbTimeLayout)
+	now := time.Now().Format(dbTimeLayout)
+	_, err = db.conn.Exec(
+		`INSERT INTO retries (bead_id, anvil, retry_count, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at)
+		 VALUES (?, ?, 0, 0, 0, 0, 1, ?, '', ?)`,
+		bead, anvil, oldTime, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second failure should trip due to time window (>30 min since first).
+	failures, tripped, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failures != 2 {
+		t.Errorf("expected 2 failures, got %d", failures)
+	}
+	if !tripped {
+		t.Error("expected needs_human to be set due to time window")
+	}
+}
+
+func TestDB_IncrementRecoveryFailures_NoTripUnder30Min(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC3", "anvil-1"
+
+	// Insert with first_recovery_failure_at 29 minutes ago (just under threshold).
+	recentTime := time.Now().Add(-29 * time.Minute).Format(dbTimeLayout)
+	now := time.Now().Format(dbTimeLayout)
+	_, err = db.conn.Exec(
+		`INSERT INTO retries (bead_id, anvil, retry_count, needs_human, clarification_needed, dispatch_failures, recovery_failures, first_recovery_failure_at, last_error, updated_at)
+		 VALUES (?, ?, 0, 0, 0, 0, 1, ?, '', ?)`,
+		bead, anvil, recentTime, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second failure should NOT trip (only 2 failures, under 30 min).
+	failures, tripped, err := db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failures != 2 {
+		t.Errorf("expected 2 failures, got %d", failures)
+	}
+	if tripped {
+		t.Error("should not trip with 2 failures under 30 min")
+	}
+}
+
+func TestDB_ResetRecoveryFailures_ClearsOnSuccess(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC4", "anvil-1"
+
+	// Trip the recovery failure circuit breaker.
+	for i := 0; i < 3; i++ {
+		_, _, _ = db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+	}
+	r, _ := db.GetRetry(bead, anvil)
+	if !r.NeedsHuman {
+		t.Fatal("expected NeedsHuman=true after 3 failures")
+	}
+
+	// Reset should clear recovery fields and needs_human.
+	if err := db.ResetRecoveryFailures(bead, anvil); err != nil {
+		t.Fatal(err)
+	}
+
+	r, _ = db.GetRetry(bead, anvil)
+	if r.NeedsHuman {
+		t.Error("expected NeedsHuman=false after reset")
+	}
+	if r.RecoveryFailures != 0 {
+		t.Errorf("expected RecoveryFailures=0, got %d", r.RecoveryFailures)
+	}
+	if r.FirstRecoveryFailure != nil {
+		t.Error("expected FirstRecoveryFailure=nil after reset")
+	}
+}
+
+func TestDB_ResetRecoveryFailures_PreservesUnrelatedNeedsHuman(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC5", "anvil-1"
+
+	// Set needs_human via MarkNeedsHuman (not recovery failures).
+	if err := db.MarkNeedsHuman(bead, anvil, "no-diff hard reject"); err != nil {
+		t.Fatal(err)
+	}
+
+	// ResetRecoveryFailures should NOT clear this needs_human.
+	if err := db.ResetRecoveryFailures(bead, anvil); err != nil {
+		t.Fatal(err)
+	}
+
+	r, _ := db.GetRetry(bead, anvil)
+	if !r.NeedsHuman {
+		t.Error("expected NeedsHuman=true to be preserved (unrelated to recovery)")
+	}
+}
+
+func TestDB_ResetRetry_ClearsRecoveryFailures(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	bead, anvil := "BD-REC6", "anvil-1"
+
+	// Trip recovery failures.
+	for i := 0; i < 3; i++ {
+		_, _, _ = db.IncrementRecoveryFailures(bead, anvil, "bd timeout")
+	}
+
+	// Full reset should clear everything.
+	if err := db.ResetRetry(bead, anvil); err != nil {
+		t.Fatal(err)
+	}
+
+	r, _ := db.GetRetry(bead, anvil)
+	if r.RecoveryFailures != 0 {
+		t.Errorf("expected RecoveryFailures=0 after full reset, got %d", r.RecoveryFailures)
+	}
+	if r.FirstRecoveryFailure != nil {
+		t.Error("expected FirstRecoveryFailure=nil after full reset")
+	}
+	if r.NeedsHuman {
+		t.Error("expected NeedsHuman=false after full reset")
+	}
+}


### PR DESCRIPTION
## Changes

- **Recovery failure tracking** - Track consecutive orphan recovery failures and flag beads as needs-human after 3 consecutive failures or 30 minutes of failing, preventing infinite recovery loops. (Forge-y04i)

## Original Issue (task): Track consecutive recovery failures and flag as needs-human

Add a failure counter (or timestamp of first failure) to the retries/recovery tracking table for each orphaned bead. After 3 consecutive failures or 30 minutes of failing, set a `needs-human` flag on the bead's retry record. This flag will be read by the TUI Needs Attention query. Files to modify: the retries table schema (if stored in Dolt, add a migration or alter; if in-memory, add fields to the struct), and the watchdog recovery loop to increment/check the counter. Key types: extend the retry record struct with `ConsecutiveFailures int`, `FirstFailureAt time.Time`, `NeedsHuman bool`. Depends on sub-task 1 for the error detail to store. The TUI sub-task depends on this flag existing.

---
Bead: Forge-y04i | Branch: forge/Forge-y04i
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)