### PR TITLE
Surface needs-human beads in TUI Needs Attention view (Forge-idle)

### DIFF
--- a/changelog.d/Forge-idle.md
+++ b/changelog.d/Forge-idle.md
@@ -1,0 +1,2 @@
+category: Added
+- **Needs Attention shows title, failure count, and recovery errors** - The TUI Needs Attention panel now displays bead titles, failure counts from dispatch and recovery circuit breakers, and properly classifies recovery failures as a distinct attention category. (Forge-idle)

--- a/internal/hearth/data.go
+++ b/internal/hearth/data.go
@@ -26,6 +26,9 @@ func classifyAttentionReason(b state.NeedsAttentionBead) AttentionReason {
 	if strings.HasPrefix(reason, "circuit breaker:") {
 		return AttentionDispatchExhausted
 	}
+	if strings.HasPrefix(reason, "recovery failed:") {
+		return AttentionRecoveryExhausted
+	}
 	if strings.Contains(reason, "ci fix exhausted") {
 		return AttentionCIFixExhausted
 	}
@@ -759,6 +762,7 @@ func FetchNeedsAttention(ds *DataSource) tea.Cmd {
 				Anvil:            b.Anvil,
 				Reason:           b.Reason,
 				ReasonCategory:   classifyAttentionReason(b),
+				FailureCount:     b.FailureCount,
 				PRID:             b.PRID,
 				PRNumber:         b.PRNumber,
 				LastWardenReject: ds.DB.LatestWardenRejectMessage(b.BeadID),

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -3721,8 +3721,7 @@ func (m *Model) renderNeedsAttention(width, height int) string {
 			label := item.BeadID
 			if item.PRNumber > 0 {
 				label = fmt.Sprintf("PR #%d %s", item.PRNumber, item.BeadID)
-			}
-			if item.Title != "" {
+			} else if item.Title != "" {
 				label += " " + item.Title
 			}
 			if item.FailureCount > 0 {

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -90,13 +90,14 @@ type activityNavItem struct {
 type AttentionReason int
 
 const (
-	AttentionUnknown            AttentionReason = iota
-	AttentionDispatchExhausted                  // Circuit breaker tripped after repeated dispatch failures
-	AttentionCIFixExhausted                     // CI fix attempts exhausted
-	AttentionReviewFixExhausted                 // Review fix attempts exhausted
-	AttentionRebaseExhausted                    // Rebase attempts exhausted
-	AttentionClarification                      // Bead flagged as needing clarification
-	AttentionStalled                            // Worker stalled (no log activity)
+	AttentionUnknown             AttentionReason = iota
+	AttentionDispatchExhausted                   // Circuit breaker tripped after repeated dispatch failures
+	AttentionRecoveryExhausted                   // Recovery failed after repeated attempts
+	AttentionCIFixExhausted                      // CI fix attempts exhausted
+	AttentionReviewFixExhausted                  // Review fix attempts exhausted
+	AttentionRebaseExhausted                     // Rebase attempts exhausted
+	AttentionClarification                       // Bead flagged as needing clarification
+	AttentionStalled                             // Worker stalled (no log activity)
 )
 
 // NeedsAttentionItem represents a bead requiring human attention.
@@ -107,6 +108,7 @@ type NeedsAttentionItem struct {
 	Anvil            string
 	Reason           string
 	ReasonCategory   AttentionReason
+	FailureCount     int
 	PRID             int // Non-zero when item originates from an exhausted PR
 	PRNumber         int
 	LastWardenReject string // Most recent warden_reject message, if any
@@ -3668,6 +3670,8 @@ func attentionReasonIcon(cat AttentionReason) string {
 	switch cat {
 	case AttentionDispatchExhausted:
 		return lipgloss.NewStyle().Foreground(colorDanger).Render("⊘ DISPATCH")
+	case AttentionRecoveryExhausted:
+		return lipgloss.NewStyle().Foreground(colorDanger).Render("⊘ RECOVERY")
 	case AttentionCIFixExhausted:
 		return lipgloss.NewStyle().Foreground(colorAccent).Render("🔧 CI FIX")
 	case AttentionReviewFixExhausted:
@@ -3717,6 +3721,12 @@ func (m *Model) renderNeedsAttention(width, height int) string {
 			label := item.BeadID
 			if item.PRNumber > 0 {
 				label = fmt.Sprintf("PR #%d %s", item.PRNumber, item.BeadID)
+			}
+			if item.Title != "" {
+				label += " " + item.Title
+			}
+			if item.FailureCount > 0 {
+				label += dimStyle.Render(fmt.Sprintf(" [%d failures]", item.FailureCount))
 			}
 			icon := attentionReasonIcon(item.ReasonCategory)
 			beadLine := fmt.Sprintf("%s %s %s", icon, label, anvil)

--- a/internal/hearth/hearth_test.go
+++ b/internal/hearth/hearth_test.go
@@ -408,6 +408,7 @@ func TestRenderNeedsAttentionReasonCategories(t *testing.T) {
 		wantText string
 	}{
 		{"dispatch exhausted", AttentionDispatchExhausted, "DISPATCH"},
+		{"recovery exhausted", AttentionRecoveryExhausted, "RECOVERY"},
 		{"CI fix exhausted", AttentionCIFixExhausted, "CI FIX"},
 		{"review fix exhausted", AttentionReviewFixExhausted, "REVIEW"},
 		{"rebase exhausted", AttentionRebaseExhausted, "REBASE"},
@@ -558,6 +559,11 @@ func TestClassifyAttentionReason(t *testing.T) {
 			name: "circuit breaker prefix",
 			bead: state.NeedsAttentionBead{NeedsHuman: true, Reason: "circuit breaker: dispatch failed 5 times"},
 			want: AttentionDispatchExhausted,
+		},
+		{
+			name: "recovery failed",
+			bead: state.NeedsAttentionBead{NeedsHuman: true, Reason: "recovery failed: bd stderr output"},
+			want: AttentionRecoveryExhausted,
 		},
 		{
 			name: "CI fix exhausted",

--- a/internal/hearth/hearth_test.go
+++ b/internal/hearth/hearth_test.go
@@ -401,6 +401,35 @@ func TestRenderNeedsAttentionShowsItems(t *testing.T) {
 	}
 }
 
+func TestRenderNeedsAttentionTitleAndFailureCount(t *testing.T) {
+	m := NewModel(nil)
+	m.needsAttention = []NeedsAttentionItem{
+		{BeadID: "bd-7", Anvil: "forge", Title: "My bead title", FailureCount: 3, ReasonCategory: AttentionDispatchExhausted},
+	}
+	m.focused = PanelNeedsAttention
+	rendered := m.renderNeedsAttention(80, 20)
+	if !strings.Contains(rendered, "My bead title") {
+		t.Errorf("expected title 'My bead title' in rendered output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "3 failures") {
+		t.Errorf("expected failure count '3 failures' in rendered output:\n%s", rendered)
+	}
+}
+
+func TestRenderNeedsAttentionPRItemNoDuplicateLabel(t *testing.T) {
+	m := NewModel(nil)
+	m.needsAttention = []NeedsAttentionItem{
+		{BeadID: "bd-12", Anvil: "forge", PRNumber: 42, Title: "PR #42", ReasonCategory: AttentionCIFixExhausted},
+	}
+	m.focused = PanelNeedsAttention
+	rendered := m.renderNeedsAttention(80, 20)
+	// "PR #42" should appear exactly once in the bead label, not twice
+	count := strings.Count(rendered, "PR #42")
+	if count != 1 {
+		t.Errorf("expected 'PR #42' to appear exactly once, got %d occurrences:\n%s", count, rendered)
+	}
+}
+
 func TestRenderNeedsAttentionReasonCategories(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -2249,6 +2249,7 @@ type NeedsAttentionBead struct {
 	Reason              string
 	NeedsHuman          bool
 	ClarificationNeeded bool
+	FailureCount        int
 	// PRID is non-zero when this item originates from an exhausted PR rather
 	// than the retries table. The caller uses this to route retry/dismiss
 	// actions to the correct DB operation.
@@ -2262,11 +2263,13 @@ type NeedsAttentionBead struct {
 // The maxCI/maxRev/maxRebase thresholds determine which PRs are considered exhausted.
 func (db *DB) NeedsAttentionBeads(maxCI, maxRev, maxRebase int) ([]NeedsAttentionBead, error) {
 	rows, err := db.conn.Query(
-		`SELECT bead_id, anvil, needs_human, clarification_needed, reason, title, description
+		`SELECT bead_id, anvil, needs_human, clarification_needed, reason, title, description, failure_count
 		 FROM (
 		     SELECT r.bead_id, r.anvil, r.needs_human, r.clarification_needed, r.last_error AS reason,
 		            COALESCE(NULLIF(q.title, ''), NULLIF(w2.title, ''), '') AS title,
-		            COALESCE(q.description, '') AS description, r.updated_at
+		            COALESCE(q.description, '') AS description,
+		            COALESCE(r.dispatch_failures, 0) + COALESCE(r.recovery_failures, 0) AS failure_count,
+		            r.updated_at
 		     FROM retries r
 		     LEFT JOIN queue_cache q ON r.bead_id = q.bead_id AND r.anvil = q.anvil
 		     LEFT JOIN (
@@ -2284,7 +2287,9 @@ func (db *DB) NeedsAttentionBeads(maxCI, maxRev, maxRebase int) ([]NeedsAttentio
 		     SELECT w.bead_id, w.anvil, 0 AS needs_human, 0 AS clarification_needed,
 		            'Worker stalled (no log activity)' AS reason,
 		            COALESCE(NULLIF(q2.title, ''), NULLIF(w.title, ''), '') AS title,
-		            COALESCE(q2.description, '') AS description, COALESCE(w.updated_at, w.started_at) AS updated_at
+		            COALESCE(q2.description, '') AS description,
+		            0 AS failure_count,
+		            COALESCE(w.updated_at, w.started_at) AS updated_at
 		     FROM workers w
 		     LEFT JOIN queue_cache q2 ON w.bead_id = q2.bead_id AND w.anvil = q2.anvil
 		     WHERE w.status = 'stalled'
@@ -2302,7 +2307,7 @@ func (db *DB) NeedsAttentionBeads(maxCI, maxRev, maxRebase int) ([]NeedsAttentio
 	for rows.Next() {
 		var b NeedsAttentionBead
 		var needsHuman, clarNeeded int
-		if err := rows.Scan(&b.BeadID, &b.Anvil, &needsHuman, &clarNeeded, &b.Reason, &b.Title, &b.Description); err != nil {
+		if err := rows.Scan(&b.BeadID, &b.Anvil, &needsHuman, &clarNeeded, &b.Reason, &b.Title, &b.Description, &b.FailureCount); err != nil {
 			return nil, err
 		}
 		b.NeedsHuman = needsHuman != 0
@@ -2316,6 +2321,9 @@ func (db *DB) NeedsAttentionBeads(maxCI, maxRev, maxRebase int) ([]NeedsAttentio
 			existing := &beads[idx]
 			existing.NeedsHuman = existing.NeedsHuman || b.NeedsHuman
 			existing.ClarificationNeeded = existing.ClarificationNeeded || b.ClarificationNeeded
+			if b.FailureCount > existing.FailureCount {
+				existing.FailureCount = b.FailureCount
+			}
 			if (b.NeedsHuman || b.ClarificationNeeded) && b.Reason != "" {
 				existing.Reason = b.Reason
 			}


### PR DESCRIPTION
## Changes

- **Needs Attention shows title, failure count, and recovery errors** - The TUI Needs Attention panel now displays bead titles, failure counts from dispatch and recovery circuit breakers, and properly classifies recovery failures as a distinct attention category. (Forge-idle)

## Original Issue (task): Surface needs-human beads in TUI Needs Attention view

Modify the TUI's Needs Attention data source query to include beads where the retries table has `needs-human = true`. Display the bead ID, title, failure count, and last error message (from sub-task 1's captured stderr). Files to modify: the TUI component that renders Needs Attention (likely in `tui/needs_attention.go` or similar), and the query/data-fetching layer that populates it. Depends on sub-task 2 for the `needs-human` flag and stored error details.

---
Bead: Forge-idle | Branch: forge/Forge-idle
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)