### PR TITLE
Add diagnostic logging to worktree cleanup paths (Forge-bk0q)

### DIFF
--- a/changelog.d/Forge-bk0q.md
+++ b/changelog.d/Forge-bk0q.md
@@ -1,0 +1,2 @@
+category: Added
+- **Worktree cleanup diagnostic logging** - Added probeNodeModules instrumentation around all git subprocess and os.RemoveAll calls in worktree cleanup paths, and bumped junction unlink log level from Debug to Info, to diagnose node_modules wipe issues. (Forge-bk0q)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -666,10 +666,18 @@ func (m *Monitor) learnRulesFromPR(ctx context.Context, anvilName, anvilPath, be
 		// Clean up worktree and local branch (best effort).
 		// Unlink junctions/symlinks first so removal doesn't destroy target content.
 		worktree.UnlinkReparsePoints(wtPath)
+		worktree.ProbeNodeModules("bellows-before-worktree-remove", anvilPath)
 		_ = bellowsGit(ctx, anvilPath, "worktree", "remove", "--force", wtPath)
+		worktree.ProbeNodeModules("bellows-after-worktree-remove", anvilPath)
+		worktree.ProbeNodeModules("bellows-before-worktree-prune", anvilPath)
 		_ = bellowsGit(ctx, anvilPath, "worktree", "prune")
+		worktree.ProbeNodeModules("bellows-after-worktree-prune", anvilPath)
+		worktree.ProbeNodeModules("bellows-before-branch-delete", anvilPath)
 		_ = bellowsGit(ctx, anvilPath, "branch", "-D", branchName)
+		worktree.ProbeNodeModules("bellows-after-branch-delete", anvilPath)
+		worktree.ProbeNodeModules("bellows-before-removeall", anvilPath)
 		_ = os.RemoveAll(wtPath)
+		worktree.ProbeNodeModules("bellows-after-removeall", anvilPath)
 	}()
 
 	// Fetch and resolve base ref.

--- a/internal/worktree/probe.go
+++ b/internal/worktree/probe.go
@@ -1,0 +1,39 @@
+package worktree
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// ProbeNodeModules logs the mtime and entry count of node_modules in
+// the given anvil directory. This is purely diagnostic and never fails.
+func ProbeNodeModules(label, anvilPath string) {
+	nmPath := filepath.Join(anvilPath, "node_modules")
+	info, err := os.Stat(nmPath)
+	if err != nil {
+		slog.Info("probeNodeModules", "label", label, "path", nmPath, "status", "not_found")
+		return
+	}
+	entries, readErr := os.ReadDir(nmPath)
+	count := -1
+	if readErr == nil {
+		count = len(entries)
+	}
+	slog.Info("probeNodeModules",
+		"label", label,
+		"path", nmPath,
+		"mtime", info.ModTime().UTC(),
+		"entryCount", count,
+	)
+}
+
+// inferAnvilPath attempts to derive the anvil root from a worktree path
+// by looking for a parent ".workers" directory component.
+func inferAnvilPath(wtPath string) string {
+	dir := filepath.Dir(wtPath)
+	if filepath.Base(dir) == ".workers" {
+		return filepath.Dir(dir)
+	}
+	return ""
+}

