### PR TITLE
Emit NotifyEvent on recovery failure escalation (Forge-z2i9)

### DIFF
--- a/changelog.d/Forge-z2i9.md
+++ b/changelog.d/Forge-z2i9.md
@@ -1,0 +1,2 @@
+category: Added
+- **Orphan recovery failure notifications** - Emit webhook notifications when a bead is flagged as needs-human due to repeated orphan recovery failures, including bead ID, title, failure count, and error details. (Forge-z2i9)

--- a/changelog.d/Forge-z2i9.md
+++ b/changelog.d/Forge-z2i9.md
@@ -1,2 +1,3 @@
 category: Added
 - **Orphan recovery failure notifications** - Emit webhook notifications when a bead is flagged as needs-human due to repeated orphan recovery failures, including bead ID, title, failure count, and error details. (Forge-z2i9)
+

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -326,6 +326,24 @@ func New(cfg *config.Config) (*Daemon, error) {
 		return true
 	}
 
+	d.shutdownMgr.OnNeedsHuman = func(beadID, anvil, title string, failures int, reason string) {
+		msg := fmt.Sprintf("Bead %s flagged needs-human after %d recovery failures: %s", beadID, failures, reason)
+		if title != "" {
+			msg = fmt.Sprintf("Bead %s (%s) flagged needs-human after %d recovery failures: %s", beadID, title, failures, reason)
+		}
+		disp := d.dispatcher.Load()
+		go func(beadID, anvil, msg string, failures int, reason string) {
+			notifCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if n := d.notifier.Load(); n != nil {
+				n.BeadFailed(notifCtx, anvil, beadID, failures, reason)
+			}
+			if disp != nil {
+				disp.Dispatch(notifCtx, notify.EventOrphanRecoveryFailed, beadID, anvil, msg)
+			}
+		}(beadID, anvil, msg, failures, reason)
+	}
+
 	// Initialize costLimitLoggedDate so Load() is always safe (zero atomic.Value
 	// returns nil on Load, which is fine for type assertion, but Store("")
 	// makes the intent explicit and avoids any future ambiguity).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -336,7 +336,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 			notifCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			if n := d.notifier.Load(); n != nil {
