### PR TITLE
Poller: bump bd ready --limit so labeled lower-priority beads aren't hidden (Forge-4kx4)

### DIFF
--- a/changelog.d/Forge-4kx4.md
+++ b/changelog.d/Forge-4kx4.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Poller bd ready limit** - Pass --limit=100 (configurable via settings.bd_ready_limit) to 'bd ready' so labeled lower-priority beads beyond the default top 10 are visible to the poller and dispatched. (Forge-4kx4)

--- a/cmd/forge/queue.go
+++ b/cmd/forge/queue.go
@@ -53,6 +53,7 @@ var queueCmd = &cobra.Command{
 		}
 
 		p := poller.New(cfg.Anvils)
+		p.BdReadyLimit = cfg.Settings.BdReadyLimit
 		beads, results := p.Poll(rootCtx)
 
 		// Report per-anvil errors

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -531,6 +531,7 @@ These settings live under the top-level `settings` key.
 | `wicket_bead_created_label` | `"forge-bead-created"` | GitHub label applied to issues for which a bead was created. |
 | `wicket_trigger_label` | `""` | When non-empty, only issues carrying this label are processed (pull model). |
 | `wicket_stale_days` | `14` | Days without an author reply before a clarification request is marked stale. After a further 7 days the issue is closed automatically. |
+| `bd_ready_limit` | `100` | Maximum number of beads returned by `bd ready`. Increase if an anvil has more than 100 ready beads. |
 
 ### Per-Anvil Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -531,7 +531,14 @@ These settings live under the top-level `settings` key.
 | `wicket_bead_created_label` | `"forge-bead-created"` | GitHub label applied to issues for which a bead was created. |
 | `wicket_trigger_label` | `""` | When non-empty, only issues carrying this label are processed (pull model). |
 | `wicket_stale_days` | `14` | Days without an author reply before a clarification request is marked stale. After a further 7 days the issue is closed automatically. |
-| `bd_ready_limit` | `100` | Maximum number of beads returned by `bd ready`. Increase if an anvil has more than 100 ready beads. |
+
+### Poller / Queue Settings
+
+These settings live under the top-level `settings` key.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `bd_ready_limit` | `100` | Maximum number of beads returned by `bd ready --limit`. Increase if an anvil has more than 100 ready beads. |
 
 ### Per-Anvil Settings
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -407,6 +407,9 @@ type SettingsConfig struct {
 	// Wicket issue awaiting clarification is marked as stale. After a further 7
 	// days, the issue is closed automatically. Defaults to 14.
 	WicketStaleDays int `mapstructure:"wicket_stale_days" yaml:"wicket_stale_days,omitempty"`
+	// BdReadyLimit is the --limit passed to 'bd ready --json'. bd defaults to
+	// 10 which can hide labeled lower-priority beads. Default: 100.
+	BdReadyLimit int `mapstructure:"bd_ready_limit" yaml:"bd_ready_limit,omitempty"`
 }
 
 // durationString returns the duration string, or omits zero values.
@@ -472,6 +475,7 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		WicketBeadCreatedLabel string `yaml:"wicket_bead_created_label,omitempty"`
 		WicketTriggerLabel     string `yaml:"wicket_trigger_label,omitempty"`
 		WicketStaleDays        int    `yaml:"wicket_stale_days,omitempty"`
+		BdReadyLimit           int    `yaml:"bd_ready_limit,omitempty"`
 	}
 
 	sh := shadow{
@@ -520,6 +524,7 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		WicketBeadCreatedLabel: s.WicketBeadCreatedLabel,
 		WicketTriggerLabel:     s.WicketTriggerLabel,
 		WicketStaleDays:        s.WicketStaleDays,
+		BdReadyLimit:           s.BdReadyLimit,
 	}
 
 	// Only include non-zero optional durations.
@@ -732,6 +737,7 @@ func Defaults() Config {
 			WicketNeedsHumanLabel:  "forge-needs-human",
 			WicketBeadCreatedLabel: "forge-bead-created",
 			WicketTriggerLabel:     "",
+			BdReadyLimit:          100,
 		},
 	}
 }
@@ -772,6 +778,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("settings.wicket_needs_human_label", "forge-needs-human")
 	v.SetDefault("settings.wicket_bead_created_label", "forge-bead-created")
 	v.SetDefault("settings.wicket_trigger_label", "")
+	v.SetDefault("settings.bd_ready_limit", 100)
 
 	// Environment variable support: FORGE_SETTINGS_POLL_INTERVAL etc.
 	// SetEnvKeyReplacer maps dotted config keys (settings.auto_learn_rules) to

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1558,6 +1558,7 @@ func (d *Daemon) pollAndDispatch(ctx context.Context) {
 		}
 	}
 	p := poller.NewStaggered(cfg.Anvils, pollInterval)
+	p.BdReadyLimit = cfg.Settings.BdReadyLimit
 	// Log each anvil's poll event as soon as it finishes so Hearth shows
 	// per-anvil timestamps that reflect the actual stagger, not a single
 	// shared timestamp logged after wg.Wait().