--- a/internal/worktree/probe.go
+++ b/internal/worktree/probe.go
@@ -9,10 +9,18 @@ import (
 // ProbeNodeModules logs the mtime and entry count of node_modules in
 // the given anvil directory. This is purely diagnostic and never fails.
 func ProbeNodeModules(label, anvilPath string) {
+	if anvilPath == "" {
+		slog.Info("probeNodeModules", "label", label, "status", "skipped_empty_anvil_path")
+		return
+	}
 	nmPath := filepath.Join(anvilPath, "node_modules")
 	info, err := os.Stat(nmPath)
 	if err != nil {
-		slog.Info("probeNodeModules", "label", label, "path", nmPath, "status", "not_found")
+		if os.IsNotExist(err) {
+			slog.Info("probeNodeModules", "label", label, "path", nmPath, "status", "not_found")
+		} else {
+			slog.Info("probeNodeModules", "label", label, "path", nmPath, "status", "stat_error", "error", err)
+		}
 		return
 	}
 	entries, readErr := os.ReadDir(nmPath)
@@ -20,12 +28,16 @@ func ProbeNodeModules(label, anvilPath string) {
 	if readErr == nil {
 		count = len(entries)
 	}
-	slog.Info("probeNodeModules",
+	args := []any{
 		"label", label,
 		"path", nmPath,
 		"mtime", info.ModTime().UTC(),
 		"entryCount", count,
-	)
+	}
+	if readErr != nil {
+		args = append(args, "read_error", readErr)
+	}
+	slog.Info("probeNodeModules", args...)
 }
 
 // inferAnvilPath attempts to derive the anvil root from a worktree path

--- a/internal/worktree/reparse_notwindows.go
+++ b/internal/worktree/reparse_notwindows.go
@@ -25,7 +25,7 @@ func unlinkReparsePoints(root string) error {
 			return nil
 		}
 
-		slog.Debug("unlinking symlink before worktree removal", "path", path)
+		slog.Info("unlinking symlink before worktree removal", "path", path)
 		if rmErr := os.Remove(path); rmErr != nil {
 			slog.Warn("failed to unlink symlink", "path", path, "error", rmErr)
 			return nil

--- a/internal/worktree/reparse_windows.go
+++ b/internal/worktree/reparse_windows.go
@@ -34,7 +34,7 @@ func unlinkReparsePoints(root string) error {
 			return nil
 		}
 
-		slog.Debug("unlinking reparse point before worktree removal", "path", path)
+		slog.Info("unlinking reparse point before worktree removal", "path", path)
 		if rmErr := os.Remove(path); rmErr != nil {
 			slog.Warn("failed to unlink reparse point", "path", path, "error", rmErr)
 			return nil // best-effort

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -346,16 +346,26 @@ func (m *Manager) Remove(ctx context.Context, anvilPath string, wt *Worktree) er
 	unlinkReparsePoints(wt.Path)
 
 	// Remove the git worktree
+	ProbeNodeModules("before-worktree-remove", anvilPath)
 	if err := gitCmd(ctx, anvilPath, "worktree", "remove", "--force", wt.Path); err != nil {
+		ProbeNodeModules("after-worktree-remove-failed", anvilPath)
 		// If worktree removal fails, try manual cleanup
+		ProbeNodeModules("before-removeall-fallback", anvilPath)
 		_ = os.RemoveAll(wt.Path)
+		ProbeNodeModules("after-removeall-fallback", anvilPath)
+	} else {
+		ProbeNodeModules("after-worktree-remove", anvilPath)
 	}
 
 	// Prune stale worktree references
+	ProbeNodeModules("before-worktree-prune", anvilPath)
 	_ = gitCmd(ctx, anvilPath, "worktree", "prune")
+	ProbeNodeModules("after-worktree-prune", anvilPath)
 
 	// Delete the local branch (best effort — might have been pushed)
+	ProbeNodeModules("before-branch-delete", anvilPath)
 	_ = gitCmd(ctx, anvilPath, "branch", "-D", wt.Branch)
+	ProbeNodeModules("after-branch-delete", anvilPath)
 
 	// NOTE: Do NOT delete the remote branch here. Worktree cleanup runs after
 	// pipeline completion, and the remote branch is still needed by the PR that
@@ -584,6 +594,7 @@ func removeWithRetry(ctx context.Context, path string) error {
 	}
 	unlinkReparsePoints(path)
 
+	anvilPath := inferAnvilPath(path)
 	var lastErr error
 	for i, delay := range delays {
 		if err := ctx.Err(); err != nil {
@@ -608,7 +619,13 @@ func removeWithRetry(ctx context.Context, path string) error {
 				return fmt.Errorf("remove worktree %s canceled: %w", path, ctx.Err())
 			}
 		}
+		if anvilPath != "" {
+			ProbeNodeModules(fmt.Sprintf("before-removeall-retry-%d", i), anvilPath)
+		}
 		lastErr = os.RemoveAll(path)
+		if anvilPath != "" {
+			ProbeNodeModules(fmt.Sprintf("after-removeall-retry-%d", i), anvilPath)
+		}
 		if lastErr == nil {
 			return nil
 		}


### PR DESCRIPTION
## Changes

- **Worktree cleanup diagnostic logging** - Added probeNodeModules instrumentation around all git subprocess and os.RemoveAll calls in worktree cleanup paths, and bumped junction unlink log level from Debug to Info, to diagnose node_modules wipe issues. (Forge-bk0q)

## Original Issue (task): Add diagnostic logging to worktree cleanup paths

Modify internal/worktree/worktree.go and any pipeline cleanup code to add instrumentation. Specifically: (1) Bump all existing slog.Debug calls around unlinkReparsePoints to slog.Info so junction unlink success/failure is visible in daemon.log. (2) Add a diagnostic probe function that logs main node_modules mtime and file count (e.g. `func probeNodeModules(label string)` using os.ReadDir and os.Stat). (3) Call this probe before and after every git subprocess invocation (git worktree remove, git worktree prune, git branch -D) and before and after every os.RemoveAll call on worktree paths in Manager.Remove and pipeline cleanup paths. This sub-task produces no behavioral change — only logging. It must be completed first so the next sub-task can use the logs to identify the culprit.

---
Bead: Forge-bk0q | Branch: forge/Forge-bk0q
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)