### PR TITLE
Pipeline doesn't release bd claim on temper exhaustion, defers to orphan recovery (Forge-s9pe)

### DIFF
--- a/changelog.d/Forge-s9pe.md
+++ b/changelog.d/Forge-s9pe.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Immediate bead release on dispatch failure** - Pipeline dispatch failures (temper exhaustion, warden rejection, etc.) now release the bead claim immediately via bd update instead of deferring to orphan recovery, reducing latency before the bead becomes available again. (Forge-s9pe)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4395,9 +4395,10 @@ func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string) {
 }
 
 // releaseBeadClaim releases a claimed bead back to open status and strips the
-// forgeReady label so it is not immediately re-dispatched. The anvil path is
-// resolved from the current config. If the release fails (bd error, missing
-// anvil config), a warning is logged — orphan recovery acts as the fallback.
+// anvil's auto_dispatch_tag so it is not immediately re-dispatched. The anvil
+// path is resolved from the current config. If the release fails (bd error,
+// missing anvil config), a warning is logged — orphan recovery acts as the
+// fallback.
 func (d *Daemon) releaseBeadClaim(beadID, anvil string) {
 	anvilCfg, ok := d.cfg.Load().Anvils[anvil]
 	if !ok || anvilCfg.Path == "" {
@@ -4408,9 +4409,14 @@ func (d *Daemon) releaseBeadClaim(beadID, anvil string) {
 	ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
 	defer cancel()
 
+	args := []string{"update", beadID, "--status=open", "--assignee="}
+	if anvilCfg.AutoDispatchTag != "" {
+		args = append(args, "--remove-label="+anvilCfg.AutoDispatchTag)
+	}
+	args = append(args, "--json")
+
 	var stderrBuf bytes.Buffer
-	cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "update", beadID,
-		"--status=open", "--assignee=", "--remove-label=forgeReady", "--json"))
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", args...))
 	cmd.Dir = anvilCfg.Path
 	cmd.Stderr = &stderrBuf
 	out, err := cmd.Output()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4356,6 +4356,11 @@ func (d *Daemon) isBeadClarificationNeeded(beadID, anvil string) (bool, error) {
 // recordDispatchFailure increments the dispatch failure counter for a bead and
 // logs a circuit-break event if the threshold is reached. When the circuit
 // breaker trips, a bead_failed notification is sent to configured webhooks.
+//
+// After recording the failure, the bead claim is released immediately via
+// bd update so the bead becomes available again without waiting for orphan
+// recovery. If the release fails, a warning is logged and orphan recovery
+// serves as the fallback.
 func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string) {
 	count, broken, err := d.db.IncrementDispatchFailures(beadID, anvil, MaxDispatchFailures, reason)
 	if err != nil {
@@ -4365,6 +4370,9 @@ func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string) {
 	_ = d.db.LogEvent(state.EventDispatchFailed,
 		fmt.Sprintf("Dispatch attempt %d failed for %s: %s", count, beadID, reason),
 		beadID, anvil)
+
+	d.releaseBeadClaim(beadID, anvil)
+
 	if broken {
 		msg := fmt.Sprintf("Bead %s circuit-broken after %d consecutive dispatch failures: %s", beadID, count, reason)
 		d.logger.Warn(msg, "bead", beadID, "anvil", anvil)
@@ -4383,6 +4391,35 @@ func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string) {
 				disp.Dispatch(notifCtx, notify.EventBeadFailed, beadID, anvil, failMsg)
 			}
 		}(beadID, anvil, reason, count)
+	}
+}
+
+// releaseBeadClaim releases a claimed bead back to open status and strips the
+// forgeReady label so it is not immediately re-dispatched. The anvil path is
+// resolved from the current config. If the release fails (bd error, missing
+// anvil config), a warning is logged — orphan recovery acts as the fallback.
+func (d *Daemon) releaseBeadClaim(beadID, anvil string) {
+	anvilCfg, ok := d.cfg.Load().Anvils[anvil]
+	if !ok || anvilCfg.Path == "" {
+		d.logger.Warn("cannot release bead claim: anvil not found in config", "bead", beadID, "anvil", anvil)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
+	defer cancel()
+
+	var stderrBuf bytes.Buffer
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", "update", beadID,
+		"--status=open", "--assignee=", "--remove-label=forgeReady", "--json"))
+	cmd.Dir = anvilCfg.Path
+	cmd.Stderr = &stderrBuf
+	out, err := cmd.Output()
+	if err != nil {
+		d.logger.Warn("failed to release bead claim, orphan recovery will handle it",
+			"bead", beadID, "anvil", anvil,
+			"error", err,
+			"stdout", strings.TrimSpace(string(out)),
+			"stderr", strings.TrimSpace(stderrBuf.String()))
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1860,7 +1860,7 @@ func (d *Daemon) pollAndDispatch(ctx context.Context) {
 		// Claim the bead atomically before dispatching
 		if err := d.claimBead(ctx, bead.ID, anvilCfg.Path); err != nil {
 			d.logger.Warn("failed to claim bead", "bead", bead.ID, "error", err)
-			d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("claim failed: %v", err))
+			d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("claim failed: %v", err), false)
 			d.activeBeads.Delete(bead.ID)
 			continue
 		}
