### PR TITLE
Follow-up to 9145: more paths still wiping main node_modules via junction (Forge-0imm)

### DIFF
--- a/changelog.d/Forge-0imm.md
+++ b/changelog.d/Forge-0imm.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Protect node_modules junction from git clean in worktree reuse and deny-pattern reset** - Unlink junctions/symlinks before git checkout --force, git clean -fd, and git reset --hard so git cannot traverse into the main checkout's node_modules and destroy its contents. Also exclude node_modules from git clean and re-link after pipeline deny-pattern resets. (Forge-0imm)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1148,9 +1148,13 @@ func Run(ctx context.Context, p Params) *Outcome {
 					// Clean any untracked files Smith may have added.
 					cleanCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "clean", "-fd", "-e", "node_modules"))
 					_ = cleanCmd.Run()
-					// Re-link node_modules after clean.
-					if linkErr := worktree.LinkNodeModules(p.AnvilConfig.Path, wt.Path); linkErr != nil {
-						log.Printf("[pipeline:%s] Warning: failed to re-link node_modules after deny reset: %v", workerID, linkErr)
+					// Re-link node_modules after clean, but only when not in
+					// SkipNodeModulesJunction mode (deps-update beads must not
+					// have junctions re-created into the main checkout).
+					if !hasDepsUpdateLabel(p.Bead.Labels) {
+						if linkErr := worktree.LinkNodeModules(p.AnvilConfig.Path, wt.Path); linkErr != nil {
+							log.Printf("[pipeline:%s] Warning: failed to re-link node_modules after deny reset: %v", workerID, linkErr)
+						}
 					}
 					// Rewind the remote branch so the denied commits are not
 					// left on origin (where a non-fast-forward on retry would
@@ -1195,9 +1199,13 @@ func Run(ctx context.Context, p Params) *Outcome {
 					// Clean any untracked files Smith may have added.
 					cleanCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "clean", "-fd", "-e", "node_modules"))
 					_ = cleanCmd.Run()
-					// Re-link node_modules after clean.
-					if linkErr := worktree.LinkNodeModules(p.AnvilConfig.Path, wt.Path); linkErr != nil {
-						log.Printf("[pipeline:%s] Warning: failed to re-link node_modules after deny reset: %v", workerID, linkErr)
+					// Re-link node_modules after clean, but only when not in
+					// SkipNodeModulesJunction mode (deps-update beads must not
+					// have junctions re-created into the main checkout).
+					if !hasDepsUpdateLabel(p.Bead.Labels) {
+						if linkErr := worktree.LinkNodeModules(p.AnvilConfig.Path, wt.Path); linkErr != nil {
+							log.Printf("[pipeline:%s] Warning: failed to re-link node_modules after deny reset: %v", workerID, linkErr)
+						}
 					}
 					// Rewind the remote branch so the denied commits are not
 					// left on origin (where a non-fast-forward on retry would

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1137,14 +1137,21 @@ func Run(ctx context.Context, p Params) *Outcome {
 				_ = p.DB.LogEvent(state.EventSmithFailed, summary, p.Bead.ID, p.AnvilName)
 
 				if iteration < maxIter {
+					// Unlink junctions/symlinks before reset+clean to prevent
+					// git from following them into the main checkout.
+					worktree.UnlinkReparsePoints(wt.Path)
 					// Reset to pre-Smith state and retry with feedback.
 					resetCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "reset", "--hard", preSmithSHA))
 					if resetErr := resetCmd.Run(); resetErr != nil {
 						log.Printf("[pipeline:%s] Failed to reset after deny validation error: %v", workerID, resetErr)
 					}
 					// Clean any untracked files Smith may have added.
-					cleanCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "clean", "-fd"))
+					cleanCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "clean", "-fd", "-e", "node_modules"))
 					_ = cleanCmd.Run()
+					// Re-link node_modules after clean.
+					if linkErr := worktree.LinkNodeModules(p.AnvilConfig.Path, wt.Path); linkErr != nil {
+						log.Printf("[pipeline:%s] Warning: failed to re-link node_modules after deny reset: %v", workerID, linkErr)
+					}
 					// Rewind the remote branch so the denied commits are not
 					// left on origin (where a non-fast-forward on retry would
 					// otherwise fail or leave stale state).
@@ -1177,14 +1184,21 @@ func Run(ctx context.Context, p Params) *Outcome {
 				_ = p.DB.LogEvent(state.EventSmithFailed, summary, p.Bead.ID, p.AnvilName)
 
 				if iteration < maxIter {
+					// Unlink junctions/symlinks before reset+clean to prevent
+					// git from following them into the main checkout.
+					worktree.UnlinkReparsePoints(wt.Path)
 					// Reset to pre-Smith state and retry with feedback.
 					resetCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "reset", "--hard", preSmithSHA))
 					if resetErr := resetCmd.Run(); resetErr != nil {
 						log.Printf("[pipeline:%s] Failed to reset after deny violation: %v", workerID, resetErr)
 					}
 					// Clean any untracked files Smith may have added.
