### PR TITLE
resetBead bd update timeout too short, kills the process and reports opaque 'exit status 1' (Forge-4omg)

### DIFF
--- a/changelog.d/Forge-4omg.md
+++ b/changelog.d/Forge-4omg.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **resetBead timeout too short for slow Dolt connections** - Bumped resetBead timeout from 10s to 5min (matching other bd write sites), surface "context deadline exceeded" in error messages, and skip incrementing the recovery failure counter on transient timeouts so they don't trip the circuit breaker. (Forge-4omg)

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -198,16 +199,18 @@ func (m *Manager) CleanupOrphans() (cleaned int) {
 				} else {
 					if err := m.resetBead(w.BeadID, anvilPath); err != nil {
 						m.logger.Warn("failed to reset bead status", "bead", w.BeadID, "error", err)
-						failures, tripped, dbErr := m.db.IncrementRecoveryFailures(w.BeadID, w.Anvil, err.Error())
-						if dbErr != nil {
-							m.logger.Warn("failed to track recovery failure", "bead", w.BeadID, "error", dbErr)
-						} else if tripped {
-							m.logger.Warn("orphan worker recovery flagged as needs-human after repeated failures", "bead", w.BeadID, "anvil", w.Anvil, "failures", failures)
-							m.db.LogEvent(state.EventRecoveryCircuitBreak,
-								fmt.Sprintf("Orphaned worker bead %s flagged needs-human after %d recovery failures: %s", w.BeadID, failures, err.Error()),
-								w.BeadID, w.Anvil)
-							if m.OnNeedsHuman != nil {
-								m.OnNeedsHuman(w.BeadID, w.Anvil, w.Title, failures, err.Error())
+						if !errors.Is(err, context.DeadlineExceeded) {
+							failures, tripped, dbErr := m.db.IncrementRecoveryFailures(w.BeadID, w.Anvil, err.Error())
+							if dbErr != nil {
+								m.logger.Warn("failed to track recovery failure", "bead", w.BeadID, "error", dbErr)
+							} else if tripped {
+								m.logger.Warn("orphan worker recovery flagged as needs-human after repeated failures", "bead", w.BeadID, "anvil", w.Anvil, "failures", failures)
+								m.db.LogEvent(state.EventRecoveryCircuitBreak,
+									fmt.Sprintf("Orphaned worker bead %s flagged needs-human after %d recovery failures: %s", w.BeadID, failures, err.Error()),
+									w.BeadID, w.Anvil)
+								if m.OnNeedsHuman != nil {
+									m.OnNeedsHuman(w.BeadID, w.Anvil, w.Title, failures, err.Error())
+								}
 							}
 						}
 					} else {
@@ -402,16 +405,18 @@ func (m *Manager) RecoverOrphanedBeads() (recovered int) {
 			// Fall through to auto-recovery (headless/CI mode or no Hearth client).
 			if err := m.resetBead(beadID, anvilPath); err != nil {
 				m.logger.Warn("failed to reset orphaned bead", "bead", beadID, "error", err)
-				failures, tripped, dbErr := m.db.IncrementRecoveryFailures(beadID, anvilName, err.Error())
-				if dbErr != nil {
-					m.logger.Warn("failed to track recovery failure", "bead", beadID, "error", dbErr)
-				} else if tripped {
-					m.logger.Warn("orphan recovery flagged as needs-human after repeated failures", "bead", beadID, "anvil", anvilName, "failures", failures)
-					m.db.LogEvent(state.EventRecoveryCircuitBreak,
-						fmt.Sprintf("Orphaned bead %s flagged needs-human after %d recovery failures: %s", beadID, failures, err.Error()),
-						beadID, anvilName)
-					if m.OnNeedsHuman != nil {
-						m.OnNeedsHuman(beadID, anvilName, bead.Title, failures, err.Error())
+				if !errors.Is(err, context.DeadlineExceeded) {
+					failures, tripped, dbErr := m.db.IncrementRecoveryFailures(beadID, anvilName, err.Error())
+					if dbErr != nil {
+						m.logger.Warn("failed to track recovery failure", "bead", beadID, "error", dbErr)
+					} else if tripped {
+						m.logger.Warn("orphan recovery flagged as needs-human after repeated failures", "bead", beadID, "anvil", anvilName, "failures", failures)
+						m.db.LogEvent(state.EventRecoveryCircuitBreak,
+							fmt.Sprintf("Orphaned bead %s flagged needs-human after %d recovery failures: %s", beadID, failures, err.Error()),
+							beadID, anvilName)
+						if m.OnNeedsHuman != nil {
+							m.OnNeedsHuman(beadID, anvilName, bead.Title, failures, err.Error())
+						}
 					}
 				}
 				continue
@@ -520,7 +525,7 @@ func (m *Manager) CleanupWorktrees() {
 // Clearing the assignee is required so the poller can re-dispatch the bead —
 // the poller filters out any bead with a non-empty assignee.
 func (m *Manager) resetBead(beadID, anvilPath string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 	defer cancel()
 
 	// Clear labels so the poller does not auto-dispatch the recovered bead
@@ -533,6 +538,10 @@ func (m *Manager) resetBead(beadID, anvilPath string) error {
 	cmd.Stderr = &stderrBuf
 	out, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("bd update %s timed out: %w", beadID, context.DeadlineExceeded)
+		}
+
 		stdoutText := strings.TrimSpace(string(out))
 		stderrText := strings.TrimSpace(stderrBuf.String())
 


### PR DESCRIPTION
## Changes

- **resetBead timeout too short for slow Dolt connections** - Bumped resetBead timeout from 10s to 5min (matching other bd write sites), surface "context deadline exceeded" in error messages, and skip incrementing the recovery failure counter on transient timeouts so they don't trip the circuit breaker. (Forge-4omg)

## Original Issue (bug): resetBead bd update timeout too short, kills the process and reports opaque 'exit status 1'

During orphan recovery, internal/shutdown/shutdown.go:523 wraps the bd update call in a 10s context timeout. When Dolt is briefly unresponsive (we observed recurring '[mysql] read tcp 127.0.0.1->127.0.0.1:3306: i/o timeout' errors against anvil munin) the bd subprocess gets killed by the deadline and produces no output. The error path then reports just 'exit status 1' with empty stdout/stderr, which is exactly the opaque failure mode that Forge-jul4 was supposed to prevent (Forge-jul4 only handled stderr capture, not killed-by-deadline). With MaxRecoveryFailures=2, two such hangs trip the recovery circuit breaker and flag the bead needs-human. Concrete incident: Fhi.Metadata-ihy9g on 2026-04-17 -- both recovery attempts took ~10.0s exactly and were misreported as bd failures. Fix: (a) bump timeout to executil.DefaultBdTimeout (5 min), matching every other bd write site in the codebase; (b) check ctx.Err() and surface 'context deadline exceeded' in the wrapped error; optionally (c) skip incrementing the recovery failure counter when the underlying error is context.DeadlineExceeded so transient Dolt slowdowns don't burn through the circuit breaker.

---
Bead: Forge-4omg | Branch: forge/Forge-4omg
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)