-				n.BeadFailed(notifCtx, anvil, beadID, failures, reason)
+				n.OrphanRecoveryFailed(notifCtx, anvil, beadID, title, failures, reason)
 			}
 			if disp != nil {
 				disp.Dispatch(notifCtx, notify.EventOrphanRecoveryFailed, beadID, anvil, msg)

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -47,8 +47,12 @@ const (
 	// release notifications. Teams webhooks use EventReleasePublished and
 	// receive Adaptive Cards; generic webhooks use EventRelease and receive a
 	// simple GenericPayload.
-	EventRelease               EventType = "release"
-	EventOrphanRecoveryFailed  EventType = "orphan_recovery_failed"
+	EventRelease EventType = "release"
+	// EventOrphanRecoveryFailed is emitted when repeated orphan recovery
+	// failures escalate a bead to needs-human. Teams webhooks use this event
+	// via the OrphanRecoveryFailed notifier method; generic webhooks also
+	// receive it via the WebhookDispatcher.
+	EventOrphanRecoveryFailed EventType = "orphan_recovery_failed"
 )
 
 // Notifier sends notifications to Teams.
@@ -138,6 +142,38 @@ func (n *Notifier) BeadFailed(ctx context.Context, anvil, beadID string, retries
 			{Title: "Bead", Value: beadID},
 			{Title: "Retries", Value: fmt.Sprintf("%d", retries)},
 			{Title: "Error", Value: lastError},
+		},
+	)
+
+	n.send(ctx, card)
+}
+
+// OrphanRecoveryFailed sends a Teams notification when repeated orphan recovery
+// failures escalate a bead to needs-human status. It is keyed off
+// EventOrphanRecoveryFailed so Teams event filters can target this event
+// independently of generic bead failures.
+func (n *Notifier) OrphanRecoveryFailed(ctx context.Context, anvil, beadID, title string, failures int, reason string) {
+	if !n.ShouldNotify(EventOrphanRecoveryFailed) {
+		return
+	}
+
+	if len(reason) > 200 {
+		reason = reason[:200] + "..."
+	}
+
+	beadLabel := beadID
+	if title != "" {
+		beadLabel = fmt.Sprintf("%s (%s)", beadID, title)
+	}
+
+	card := adaptiveCard(
+		"🚨 Orphan Recovery Escalated (needs human)",
+		"attention",
+		[]cardFact{
+			{Title: "Anvil", Value: anvil},
+			{Title: "Bead", Value: beadLabel},
+			{Title: "Failures", Value: fmt.Sprintf("%d", failures)},
+			{Title: "Reason", Value: reason},
 		},
 	)
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -47,7 +47,8 @@ const (
 	// release notifications. Teams webhooks use EventReleasePublished and
 	// receive Adaptive Cards; generic webhooks use EventRelease and receive a
 	// simple GenericPayload.
-	EventRelease EventType = "release"
+	EventRelease               EventType = "release"
+	EventOrphanRecoveryFailed  EventType = "orphan_recovery_failed"
 )
 
 // Notifier sends notifications to Teams.

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -66,6 +66,12 @@ type Manager struct {
 	// auto-recovered. If nil or returns false, auto-recovery proceeds as
 	// before. Set by the daemon after construction.
 	OnOrphanFound func(beadID, anvil, title, branch string) bool
+
+	// OnNeedsHuman, when set, is called when a bead is flagged as
+	// needs-human due to repeated recovery failures. The daemon uses this
+	// to fire webhook notifications. Parameters: beadID, anvil, title
+	// (may be empty if unknown), failure count, and the underlying error.
+	OnNeedsHuman func(beadID, anvil, title string, failures int, reason string)
 }
 
 // NewManager creates a new shutdown manager.
@@ -192,8 +198,17 @@ func (m *Manager) CleanupOrphans() (cleaned int) {
 				} else {
 					if err := m.resetBead(w.BeadID, anvilPath); err != nil {
 						m.logger.Warn("failed to reset bead status", "bead", w.BeadID, "error", err)
-						if _, _, dbErr := m.db.IncrementRecoveryFailures(w.BeadID, w.Anvil, err.Error()); dbErr != nil {
+						failures, tripped, dbErr := m.db.IncrementRecoveryFailures(w.BeadID, w.Anvil, err.Error())
+						if dbErr != nil {
 							m.logger.Warn("failed to track recovery failure", "bead", w.BeadID, "error", dbErr)
+						} else if tripped {
+							m.logger.Warn("orphan worker recovery flagged as needs-human after repeated failures", "bead", w.BeadID, "anvil", w.Anvil, "failures", failures)
+							m.db.LogEvent(state.EventRecoveryCircuitBreak,
+								fmt.Sprintf("Orphaned worker bead %s flagged needs-human after %d recovery failures: %s", w.BeadID, failures, err.Error()),
+								w.BeadID, w.Anvil)
+							if m.OnNeedsHuman != nil {
+								m.OnNeedsHuman(w.BeadID, w.Anvil, "", failures, err.Error())
+							}
 						}
 					} else {
 						_ = m.db.ResetRecoveryFailures(w.BeadID, w.Anvil)
@@ -392,9 +407,12 @@ func (m *Manager) RecoverOrphanedBeads() (recovered int) {
 					m.logger.Warn("failed to track recovery failure", "bead", beadID, "error", dbErr)
 				} else if tripped {
 					m.logger.Warn("orphan recovery flagged as needs-human after repeated failures", "bead", beadID, "anvil", anvilName, "failures", failures)
-					m.db.LogEvent(state.EventError,
-						fmt.Sprintf("Orphaned bead %s flagged needs-human after %d recovery failures", beadID, failures),
+					m.db.LogEvent(state.EventRecoveryCircuitBreak,
+						fmt.Sprintf("Orphaned bead %s flagged needs-human after %d recovery failures: %s", beadID, failures, err.Error()),
 						beadID, anvilName)
+					if m.OnNeedsHuman != nil {
+						m.OnNeedsHuman(beadID, anvilName, bead.Title, failures, err.Error())
+					}
 				}
 				continue
 			}

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -207,7 +207,7 @@ func (m *Manager) CleanupOrphans() (cleaned int) {
 								fmt.Sprintf("Orphaned worker bead %s flagged needs-human after %d recovery failures: %s", w.BeadID, failures, err.Error()),
 								w.BeadID, w.Anvil)
 							if m.OnNeedsHuman != nil {
-								m.OnNeedsHuman(w.BeadID, w.Anvil, "", failures, err.Error())
+								m.OnNeedsHuman(w.BeadID, w.Anvil, w.Title, failures, err.Error())
 							}
 						}
 					} else {

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1445,6 +1445,9 @@ const (
 
 	// Pipeline hook events.
 	EventHookFailed EventType = "hook_failed"
+
+	// Recovery circuit breaker — orphan bead recovery exhausted retries.
+	EventRecoveryCircuitBreak EventType = "recovery_circuit_break"
 )
 
 // Event represents a logged event.


### PR DESCRIPTION
## Changes

- **Orphan recovery failure notifications** - Emit webhook notifications when a bead is flagged as needs-human due to repeated orphan recovery failures, including bead ID, title, failure count, and error details. (Forge-z2i9)

## Original Issue (task): Emit NotifyEvent on recovery failure escalation

When a bead is flagged as `needs-human` (from sub-task 2), emit a `NotifyEvent` through Forge's existing notification/event system so that configured webhooks fire. The event message should include the bead ID, title, failure count, and the underlying bd error message (from sub-task 1). Files to modify: the watchdog module (at the point where `needs-human` is set), and potentially the notification event types file to add a new event variant like `OrphanRecoveryFailed`. Depends on sub-tasks 1 and 2.

---
Bead: Forge-z2i9 | Branch: forge/Forge-z2i9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)