@@ -1908,7 +1908,7 @@ func (d *Daemon) dispatchBead(ctx context.Context, bead poller.Bead, anvilCfg co
 		d.logger.Error("anvil branch check failed at dispatch time, aborting bead",
 			"bead", bead.ID, "anvil", bead.Anvil, "error", err)
 		d.recordDispatchFailure(bead.ID, bead.Anvil,
-			fmt.Sprintf("anvil branch check failed: %v", err))
+			fmt.Sprintf("anvil branch check failed: %v", err), true)
 		return
 	}
 
@@ -1929,7 +1929,7 @@ func (d *Daemon) dispatchBead(ctx context.Context, bead poller.Bead, anvilCfg co
 			d.logger.Info("creating epic branch", "bead", bead.ID, "branch", epicBranch)
 			if err := d.worktreeMgr.CreateEpicBranch(ctx, anvilCfg.Path, epicBranch); err != nil {
 				d.logger.Error("failed to create epic branch", "bead", bead.ID, "branch", epicBranch, "error", err)
-				d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("epic branch creation failed: %v", err))
+				d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("epic branch creation failed: %v", err), true)
 				return
 			}
 			_ = d.db.LogEvent(state.EventBeadClaimed,
@@ -2093,10 +2093,10 @@ func (d *Daemon) dispatchBead(ctx context.Context, bead poller.Bead, anvilCfg co
 			d.logger.Error("crucible failed", "bead", bead.ID, "error", result.Error)
 			if result.PausedChildID != "" {
 				d.recordDispatchFailure(bead.ID, bead.Anvil,
-					fmt.Sprintf("crucible paused: child %s failed", result.PausedChildID))
+					fmt.Sprintf("crucible paused: child %s failed", result.PausedChildID), true)
 			} else {
 				d.recordDispatchFailure(bead.ID, bead.Anvil,
-					fmt.Sprintf("crucible error: %v", result.Error))
+					fmt.Sprintf("crucible error: %v", result.Error), true)
 			}
 			return
 		}
@@ -2219,7 +2219,7 @@ normalPipeline:
 			if err := d.db.MarkNeedsHuman(bead.ID, bead.Anvil, reason); err != nil {
 				d.logger.Error("failed to mark bead as needs_human", "bead", bead.ID, "error", err)
 			}
-			d.recordDispatchFailure(bead.ID, bead.Anvil, reason)
+			d.recordDispatchFailure(bead.ID, bead.Anvil, reason, true)
 			holdOff := d.cfg.Load().Settings.PollInterval
 			if holdOff <= 0 {
 				holdOff = DefaultPollInterval
@@ -2232,7 +2232,7 @@ normalPipeline:
 			return
 		}
 		d.logger.Error("pipeline error", "bead", bead.ID, "error", outcome.Error)
-		d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("pipeline error: %v", outcome.Error))
+		d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("pipeline error: %v", outcome.Error), true)
 		return
 	}
 