@@ -3009,7 +3010,9 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			// If not in cache, poll as fallback
 			if targetBead == nil {
 				d.logger.Info("bead not in cache, polling anvils", "bead", rp.BeadID)
-				p := poller.New(d.cfg.Load().Anvils)
+				currentCfg := d.cfg.Load()
+				p := poller.New(currentCfg.Anvils)
+				p.BdReadyLimit = currentCfg.Settings.BdReadyLimit
 				var beads []poller.Bead
 				var pollErrors []string
 

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -80,7 +80,7 @@ type BeadPoller struct {
 
 // New creates a BeadPoller for the given anvil configurations.
 func New(anvils map[string]config.AnvilConfig) *BeadPoller {
-	return &BeadPoller{anvils: anvils}
+	return &BeadPoller{anvils: anvils, BdReadyLimit: 100}
 }
 
 // NewStaggered creates a BeadPoller that staggers anvil polls across the
@@ -92,7 +92,7 @@ func NewStaggered(anvils map[string]config.AnvilConfig, pollInterval time.Durati
 	if len(anvils) > 1 {
 		stagger = pollInterval / time.Duration(len(anvils))
 	}
-	return &BeadPoller{anvils: anvils, StaggerInterval: stagger}
+	return &BeadPoller{anvils: anvils, StaggerInterval: stagger, BdReadyLimit: 100}
 }
 
 // Poll runs 'bd ready --json' in each anvil directory, merges results,
@@ -170,7 +170,8 @@ func (p *BeadPoller) Poll(ctx context.Context) ([]Bead, []AnvilResult) {
 	return all, results
 }
 
-// pollAnvil runs 'bd ready --json' in an anvil directory and parses the output.
+// pollAnvil runs 'bd ready --json --limit <n>' in an anvil directory and parses the output.
+// The limit is taken from BdReadyLimit (default 100 when unset/non-positive).
 func (p *BeadPoller) pollAnvil(ctx context.Context, name string, anvil config.AnvilConfig) ([]Bead, error) {
 	// Build command with timeout
 	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -73,6 +74,8 @@ type BeadPoller struct {
 	// timestamps immediately (rather than after wg.Wait), so that staggered
 	// polls produce distinct timestamps in monitoring/event logs.
 	OnAnvilDone func(AnvilResult)
+	// BdReadyLimit is the --limit passed to 'bd ready'. Default: 100.
+	BdReadyLimit int
 }
 
 // New creates a BeadPoller for the given anvil configurations.
@@ -138,7 +141,7 @@ func (p *BeadPoller) Poll(ctx context.Context) ([]Bead, []AnvilResult) {
 					return
 				}
 			}
-			beads, err := pollAnvil(ctx, name, anvil)
+			beads, err := p.pollAnvil(ctx, name, anvil)
 			r := AnvilResult{Name: name, Beads: beads, Err: err}
 			if p.OnAnvilDone != nil {
 				p.OnAnvilDone(r)
@@ -168,12 +171,16 @@ func (p *BeadPoller) Poll(ctx context.Context) ([]Bead, []AnvilResult) {
 }
 
 // pollAnvil runs 'bd ready --json' in an anvil directory and parses the output.
-func pollAnvil(ctx context.Context, name string, anvil config.AnvilConfig) ([]Bead, error) {
+func (p *BeadPoller) pollAnvil(ctx context.Context, name string, anvil config.AnvilConfig) ([]Bead, error) {
 	// Build command with timeout
 	cmdCtx, cancel := context.WithTimeout(ctx, executil.DefaultBdTimeout)
 	defer cancel()
 
-	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "ready", "--json"))
+	limit := p.BdReadyLimit
+	if limit <= 0 {
+		limit = 100
+	}
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "ready", "--json", "--limit", strconv.Itoa(limit)))
 	cmd.Dir = anvil.Path
 
 	var stderr bytes.Buffer
@@ -299,7 +306,7 @@ func (p *BeadPoller) PollSingle(ctx context.Context, name string) ([]Bead, error
 	if !ok {
 		return nil, fmt.Errorf("anvil %q not found", name)
 	}
-	return pollAnvil(ctx, name, anvil)
+	return p.pollAnvil(ctx, name, anvil)
 }
 
 // PollInProgress runs 'bd list --status=in_progress --json' in each anvil directory


### PR DESCRIPTION
## Changes

- **Poller bd ready limit** - Pass --limit=100 (configurable via settings.bd_ready_limit) to 'bd ready' so labeled lower-priority beads beyond the default top 10 are visible to the poller and dispatched. (Forge-4kx4)

## Original Issue (bug): Poller: bump bd ready --limit so labeled lower-priority beads aren't hidden

internal/poller/poller.go:176 calls 'bd ready --json' with no --limit flag. bd defaults to --limit=10, so the poller only ever sees the top 10 ready beads (by priority). When an anvil has more than 10 unlabeled higher-priority beads ahead of a labeled lower-priority one, the labeled bead never appears in the poller's result and is never dispatched — even though it's the only bead forge actually wants to run. Workaround today is to bump the bead priority to 0 or 1, which is wrong (skews real priority data). Hearth's queue display shows both Ready (labeled) and Unlabeled sections from the same poller fetch, so we cannot just add --label=forgeReady to the bd command (that would empty the Unlabeled section and break the press-l-to-label UX). Fix: pass --limit=N to bd ready where N is large enough to fit any realistic anvil's ready set. Concrete change: at internal/poller/poller.go:176, add ',"--limit=100"' to the args slice. Munin currently has 36 ready beads; 100 is generous headroom. Optionally make it configurable as settings.bd_ready_limit (default 100) for users with very large backlogs. Verification: on munin, after fix the hearth queue should show all 36 ready beads (currently shows 10) and a labeled P3 bead at position 30 should be picked up by the poller and dispatched.

---
Bead: Forge-4kx4 | Branch: forge/Forge-4kx4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)