-					cleanCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "clean", "-fd"))
+					cleanCmd := executil.HideWindow(exec.Command("git", "-C", wt.Path, "clean", "-fd", "-e", "node_modules"))
 					_ = cleanCmd.Run()
+					// Re-link node_modules after clean.
+					if linkErr := worktree.LinkNodeModules(p.AnvilConfig.Path, wt.Path); linkErr != nil {
+						log.Printf("[pipeline:%s] Warning: failed to re-link node_modules after deny reset: %v", workerID, linkErr)
+					}
 					// Rewind the remote branch so the denied commits are not
 					// left on origin (where a non-fast-forward on retry would
 					// otherwise fail or leave stale state).

--- a/internal/worktree/nodemodules.go
+++ b/internal/worktree/nodemodules.go
@@ -52,6 +52,12 @@ func linkNodeModules(anvilPath, worktreePath string) error {
 	return nil
 }
 
+// LinkNodeModules is the exported form of linkNodeModules for use by packages
+// that need to re-establish node_modules links after git operations.
+func LinkNodeModules(anvilPath, worktreePath string) error {
+	return linkNodeModules(anvilPath, worktreePath)
+}
+
 // createDirLink creates a directory symlink (Unix) or junction (Windows)
 // pointing from dst to src.
 func createDirLink(src, dst string) error {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -121,6 +121,12 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 	// leftover directory from a failed run), remove it so we can create fresh.
 	if _, err := os.Stat(worktreePath); err == nil {
 		if isValidWorktree(ctx, worktreePath) {
+			// Unlink junctions/symlinks (e.g. node_modules) BEFORE any git
+			// operations that might follow them into the main checkout and
+			// destroy content there. On Windows, git clean -fd traverses
+			// junctions as regular directories and deletes the target's files.
+			unlinkReparsePoints(worktreePath)
+
 			if opts.ResetBranch {
 				// Hard-reset the branch back to the base ref, discarding all
 				// previous commits. This prevents inheriting junk from a
@@ -141,8 +147,8 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 				}
 			}
 			_ = git(worktreePath, "checkout", "--force", "HEAD")
-			_ = git(worktreePath, "clean", "-fd")
-			// Re-link node_modules — git clean -fd removes untracked symlinks.
+			_ = git(worktreePath, "clean", "-fd", "-e", "node_modules")
+			// Re-link node_modules for the worktree.
 			if !opts.LocalHead && !opts.SkipNodeModulesJunction {
 				if err := linkNodeModules(anvilPath, worktreePath); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to link node_modules: %v\n", err)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -549,7 +549,7 @@ func TestCreateWithOptions_SkipNodeModulesJunction_ReuseClean(t *testing.T) {
 	}
 
 	// Second call with SkipNodeModulesJunction=true on the reuse path.
-	// git clean -fd removes the symlink; it must not be re-linked.
+	// unlinkReparsePoints removes the symlink; it must not be re-linked.
 	wt2, err := mgr.CreateWithOptions(ctx, anvilDir, "skip-nm-reuse", CreateOptions{
 		SkipNodeModulesJunction: true,
 	})


### PR DESCRIPTION
## Changes

- **Protect node_modules junction from git clean in worktree reuse and deny-pattern reset** - Unlink junctions/symlinks before git checkout --force, git clean -fd, and git reset --hard so git cannot traverse into the main checkout's node_modules and destroy its contents. Also exclude node_modules from git clean and re-link after pipeline deny-pattern resets. (Forge-0imm)

## Original Issue (bug): Follow-up to 9145: more paths still wiping main node_modules via junction

After Forge-9145 (0504dfc) shipped with unlinkReparsePoints in Manager.Remove AND the bellows warden-learn cleanup path, munin main client/node_modules STILL gets wiped during normal operation. Confirmed with dre01 dispatch at 16:06:45 where main had been freshly populated (563 packages incl eslint) — by 16:14:41 when temper ran, eslint was gone. Smith iter 1 log shows Smith only ran cd and grep, no npm/rm. So the wipe happens in forge internals, not Smith. Suspects to investigate: (1) git clean -fd in Manager.Create reuse path (worktree.go:139) — Windows git handling of junctions is historically quirky; may follow into node_modules despite gitignore. (2) git worktree add -f at worktree.go:178/184 — with --force flag, may delete existing content. (3) isValidWorktree path that reuses worktree: after linkNodeModules, subsequent runs call git clean which might touch the junction. (4) A race between concurrent workers (max_smiths=3 now) sharing the same main node_modules target. (5) git worktree prune at worktree.go:347 — does prune walk orphaned worktrees and delete through junctions? Debug approach: bump daemon log level to DEBUG so the slog.Debug calls in unlinkReparsePoints are visible, then capture a full pipeline cycle and see where node_modules loses content. Could also add tracing (mtime check) before/after each git operation in worktree.go to pinpoint which exact subprocess wipes.

---
Bead: Forge-0imm | Branch: forge/Forge-0imm
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)