@@ -2281,7 +2281,7 @@ normalPipeline:
 			if err := d.db.MarkNeedsHuman(bead.ID, bead.Anvil, reason); err != nil {
 				d.logger.Error("failed to mark bead as needs_human", "bead", bead.ID, "error", err)
 			}
-			d.recordDispatchFailure(bead.ID, bead.Anvil, reason)
+			d.recordDispatchFailure(bead.ID, bead.Anvil, reason, true)
 			// Hold the activeBeads slot for a full poll interval so the bead is not
 			// immediately re-dispatched before a human can investigate.
 			holdOff := d.cfg.Load().Settings.PollInterval
@@ -2296,7 +2296,7 @@ normalPipeline:
 			}
 		} else {
 			d.logger.Warn("pipeline did not succeed", "bead", bead.ID, "verdict", outcome.Verdict)
-			d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("pipeline failed: %s", outcome.Verdict))
+			d.recordDispatchFailure(bead.ID, bead.Anvil, fmt.Sprintf("pipeline failed: %s", outcome.Verdict), true)
 		}
 		return
 	}
@@ -2558,7 +2558,7 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 		if markErr := d.db.MarkNeedsHuman(bead.ID, bead.Anvil, closeErr); markErr != nil {
 			d.logger.Error("failed to mark bead as needs_human", "bead", bead.ID, "error", markErr)
 		}
-		d.recordDispatchFailure(bead.ID, bead.Anvil, closeErr)
+		d.recordDispatchFailure(bead.ID, bead.Anvil, closeErr, true)
 	} else {
 		_ = d.db.ClearRetry(bead.ID, bead.Anvil)
 		_ = d.db.LogEvent(state.EventNoChangesNeeded,
@@ -4357,11 +4357,14 @@ func (d *Daemon) isBeadClarificationNeeded(beadID, anvil string) (bool, error) {
 // logs a circuit-break event if the threshold is reached. When the circuit
 // breaker trips, a bead_failed notification is sent to configured webhooks.
 //
-// After recording the failure, the bead claim is released immediately via
-// bd update so the bead becomes available again without waiting for orphan
-// recovery. If the release fails, a warning is logged and orphan recovery
-// serves as the fallback.
-func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string) {
+// When releaseClaim is true, the bead claim is released immediately via bd
+// update so the bead becomes available again without waiting for orphan
+// recovery. Pass releaseClaim=false for pre-claim failures (e.g. claimBead
+// error) where Forge does not own the bead in bd — releasing in those cases
+// risks unassigning a bead legitimately held by another instance or a human.
+// If the release fails, a warning is logged and orphan recovery is the
+// fallback.
+func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string, releaseClaim bool) {
 	count, broken, err := d.db.IncrementDispatchFailures(beadID, anvil, MaxDispatchFailures, reason)
 	if err != nil {
 		d.logger.Error("failed to record dispatch failure", "bead", beadID, "error", err)
@@ -4371,7 +4374,9 @@ func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string) {
 		fmt.Sprintf("Dispatch attempt %d failed for %s: %s", count, beadID, reason),
 		beadID, anvil)
 
-	d.releaseBeadClaim(beadID, anvil)
+	if releaseClaim {
+		d.releaseBeadClaim(beadID, anvil)
+	}
 
 	if broken {
 		msg := fmt.Sprintf("Bead %s circuit-broken after %d consecutive dispatch failures: %s", beadID, count, reason)
@@ -4406,7 +4411,11 @@ func (d *Daemon) releaseBeadClaim(beadID, anvil string) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), executil.DefaultBdTimeout)
+	baseCtx := d.runCtx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, executil.DefaultBdTimeout)
 	defer cancel()
 
 	args := []string{"update", beadID, "--status=open", "--assignee="}
@@ -4469,7 +4478,7 @@ func (d *Daemon) applyDecomposedOutcome(bead poller.Bead, anvilCfg config.AnvilC
 								"parent", beadID, "child", sub.ID, "tag", anvilCfg.AutoDispatchTag, "error", err)
 							reason := fmt.Sprintf("failed to propagate auto_dispatch tag %q to child bead %s: %v",
 								anvilCfg.AutoDispatchTag, sub.ID, err)
-							d.recordDispatchFailure(beadID, anvil, reason)
+							d.recordDispatchFailure(beadID, anvil, reason, true)
 						} else {
 							d.logger.Info("copied auto_dispatch tag to child bead",
 								"parent", beadID, "child", sub.ID, "tag", anvilCfg.AutoDispatchTag)
@@ -4495,7 +4504,7 @@ func (d *Daemon) applyDecomposedOutcome(bead poller.Bead, anvilCfg config.AnvilC
 		reason = reason + ": " + sr.Reason
 	}
 	d.logger.Warn("bead decomposition produced no children; recording as dispatch failure", "bead", beadID, "reason", reason)
-	d.recordDispatchFailure(beadID, anvil, reason)
+	d.recordDispatchFailure(beadID, anvil, reason, true)
 }
 
 // fetchExternalRef does a one-shot bd show lookup for the bead's external_ref.
