### PR TITLE
Worktree Manager.Remove also needs unlinkReparsePoints before git/os removal (Forge-9145)

### DIFF
--- a/changelog.d/Forge-9145.md
+++ b/changelog.d/Forge-9145.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Worktree Remove unlinks junctions before removal** - Manager.Remove now calls unlinkReparsePoints before git worktree remove, preventing node_modules junction targets from being destroyed during worker cleanup. (Forge-9145)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Robin831/Forge/internal/state"
 	"github.com/Robin831/Forge/internal/vcs"
 	"github.com/Robin831/Forge/internal/warden"
+	"github.com/Robin831/Forge/internal/worktree"
 )
 
 // Event types emitted by the Bellows monitor.
@@ -663,6 +664,8 @@ func (m *Monitor) learnRulesFromPR(ctx context.Context, anvilName, anvilPath, be
 
 	defer func() {
 		// Clean up worktree and local branch (best effort).
+		// Unlink junctions/symlinks first so removal doesn't destroy target content.
+		worktree.UnlinkReparsePoints(wtPath)
 		_ = bellowsGit(ctx, anvilPath, "worktree", "remove", "--force", wtPath)
 		_ = bellowsGit(ctx, anvilPath, "worktree", "prune")
 		_ = bellowsGit(ctx, anvilPath, "branch", "-D", branchName)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -334,6 +334,11 @@ func branchExists(ctx context.Context, repoPath, branch string) bool {
 
 // Remove tears down a worktree and cleans up its branch.
 func (m *Manager) Remove(ctx context.Context, anvilPath string, wt *Worktree) error {
+	// Unlink junctions/symlinks (e.g. node_modules) before removal so that
+	// git worktree remove and os.RemoveAll don't walk into and destroy the
+	// target content in the main checkout.
+	unlinkReparsePoints(wt.Path)
+
 	// Remove the git worktree
 	if err := gitCmd(ctx, anvilPath, "worktree", "remove", "--force", wt.Path); err != nil {
 		// If worktree removal fails, try manual cleanup
@@ -611,6 +616,12 @@ func removeWithRetry(ctx context.Context, path string) error {
 // stale directory cleanup.
 func RemoveWithRetry(ctx context.Context, path string) error {
 	return removeWithRetry(ctx, path)
+}
+
+// UnlinkReparsePoints is the exported form of unlinkReparsePoints for use by
+// other packages that need to safely remove worktree directories.
+func UnlinkReparsePoints(path string) {
+	unlinkReparsePoints(path)
 }
 
 // verifyWorktreeGitFile checks that a worktree directory contains a valid .git

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -562,6 +562,48 @@ func TestCreateWithOptions_SkipNodeModulesJunction_ReuseClean(t *testing.T) {
 	}
 }
 
+// TestRemove_PreservesSymlinkTarget verifies that Manager.Remove unlinks
+// junctions/symlinks before removal so that the target content (e.g. the main
+// checkout's node_modules) is not destroyed.
+func TestRemove_PreservesSymlinkTarget(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	// Create a target directory simulating the main checkout's node_modules.
+	targetDir := filepath.Join(anvilDir, "node_modules")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	markerFile := filepath.Join(targetDir, "eslint")
+	if err := os.WriteFile(markerFile, []byte("package\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := NewManager()
+	ctx := context.Background()
+	wt, err := mgr.CreateWithOptions(ctx, anvilDir, "symlink-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	// Create a symlink inside the worktree pointing to the main node_modules.
+	wtNodeModules := filepath.Join(wt.Path, "node_modules")
+	// Remove any existing link from CreateWithOptions so we can create our own.
+	_ = os.Remove(wtNodeModules)
+	if err := createDirLink(targetDir, wtNodeModules); err != nil {
+		t.Skipf("cannot create directory link: %v", err)
+	}
+
+	// Remove the worktree.
+	if err := mgr.Remove(ctx, anvilDir, wt); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	// The target directory's contents must be preserved.
+	if _, err := os.Stat(markerFile); err != nil {
+		t.Errorf("Remove destroyed symlink target content — main checkout's node_modules/eslint is missing: %v", err)
+	}
+}
+
 // gitOutput runs a git command and returns trimmed stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()


### PR DESCRIPTION
## Changes

- **Worktree Remove unlinks junctions before removal** - Manager.Remove now calls unlinkReparsePoints before git worktree remove, preventing node_modules junction targets from being destroyed during worker cleanup. (Forge-9145)

## Original Issue (bug): Worktree Manager.Remove also needs unlinkReparsePoints before git/os removal

Forge-17gt fixed the stale-dir removal path in removeWithRetry (worktree.go:149) by calling unlinkReparsePoints before os.RemoveAll. But Manager.Remove (worktree.go:336), which runs at end-of-pipeline cleanup after EVERY smith/burnish/quench worker, still calls git worktree remove --force path followed by fallback os.RemoveAll. Neither unlinks junctions first. On Windows, git worktree remove --force walks into the node_modules junction and destroys target content in the main checkout. Real-world impact: munin main client/node_modules gets wiped to 0 packages after every successful worker completion. Symptoms: every subsequent smith iter 1 runs real work but temper hits client-lint failed in 0.5s because eslint missing from node_modules. Smith iter 2 diagnoses env issue, makes no changes, forge misinterprets as warden rejection. Fix: Manager.Remove should call unlinkReparsePoints(wt.Path) BEFORE running git worktree remove --force. Same helper, same logic, applied to the second path. Audit for any other os.RemoveAll or git worktree remove call sites on worker dirs.

---
Bead: Forge-9145 | Branch: forge/Forge-9145
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)