### PR TITLE
Ledger: Labels column always empty in list view — bd sql query misses labels table (Forge-myij)

### DIFF
--- a/changelog.d/Forge-myij.md
+++ b/changelog.d/Forge-myij.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Ledger labels column populated** - Join the labels table in bd sql queries so the Labels column in the Ledger list and kanban views displays bead labels instead of always being empty. (Forge-myij)

--- a/internal/ledger/data.go
+++ b/internal/ledger/data.go
@@ -50,6 +50,7 @@ type beadJSON struct {
 	IssueType   string          `json:"issue_type"`
 	Assignee    string          `json:"assignee"`
 	Labels      []string        `json:"labels"`
+	LabelsCSV   string          `json:"_labels_csv"`
 	Blocks      []string        `json:"blocks"`
 	DependsOn   []string        `json:"depends_on"`
 	ClosedAt    json.RawMessage `json:"closed_at"`
@@ -74,6 +75,9 @@ func (b *Bead) UnmarshalJSON(data []byte) error {
 	b.IssueType = raw.IssueType
 	b.Assignee = raw.Assignee
 	b.Labels = raw.Labels
+	if len(b.Labels) == 0 && raw.LabelsCSV != "" {
+		b.Labels = strings.Split(raw.LabelsCSV, ",")
+	}
 	b.Blocks = raw.Blocks
 	b.DependsOn = raw.DependsOn
 	b.ClosedAt = parseTimeSafe(raw.ClosedAt)
@@ -245,7 +249,7 @@ func fetchAnvilBeadsWithExec(execFn bdExecFunc, anvilName, anvilPath string, db 
 			func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 				defer cancel()
-				query := fmt.Sprintf(`SELECT * FROM issues WHERE status = '%s'`, status)
+				query := fmt.Sprintf(`SELECT i.*, IFNULL(GROUP_CONCAT(l.label ORDER BY l.label SEPARATOR ','), '') AS _labels_csv FROM issues i LEFT JOIN labels l ON l.issue_id = i.id WHERE i.status = '%s' GROUP BY i.id`, status)
 				out, err := execFn(ctx, anvilPath, "sql", "--json", query)
 				if err != nil {
 					// Fall back to bd list if bd sql is not supported.
@@ -276,7 +280,7 @@ func fetchAnvilBeadsWithExec(execFn bdExecFunc, anvilName, anvilPath string, db 
 		{
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
-			query := `SELECT * FROM issues WHERE status = 'closed' ORDER BY updated_at DESC LIMIT 50`
+			query := `SELECT i.*, IFNULL(GROUP_CONCAT(l.label ORDER BY l.label SEPARATOR ','), '') AS _labels_csv FROM issues i LEFT JOIN labels l ON l.issue_id = i.id WHERE i.status = 'closed' GROUP BY i.id ORDER BY i.updated_at DESC LIMIT 50`
 			out, err := execFn(ctx, anvilPath, "sql", "--json", query)
 			if err != nil {
 				out, err = execFn(ctx, anvilPath, "list", "--status=closed", "--limit", "50", "--json")
@@ -361,7 +365,7 @@ func fetchAllBeadsWithExec(execFn bdExecFunc, anvils map[string]string, db *stat
 				defer openCancel()
 				for _, status := range []string{"open", "in_progress"} {
 					func() {
-						query := fmt.Sprintf(`SELECT * FROM issues WHERE status = '%s'`, status)
+						query := fmt.Sprintf(`SELECT i.*, IFNULL(GROUP_CONCAT(l.label ORDER BY l.label SEPARATOR ','), '') AS _labels_csv FROM issues i LEFT JOIN labels l ON l.issue_id = i.id WHERE i.status = '%s' GROUP BY i.id`, status)
 						out, err := execFn(openCtx, path, "sql", "--json", query)
 						if err != nil {
 							out, err = execFn(openCtx, path, "list", "--status="+status, "--limit", "0", "--json")
@@ -404,7 +408,7 @@ func fetchAllBeadsWithExec(execFn bdExecFunc, anvils map[string]string, db *stat
 				defer wg.Done()
 				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 				defer cancel()
-				query := `SELECT * FROM issues WHERE status = 'closed' ORDER BY updated_at DESC LIMIT 50`
+				query := `SELECT i.*, IFNULL(GROUP_CONCAT(l.label ORDER BY l.label SEPARATOR ','), '') AS _labels_csv FROM issues i LEFT JOIN labels l ON l.issue_id = i.id WHERE i.status = 'closed' GROUP BY i.id ORDER BY i.updated_at DESC LIMIT 50`
 				out, err := execFn(ctx, path, "sql", "--json", query)
 				if err != nil {
 					out, err = execFn(ctx, path, "list", "--status=closed", "--limit", "50", "--json")

--- a/internal/ledger/data_test.go
+++ b/internal/ledger/data_test.go
@@ -292,6 +292,126 @@ func TestFetchAnvilBeadsWithExecAnvilNameSet(t *testing.T) {
 	assert.Equal(t, "anvil-name", update.Beads[0].Anvil, "Anvil must be the registry name, not the filesystem path")
 }
 
+// ---- Labels via bd sql (_labels_csv) tests ----
+
+// mockSQLExec returns a bdExecFunc that succeeds for "bd sql" calls (returning
+// sqlResp) and returns the given fallback for "bd list" calls.
+func mockSQLExec(sqlResp []byte) bdExecFunc {
+	return func(ctx context.Context, anvilPath string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "sql" {
+			return sqlResp, nil
+		}
+		return []byte("[]"), nil
+	}
+}
+
+func TestFetchAnvilBeads_IncludesLabels(t *testing.T) {
+	resp := []byte(`[{"id":"b-1","title":"Bug","status":"open","priority":2,"_labels_csv":"bug,forgeReady"}]`)
+	execFn := mockSQLExec(resp)
+
+	cmd := fetchAnvilBeadsWithExec(execFn, "myAnvil", "/tmp/anvil", nil)
+	msg := cmd()
+	update := msg.(UpdateBeadsMsg)
+
+	require.NoError(t, update.Err)
+	require.NotEmpty(t, update.Beads)
+
+	var found *Bead
+	for i := range update.Beads {
+		if update.Beads[i].ID == "b-1" {
+			found = &update.Beads[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "bead b-1 must be in results")
+	assert.Equal(t, []string{"bug", "forgeReady"}, found.Labels)
+}
+
+func TestFetchAnvilBeads_NoLabels(t *testing.T) {
+	resp := []byte(`[{"id":"b-2","title":"No labels","status":"open","priority":3,"_labels_csv":""}]`)
+	execFn := mockSQLExec(resp)
+
+	cmd := fetchAnvilBeadsWithExec(execFn, "myAnvil", "/tmp/anvil", nil)
+	msg := cmd()
+	update := msg.(UpdateBeadsMsg)
+
+	require.NoError(t, update.Err)
+	var found *Bead
+	for i := range update.Beads {
+		if update.Beads[i].ID == "b-2" {
+			found = &update.Beads[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "bead b-2 must be in results")
+	assert.Empty(t, found.Labels, "empty _labels_csv must produce nil/empty Labels slice")
+}
+
+func TestFetchAnvilBeads_MultipleLabels(t *testing.T) {
+	resp := []byte(`[{"id":"b-3","title":"Many labels","status":"open","priority":1,"_labels_csv":"bug,enhancement,forgeReady,urgent"}]`)
+	execFn := mockSQLExec(resp)
+
+	cmd := fetchAnvilBeadsWithExec(execFn, "myAnvil", "/tmp/anvil", nil)
+	msg := cmd()
+	update := msg.(UpdateBeadsMsg)
+
+	require.NoError(t, update.Err)
+	var found *Bead
+	for i := range update.Beads {
+		if update.Beads[i].ID == "b-3" {
+			found = &update.Beads[i]
+			break
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, []string{"bug", "enhancement", "forgeReady", "urgent"}, found.Labels)
+}
+
+func TestBead_UnmarshalLabelsCSV(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected []string
+	}{
+		{
+			name:     "empty csv",
+			json:     `{"id":"x","title":"t","status":"open","priority":1,"_labels_csv":""}`,
+			expected: nil,
+		},
+		{
+			name:     "single label",
+			json:     `{"id":"x","title":"t","status":"open","priority":1,"_labels_csv":"bug"}`,
+			expected: []string{"bug"},
+		},
+		{
+			name:     "multiple labels",
+			json:     `{"id":"x","title":"t","status":"open","priority":1,"_labels_csv":"a,b,c"}`,
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "labels array takes precedence",
+			json:     `{"id":"x","title":"t","status":"open","priority":1,"labels":["from-array"],"_labels_csv":"from-csv"}`,
+			expected: []string{"from-array"},
+		},
+		{
+			name:     "no labels field at all",
+			json:     `{"id":"x","title":"t","status":"open","priority":1}`,
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b Bead
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &b))
+			if tt.expected == nil {
+				assert.Empty(t, b.Labels)
+			} else {
+				assert.Equal(t, tt.expected, b.Labels)
+			}
+		})
+	}
+}
+
 // ---- End of fetchAnvilBeadsWithExec tests ----
 
 func TestParseTimeSafeOutOfRangeYear(t *testing.T) {

--- a/internal/ledger/data_test.go
+++ b/internal/ledger/data_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -294,12 +295,20 @@ func TestFetchAnvilBeadsWithExecAnvilNameSet(t *testing.T) {
 
 // ---- Labels via bd sql (_labels_csv) tests ----
 
-// mockSQLExec returns a bdExecFunc that succeeds for "bd sql" calls (returning
-// sqlResp) and returns the given fallback for "bd list" calls.
-func mockSQLExec(sqlResp []byte) bdExecFunc {
+// mockSQLExec returns a bdExecFunc for testing the "bd sql" fast-path.
+// For "bd sql" calls it returns sqlResp only when the SQL query contains the
+// substring "status = '<matchStatus>'" (preventing the same bead from being
+// returned by every status-specific query and appearing as duplicates). For all
+// other calls (e.g. "bd list" fallbacks and non-matching status queries) it
+// returns an empty JSON array.
+func mockSQLExec(sqlResp []byte, matchStatus string) bdExecFunc {
 	return func(ctx context.Context, anvilPath string, args ...string) ([]byte, error) {
 		if len(args) > 0 && args[0] == "sql" {
-			return sqlResp, nil
+			// args layout from fetchAnvilBeadsWithExec: ["sql", "--json", <query>]
+			if len(args) > 2 && strings.Contains(args[2], "status = '"+matchStatus+"'") {
+				return sqlResp, nil
+			}
+			return []byte("[]"), nil
 		}
 		return []byte("[]"), nil
 	}
@@ -307,63 +316,49 @@ func mockSQLExec(sqlResp []byte) bdExecFunc {
 
 func TestFetchAnvilBeads_IncludesLabels(t *testing.T) {
 	resp := []byte(`[{"id":"b-1","title":"Bug","status":"open","priority":2,"_labels_csv":"bug,forgeReady"}]`)
-	execFn := mockSQLExec(resp)
+	execFn := mockSQLExec(resp, "open")
 
 	cmd := fetchAnvilBeadsWithExec(execFn, "myAnvil", "/tmp/anvil", nil)
 	msg := cmd()
 	update := msg.(UpdateBeadsMsg)
 
 	require.NoError(t, update.Err)
-	require.NotEmpty(t, update.Beads)
+	require.Len(t, update.Beads, 1, "each bead must appear exactly once (no duplicates across status queries)")
 
-	var found *Bead
-	for i := range update.Beads {
-		if update.Beads[i].ID == "b-1" {
-			found = &update.Beads[i]
-			break
-		}
-	}
-	require.NotNil(t, found, "bead b-1 must be in results")
+	found := &update.Beads[0]
+	assert.Equal(t, "b-1", found.ID)
 	assert.Equal(t, []string{"bug", "forgeReady"}, found.Labels)
 }
 
 func TestFetchAnvilBeads_NoLabels(t *testing.T) {
 	resp := []byte(`[{"id":"b-2","title":"No labels","status":"open","priority":3,"_labels_csv":""}]`)
-	execFn := mockSQLExec(resp)
+	execFn := mockSQLExec(resp, "open")
 
 	cmd := fetchAnvilBeadsWithExec(execFn, "myAnvil", "/tmp/anvil", nil)
 	msg := cmd()
 	update := msg.(UpdateBeadsMsg)
 
 	require.NoError(t, update.Err)
-	var found *Bead
-	for i := range update.Beads {
-		if update.Beads[i].ID == "b-2" {
-			found = &update.Beads[i]
-			break
-		}
-	}
-	require.NotNil(t, found, "bead b-2 must be in results")
+	require.Len(t, update.Beads, 1, "each bead must appear exactly once (no duplicates across status queries)")
+
+	found := &update.Beads[0]
+	assert.Equal(t, "b-2", found.ID)
 	assert.Empty(t, found.Labels, "empty _labels_csv must produce nil/empty Labels slice")
 }
 
 func TestFetchAnvilBeads_MultipleLabels(t *testing.T) {
 	resp := []byte(`[{"id":"b-3","title":"Many labels","status":"open","priority":1,"_labels_csv":"bug,enhancement,forgeReady,urgent"}]`)
-	execFn := mockSQLExec(resp)
+	execFn := mockSQLExec(resp, "open")
 
 	cmd := fetchAnvilBeadsWithExec(execFn, "myAnvil", "/tmp/anvil", nil)
 	msg := cmd()
 	update := msg.(UpdateBeadsMsg)
 
 	require.NoError(t, update.Err)
-	var found *Bead
-	for i := range update.Beads {
-		if update.Beads[i].ID == "b-3" {
-			found = &update.Beads[i]
-			break
-		}
-	}
-	require.NotNil(t, found)
+	require.Len(t, update.Beads, 1, "each bead must appear exactly once (no duplicates across status queries)")
+
+	found := &update.Beads[0]
+	assert.Equal(t, "b-3", found.ID)
 	assert.Equal(t, []string{"bug", "enhancement", "forgeReady", "urgent"}, found.Labels)
 }
 


### PR DESCRIPTION
## Changes

- **Ledger labels column populated** - Join the labels table in bd sql queries so the Labels column in the Ledger list and kanban views displays bead labels instead of always being empty. (Forge-myij)

## Original Issue (bug): Ledger: Labels column always empty in list view — bd sql query misses labels table

## Problem

In the Forge Ledger TUI list view, the **Labels** column header is visible but every cell in that column is blank, even for beads that clearly have labels (e.g. `forgeReady`, `bug`, `forge` — visible via `bd show <id>`).

Not a column-width or layout issue. The column has a fixed 14-character allocation and renders correctly when given data — the underlying `Bead.Labels` slice is simply empty for every bead because the loader never populates it.

## Reproduction

```
forge ledger
# Open list view. Observe that Labels column is empty for all rows,
# including beads known to have forgeReady / bug / etc. labels.
```

Cross-check against `bd sql --json "SELECT issue_id, label FROM labels WHERE issue_id='Hytte-c4c6'"` → returns four labels. The bd database has the data; the ledger isn't loading it.

## Root cause

`internal/ledger/data.go:244-272` switched from `bd list --json` to `bd sql --json` for a ~6× speedup:

```go
query := fmt.Sprintf(`SELECT * FROM issues WHERE status = '%s'`, status)
out, err := execFn(ctx, anvilPath, "sql", "--json", query)
if err != nil {
    // Fall back to bd list if bd sql is not supported.
    out, err = execFn(ctx, anvilPath, "list", "--status="+status, "--limit", "0", "--json")
}
```

Confirmed:

- `bd list --json` returns a per-issue object with `labels: ["forgeReady", "bug", ...]` populated by the bd CLI performing an internal join.
- `bd sql --json "SELECT * FROM issues"` returns the raw `issues` table, which has no labels column. Labels live in a separate table: `labels(issue_id, label)` (verified via `DESCRIBE labels`).

So the SQL fast-path misses labels entirely. The fallback to `bd list` would return labels but only fires on errors — and `bd sql` succeeds, so the fallback never runs.

Same bug likely present in `fetchAllBeadsWithExec` at `data.go:340-427` (same bd sql pattern, same three `SELECT * FROM issues` queries), in `fetchAnvilBeadsWithExec` for all three status buckets (open/in_progress/closed), and in the closed-beads fetch at `:276-298`.

## Fix

Options, in rough order of preference:

### Option A — Enrich the SQL query with a joined `labels` column (preferred)

Dolt is MySQL-compatible and supports `GROUP_CONCAT`. Change the query to:

```sql
SELECT i.*, IFNULL(GROUP_CONCAT(l.label ORDER BY l.label SEPARATOR ','), '') AS _labels_csv
FROM issues i
LEFT JOIN labels l ON l.issue_id = i.id
WHERE i.status = ?
GROUP BY i.id
```

Then after `json.Unmarshal`, split the `_labels_csv` field (which the current `beadJSON` struct doesn't have — add a `LabelsCSV string \`json:"_labels_csv"\`` field and populate `Bead.Labels` from it in `UnmarshalJSON`).

Preserves the 6× speedup. Single query per status bucket. Works the same for `fetchAllBeadsWithExec`.

**Edge case**: a bead with zero labels must produce an empty `_labels_csv` (not NULL), hence the `IFNULL`. The split should treat empty string as empty slice, not a single empty-string entry.

### Option B — Second query for labels, merge in Go

After the issues query returns, run one batch query:

```sql
SELECT issue_id, label FROM labels WHERE issue_id IN (<list>)
```

Build a `map[string][]string` keyed by issue_id, then populate `beads[i].Labels` from the map. Two round-trips per status bucket instead of one, but simpler SQL and no schema change to `beadJSON`.

### Option C — Abandon the SQL fast-path for label-bearing use cases

Always use `bd list --json`. Simplest change (delete the `bd sql` branch) but loses the 6× speedup that motivated the refactor in the first place. Not recommended.

**Recommend Option A.** Retains the performance win and is ~15 lines of change concentrated in `data.go`.

## Not the problem: column width

The user's initial hypothesis was that labels were hidden behind another column. Verified against `internal/ledger/list.go:44-54`: `colLabels = 14` with explicit padding and truncation. When the slice has data, `strings.Join(b.Labels, ",")` renders and gets truncated to fit. No layout change needed — once the data is populated the existing width is enough to show the most important labels (typically `forgeReady`, `bug`, `enhancement`, etc. fit within 14 chars either individually or as short combinations).

If labels commonly exceed 14 chars in practice once populated, a separate follow-up could consider reducing `colAssignee` (currently 12, often unused in this repo) to give labels a bit more room. Out of scope here.

## Tests

`internal/ledger/data_test.go`:

- `TestFetchAnvilBeads_IncludesLabels`: stub `execFn` to return JSON with a labels field (matching the new query shape), assert that returned `Bead.Labels` is populated correctly.
- `TestFetchAnvilBeads_NoLabels`: stub return with empty `_labels_csv` (or null label column if Option B), assert `Bead.Labels` is `nil` or an empty slice (consistent with bd list behavior).
- `TestFetchAnvilBeads_MultipleLabels`: stub return with comma-separated labels, assert they're split correctly.
- If Option A: `TestBead_UnmarshalLabelsCSV` covering the split edge cases (empty string, single label, multiple labels, trailing/leading whitespace if any).

## Files touched

- `internal/ledger/data.go` — change the query, update JSON parsing.
- `internal/ledger/data_test.go` — new tests and updated stubs.
- `changelog.d/Forge-<id>.md` — Fixed category fragment.

## Acceptance criteria

- Opening `forge ledger` and selecting list view shows populated Labels cells for every bead that has labels in bd.
- A bead with no labels shows an empty cell (existing behavior, no regression).
- Performance of the anvil load is unchanged (single query per status bucket, no extra round-trips — Option A) or within acceptable range (Option B's extra query should add <50 ms for typical anvil sizes).
- Kanban view (if it also uses fetched Labels — check `internal/ledger/kanban.go`) also displays labels correctly; same underlying fix benefits both views.

---
Bead: Forge-myij | Branch: forge/Forge-myij
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)