@@ -5183,7 +5192,7 @@ func (d *Daemon) handleWardenRerun(beadID, anvil, branch string, anvilCfg config
 		_ = d.db.LogEvent(state.EventWardenReject, fmt.Sprintf("Warden re-review: %s — %s", result.Verdict, result.Summary), beadID, anvil)
 		_ = d.db.UpdateWorkerStatus(workerID, state.WorkerFailed)
 		// Bead stays in needs attention — record the updated feedback.
-		d.recordDispatchFailure(beadID, anvil, fmt.Sprintf("warden re-review: %s", result.Summary))
+		d.recordDispatchFailure(beadID, anvil, fmt.Sprintf("warden re-review: %s", result.Summary), true)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2948,3 +2948,140 @@ func TestFetchExternalRef(t *testing.T) {
 		assert.Equal(t, "gh-99", got)
 	})
 }
+
+// TestReleaseBeadClaim verifies that releaseBeadClaim invokes bd with the
+// correct arguments (--status=open --assignee= and --remove-label for the
+// auto_dispatch_tag), and that it does NOT invoke bd when the anvil is absent
+// from config (covering the claim-race / pre-claim safety condition).
+func TestReleaseBeadClaim(t *testing.T) {
+	t.Run("calls bd update with correct args and removes auto_dispatch_tag", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "forge-release-bead-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		argsFile := filepath.Join(tmpDir, "bd-args.txt")
+		var bdScript, bdContent string
+		if runtime.GOOS == "windows" {
+			bdScript = filepath.Join(tmpDir, "bd.bat")
+			bdContent = "@echo off\necho %* > \"" + argsFile + "\"\nexit /b 0\n"
+		} else {
+			bdScript = filepath.Join(tmpDir, "bd")
+			bdContent = "#!/bin/sh\necho \"$@\" > '" + argsFile + "'\nexit 0\n"
+		}
+		require.NoError(t, os.WriteFile(bdScript, []byte(bdContent), 0o755))
+
+		oldPath := os.Getenv("PATH")
+		os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+		defer os.Setenv("PATH", oldPath)
+
+		dbPath := filepath.Join(tmpDir, "state.db")
+		db, err := state.Open(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		d := &Daemon{
+			db:     db,
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			runCtx: context.Background(),
+		}
+		d.cfg.Store(&config.Config{
+			Anvils: map[string]config.AnvilConfig{
+				"test-anvil": {Path: tmpDir, AutoDispatchTag: "forgeReady"},
+			},
+		})
+
+		d.releaseBeadClaim("TEST-1", "test-anvil")
+
+		require.FileExists(t, argsFile)
+		argsBytes, err := os.ReadFile(argsFile)
+		require.NoError(t, err)
+		args := strings.TrimSpace(string(argsBytes))
+		assert.Contains(t, args, "update")
+		assert.Contains(t, args, "TEST-1")
+		assert.Contains(t, args, "--status=open")
+		assert.Contains(t, args, "--assignee=")
+		assert.Contains(t, args, "--remove-label=forgeReady")
+	})
+
+	t.Run("does not call bd when anvil is missing from config (claim-race safety)", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "forge-release-bead-noanvil-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		calledFile := filepath.Join(tmpDir, "bd-called.txt")
+		var bdScript, bdContent string
+		if runtime.GOOS == "windows" {
+			bdScript = filepath.Join(tmpDir, "bd.bat")
+			bdContent = "@echo off\necho called > \"" + calledFile + "\"\nexit /b 0\n"
+		} else {
+			bdScript = filepath.Join(tmpDir, "bd")
+			bdContent = "#!/bin/sh\ntouch '" + calledFile + "'\nexit 0\n"
+		}
+		require.NoError(t, os.WriteFile(bdScript, []byte(bdContent), 0o755))
+
+		oldPath := os.Getenv("PATH")
+		os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+		defer os.Setenv("PATH", oldPath)
+
+		dbPath := filepath.Join(tmpDir, "state.db")
+		db, err := state.Open(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		d := &Daemon{
+			db:     db,
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			runCtx: context.Background(),
+		}
+		// Anvil "unknown-anvil" is not in config — simulates pre-claim or race condition.
+		d.cfg.Store(&config.Config{
+			Anvils: map[string]config.AnvilConfig{},
+		})
+
+		d.releaseBeadClaim("TEST-2", "unknown-anvil")
+
+		assert.NoFileExists(t, calledFile, "bd must not be called when anvil is absent from config")
+	})
+
+	t.Run("recordDispatchFailure skips bd release when releaseClaim is false", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "forge-release-bead-skip-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		calledFile := filepath.Join(tmpDir, "bd-called.txt")
+		var bdScript, bdContent string
+		if runtime.GOOS == "windows" {
+			bdScript = filepath.Join(tmpDir, "bd.bat")
+			bdContent = "@echo off\necho called > \"" + calledFile + "\"\nexit /b 0\n"
+		} else {
+			bdScript = filepath.Join(tmpDir, "bd")
+			bdContent = "#!/bin/sh\ntouch '" + calledFile + "'\nexit 0\n"
+		}
+		require.NoError(t, os.WriteFile(bdScript, []byte(bdContent), 0o755))
+
+		oldPath := os.Getenv("PATH")
+		os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+		defer os.Setenv("PATH", oldPath)
+
+		dbPath := filepath.Join(tmpDir, "state.db")
+		db, err := state.Open(dbPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		d := &Daemon{
+			db:     db,
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			runCtx: context.Background(),
+		}
+		d.cfg.Store(&config.Config{
+			Anvils: map[string]config.AnvilConfig{
+				"test-anvil": {Path: tmpDir},
+			},
+		})
+
+		// releaseClaim=false simulates a claim failure — bd must not be invoked.
+		d.recordDispatchFailure("TEST-3", "test-anvil", "claim failed: connection refused", false)
+
+		assert.NoFileExists(t, calledFile, "bd must not be called when releaseClaim is false")
+	})
+}


### PR DESCRIPTION
## Changes

- **Immediate bead release on dispatch failure** - Pipeline dispatch failures (temper exhaustion, warden rejection, etc.) now release the bead claim immediately via bd update instead of deferring to orphan recovery, reducing latency before the bead becomes available again. (Forge-s9pe)

## Original Issue (bug): Pipeline doesn't release bd claim on temper exhaustion, defers to orphan recovery

When the pipeline gives up after temper iterations are exhausted (pipeline.go:1309), it calls recordDispatchFailure (daemon.go:2234-2235) which only increments a state.db counter -- it does not call 'bd update --status=open' to release the bead claim. The bead stays in_progress in bd with an assignee but no worker row, which makes it a true orphan from bd's perspective. Orphan recovery then has to clean it up 1-2 minutes later on the next periodic scan. This is wasteful and adds latency before the bead becomes available again, and it depends on orphan recovery's bd-update path working correctly (see Forge-4omg for a recent failure of that path). Suggested fix: the dispatch-failure cleanup path in daemon.go should call bd update directly to release the claim and strip forgeReady label, and only fall back to orphan recovery for true crashes/process kills. Lower priority than Forge-4omg because it is a design wart, not a hard failure.

---
Bead: Forge-s9pe | Branch: forge/Forge-s9pe
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)