### PR TITLE
Two-tier polling: fast labeled path + slow unfiltered path for crucible reconstruction (Forge-fbyh)

### DIFF
--- a/changelog.d/Forge-fbyh.md
+++ b/changelog.d/Forge-fbyh.md
@@ -1,0 +1,2 @@
+category: Added
+- **Two-tier polling for faster bead discovery** - The poller now uses a fast label-filtered path every poll interval and a slow unfiltered path on a separate cadence (configurable via `crucible_poll_interval`, default 3m) to rebuild the Crucible parent-child graph. This reduces no-op poll cycle time by ~3.6x while preserving Crucible candidate detection. (Forge-fbyh)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ settings:
   questgiver_enabled: false
   questgiver_interval: 24h
   crucible_enabled: true
+  crucible_poll_interval: 3m
   auto_merge_crucible_children: true
 
 notifications:
@@ -489,6 +490,7 @@ anvils:
 | `smelter_enabled` | bool | `true` | | Enable/disable the Smelter background process. When `false`, scheduled smelter runs are disabled. |
 | `smelter_interval` | duration | `8h` | `1h` or `0` | How often the Smelter runs its background processing. `0` disables scheduled runs. The Smelter skips the startup run if it already flushed within this interval, so daemon restarts don't produce redundant PRs. For low-volume setups where warden rules accumulate slowly, `48h` or `72h` is a reasonable value. |
 | `crucible_enabled` | bool | `false` | | Enable Crucible auto-orchestration for parent beads with children. When a ready bead blocks other beads, the Crucible creates a feature branch, dispatches children in topological order, merges each child PR, then creates a final PR to main. |
+| `crucible_poll_interval` | duration | `3m` | `30s` or `0` | Interval for the slow unfiltered poll that rebuilds the Crucible parent-child (Blocks) graph. The fast path polls with a label filter every `poll_interval`; the slow path runs every `crucible_poll_interval` to discover parent-child relationships. `0` disables two-tier polling (all polls are unfiltered). |
 | `auto_merge_crucible_children` | bool | `true` | | Auto-merge child PRs targeting a Crucible feature branch after the pipeline succeeds. Set to `false` to require manual merge of child PRs. |
 | `questgiver_enabled` | bool | `false` | | Enable the QuestGiver E2E quest monitor globally. When false, no quest scanning occurs. |
 | `questgiver_interval` | duration | `24h` | `0` | How often the QuestGiver polls anvils for quests. `0` disables. |
@@ -736,6 +738,7 @@ Environment variables with the `FORGE_` prefix override YAML values. Nested keys
 | `FORGE_SETTINGS_SMELTER_INTERVAL` | `settings.smelter_interval` |
 | `FORGE_SETTINGS_GO_RACE_DETECTION` | `settings.go_race_detection` |
 | `FORGE_SETTINGS_CRUCIBLE_ENABLED` | `settings.crucible_enabled` |
+| `FORGE_SETTINGS_CRUCIBLE_POLL_INTERVAL` | `settings.crucible_poll_interval` |
 | `FORGE_SETTINGS_AUTO_MERGE_CRUCIBLE_CHILDREN` | `settings.auto_merge_crucible_children` |
 | `FORGE_SETTINGS_QUESTGIVER_ENABLED` | `settings.questgiver_enabled` |
 | `FORGE_SETTINGS_QUESTGIVER_INTERVAL` | `settings.questgiver_interval` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -410,6 +410,12 @@ type SettingsConfig struct {
 	// BdReadyLimit is the --limit passed to 'bd ready --json'. bd defaults to
 	// 10 which can hide labeled lower-priority beads. Default: 100.
 	BdReadyLimit int `mapstructure:"bd_ready_limit" yaml:"bd_ready_limit,omitempty"`
+	// CruciblePollInterval is the interval for the slow unfiltered poll that
+	// rebuilds the Crucible Blocks graph. The fast path polls with a label
+	// filter every PollInterval; the slow path runs every CruciblePollInterval
+	// to discover parent-child relationships for Crucible detection.
+	// Default: 3m. Set to 0 to disable two-tier polling (all polls unfiltered).
+	CruciblePollInterval time.Duration `mapstructure:"crucible_poll_interval" yaml:"crucible_poll_interval,omitempty"`
 }
 
 // durationString returns the duration string, or omits zero values.
@@ -474,8 +480,9 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		WicketNeedsHumanLabel  string `yaml:"wicket_needs_human_label,omitempty"`
 		WicketBeadCreatedLabel string `yaml:"wicket_bead_created_label,omitempty"`
 		WicketTriggerLabel     string `yaml:"wicket_trigger_label,omitempty"`
-		WicketStaleDays        int    `yaml:"wicket_stale_days,omitempty"`
-		BdReadyLimit           int    `yaml:"bd_ready_limit,omitempty"`
+		WicketStaleDays          int    `yaml:"wicket_stale_days,omitempty"`
+		BdReadyLimit             int    `yaml:"bd_ready_limit,omitempty"`
+		CruciblePollInterval     string `yaml:"crucible_poll_interval,omitempty"`
 	}
 
 	sh := shadow{
@@ -525,6 +532,10 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		WicketTriggerLabel:     s.WicketTriggerLabel,
 		WicketStaleDays:        s.WicketStaleDays,
 		BdReadyLimit:           s.BdReadyLimit,
+	}
+
+	if s.CruciblePollInterval > 0 {
+		sh.CruciblePollInterval = durationString(s.CruciblePollInterval)
 	}
 
 	// Only include non-zero optional durations.
@@ -737,7 +748,8 @@ func Defaults() Config {
 			WicketNeedsHumanLabel:  "forge-needs-human",
 			WicketBeadCreatedLabel: "forge-bead-created",
 			WicketTriggerLabel:     "",
-			BdReadyLimit:          100,
+			BdReadyLimit:           100,
+			CruciblePollInterval:   3 * time.Minute,
 		},
 	}
 }
@@ -779,6 +791,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("settings.wicket_bead_created_label", "forge-bead-created")
 	v.SetDefault("settings.wicket_trigger_label", "")
 	v.SetDefault("settings.bd_ready_limit", 100)
+	v.SetDefault("settings.crucible_poll_interval", "3m")
 
 	// Environment variable support: FORGE_SETTINGS_POLL_INTERVAL etc.
 	// SetEnvKeyReplacer maps dotted config keys (settings.auto_learn_rules) to
@@ -916,6 +929,13 @@ func Load(configFile string) (*Config, error) {
 		}
 		cfg.Settings.WicketInterval = d
 	}
+	if raw := v.GetString("settings.crucible_poll_interval"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid crucible_poll_interval %q: %w", raw, err)
+		}
+		cfg.Settings.CruciblePollInterval = d
+	}
 
 	// Decrypt any enc:-prefixed webhook URLs written by Hytte.
 	decryptWebhookURLs(&cfg)
@@ -1015,6 +1035,12 @@ func (c *Config) Validate() []string {
 	}
 	if c.Settings.AdventurerTimeout < 0 {
 		errs = append(errs, "settings.adventurer_timeout must not be negative")
+	}
+
+	if c.Settings.CruciblePollInterval < 0 {
+		errs = append(errs, "settings.crucible_poll_interval must not be negative (set to 0 to disable two-tier polling)")
+	} else if c.Settings.CruciblePollInterval > 0 && c.Settings.CruciblePollInterval < 30*time.Second {
+		errs = append(errs, "settings.crucible_poll_interval must be >= 30s when enabled (or 0 to disable)")
 	}
 
 	for name, anvil := range c.Anvils {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1571,7 +1571,11 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 	// if hot-reload swaps the pointer concurrently.
 	cfg := d.cfg.Load()
 
-	if fullPoll {
+	// Legacy mode (Crucible polling disabled) must remain unfiltered even when
+	// individual callers request a fast poll.
+	effectiveFullPoll := fullPoll || cfg.Settings.CruciblePollInterval <= 0
+
+	if effectiveFullPoll {
 		d.logger.Info("polling anvils (full)", "count", len(cfg.Anvils))
 	} else {
 		d.logger.Info("polling anvils (fast)", "count", len(cfg.Anvils))
@@ -1628,11 +1632,11 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 	}
 	p := poller.NewStaggered(cfg.Anvils, pollInterval)
 	p.BdReadyLimit = cfg.Settings.BdReadyLimit
-	if !fullPoll {
+	if !effectiveFullPoll {
 		p.UseLabelFilter = true
 	}
 	pollKind := "full"
-	if !fullPoll {
+	if !effectiveFullPoll {
 		pollKind = "fast"
 	}
 	// Log each anvil's poll event as soon as it finishes so Hearth shows
@@ -1647,7 +1651,7 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 	}
 	beads, results := p.Poll(ctx)
 
-	if fullPoll {
+	if effectiveFullPoll {
 		// Slow path: rebuild the cached Blocks graph from the unfiltered results.
 		graph := poller.BuildBlocksGraph(beads)
 		d.cachedBlocksMu.Lock()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -175,6 +175,10 @@ type Daemon struct {
 	cachedBlocks   poller.BlocksGraph
 	cachedBlocksMu sync.RWMutex
 
+	// crucibleTickerResetCh signals the poll loop to reset the crucible
+	// ticker when hot-reload detects a crucible_poll_interval change.
+	crucibleTickerResetCh chan struct{}
+
 	// Per-anvil temper.yaml cache keyed by anvil path.
 	// Avoids repeated filesystem I/O on every dispatch and de-duplicates
 	// log spam when the file is invalid or unreadable.
@@ -300,8 +304,9 @@ func New(cfg *config.Config) (*Daemon, error) {
 		shutdownMgr:   shutdown.NewManager(db, wtMgr, logger, anvilPathMap(cfg)),
 		worktreeMgr:   wtMgr,
 		promptBuilder: prompt.NewBuilder(),
-		vcsProviders:  vcsProviders,
-		reqTracker:    *ipc.NewRequestTracker("forge-"),
+		vcsProviders:          vcsProviders,
+		reqTracker:            *ipc.NewRequestTracker("forge-"),
+		crucibleTickerResetCh: make(chan struct{}, 1),
 	}
 	d.notifier.Store(notifier)
 	d.dispatcher.Store(dispatcher)
@@ -648,6 +653,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 			d.updateSmelterSettings(old, new)
 			// Propagate config changes to Wicket monitor (interval, labels, etc.)
 			d.updateWicketConfig(new)
+			// Signal the poll loop to reset the crucible ticker when the interval changes.
+			if old.Settings.CruciblePollInterval != new.Settings.CruciblePollInterval {
+				select {
+				case d.crucibleTickerResetCh <- struct{}{}:
+				default:
+				}
+			}
 			d.db.LogEvent(state.EventConfigReload, "Configuration reloaded", "", "")
 		})
 		go func() {
@@ -833,8 +845,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if crucibleInterval > 0 {
 		crucibleTicker = time.NewTicker(crucibleInterval)
 		crucibleC = crucibleTicker.C
-		defer crucibleTicker.Stop()
 	}
+	defer func() {
+		if crucibleTicker != nil {
+			crucibleTicker.Stop()
+		}
+	}()
 
 	for {
 		select {
@@ -859,11 +875,30 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 		case <-ticker.C:
 			// Fast path when two-tier is active; full poll when disabled.
-			d.pollAndDispatch(ctx, crucibleInterval == 0)
+			d.pollAndDispatch(ctx, crucibleTicker == nil)
 
 		case <-crucibleC:
 			// Slow path: unfiltered poll to rebuild the Blocks graph.
 			d.pollAndDispatch(ctx, true)
+
+		case <-d.crucibleTickerResetCh:
+			newInterval := d.cfg.Load().Settings.CruciblePollInterval
+			if newInterval > 0 {
+				if crucibleTicker != nil {
+					crucibleTicker.Reset(newInterval)
+				} else {
+					crucibleTicker = time.NewTicker(newInterval)
+					crucibleC = crucibleTicker.C
+				}
+				d.logger.Info("crucible poll interval updated", "interval", newInterval)
+			} else {
+				if crucibleTicker != nil {
+					crucibleTicker.Stop()
+					crucibleTicker = nil
+					crucibleC = nil
+				}
+				d.logger.Info("two-tier polling disabled, all polls now unfiltered")
+			}
 		}
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -170,6 +170,11 @@ type Daemon struct {
 	lastBeads   []poller.Bead
 	lastBeadsMu sync.RWMutex
 
+	// Cached Blocks graph from the last slow (unfiltered) poll. Used by
+	// fast (label-filtered) polls to detect Crucible parent beads.
+	cachedBlocks   poller.BlocksGraph
+	cachedBlocksMu sync.RWMutex
+
 	// Per-anvil temper.yaml cache keyed by anvil path.
 	// Avoids repeated filesystem I/O on every dispatch and de-duplicates
 	// log spam when the file is invalid or unreadable.
@@ -660,8 +665,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
-	// Initial poll
-	d.pollAndDispatch(ctx)
+	// Initial poll (full/unfiltered to populate the Blocks cache)
+	d.pollAndDispatch(ctx, true)
 
 	// Start PR Monitor (Bellows)
 	monitorAnvils := make(map[string]string)
@@ -819,6 +824,18 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}
 
+	// Two-tier polling: fast ticker uses label-filtered polls for dispatch;
+	// slow ticker runs unfiltered polls to rebuild the Crucible Blocks graph.
+	// When CruciblePollInterval is 0, all polls are unfiltered (legacy mode).
+	crucibleInterval := d.cfg.Load().Settings.CruciblePollInterval
+	var crucibleTicker *time.Ticker
+	var crucibleC <-chan time.Time
+	if crucibleInterval > 0 {
+		crucibleTicker = time.NewTicker(crucibleInterval)
+		crucibleC = crucibleTicker.C
+		defer crucibleTicker.Stop()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -841,7 +858,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return nil
 
 		case <-ticker.C:
-			d.pollAndDispatch(ctx)
+			// Fast path when two-tier is active; full poll when disabled.
+			d.pollAndDispatch(ctx, crucibleInterval == 0)
+
+		case <-crucibleC:
+			// Slow path: unfiltered poll to rebuild the Blocks graph.
+			d.pollAndDispatch(ctx, true)
 		}
 	}
 }
@@ -1495,11 +1517,15 @@ func (d *Daemon) runStaleDetection(ctx context.Context) {
 }
 
 // pollAndDispatch polls all anvils for ready beads and dispatches workers.
+// When fullPoll is true, an unfiltered poll is performed and the cached Blocks
+// graph is rebuilt (slow path). When false, a label-filtered poll is performed
+// and the cached Blocks graph is merged into the results (fast path).
+//
 // It is serialized via a try-lock: if a poll is already running (e.g. an IPC
 // "refresh" overlapping with the ticker), the second caller returns immediately.
 // The in-progress poll already holds a consistent capacity snapshot, so
 // skipping the duplicate avoids double-dispatching past max_total_smiths.
-func (d *Daemon) pollAndDispatch(ctx context.Context) {
+func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 	if !d.pollRunning.CompareAndSwap(false, true) {
 		d.logger.Debug("pollAndDispatch already running, skipping concurrent invocation")
 		return
@@ -1510,7 +1536,11 @@ func (d *Daemon) pollAndDispatch(ctx context.Context) {
 	// if hot-reload swaps the pointer concurrently.
 	cfg := d.cfg.Load()
 
-	d.logger.Info("polling anvils", "count", len(cfg.Anvils))
+	if fullPoll {
+		d.logger.Info("polling anvils (full)", "count", len(cfg.Anvils))
+	} else {
+		d.logger.Info("polling anvils (fast)", "count", len(cfg.Anvils))
+	}
 
 	// Periodically recover orphaned in-progress beads (every 10 poll cycles).
 	// Recovery also runs once at startup (see Start). Running it here catches
@@ -1563,6 +1593,13 @@ func (d *Daemon) pollAndDispatch(ctx context.Context) {
 	}
 	p := poller.NewStaggered(cfg.Anvils, pollInterval)
 	p.BdReadyLimit = cfg.Settings.BdReadyLimit
+	if !fullPoll {
+		p.UseLabelFilter = true
+	}
+	pollKind := "full"
+	if !fullPoll {
+		pollKind = "fast"
+	}
 	// Log each anvil's poll event as soon as it finishes so Hearth shows
 	// per-anvil timestamps that reflect the actual stagger, not a single
 	// shared timestamp logged after wg.Wait().
@@ -1570,10 +1607,25 @@ func (d *Daemon) pollAndDispatch(ctx context.Context) {
 		if r.Err != nil {
 			_ = d.db.LogEvent(state.EventPollError, r.Err.Error(), "", r.Name)
 		} else {
-			_ = d.db.LogEvent(state.EventPoll, fmt.Sprintf("Polled anvil: %s (%d ready)", r.Name, len(r.Beads)), "", r.Name)
+			_ = d.db.LogEvent(state.EventPoll, fmt.Sprintf("Polled anvil [%s]: %s (%d ready)", pollKind, r.Name, len(r.Beads)), "", r.Name)
 		}
 	}
 	beads, results := p.Poll(ctx)
+
+	if fullPoll {
+		// Slow path: rebuild the cached Blocks graph from the unfiltered results.
+		graph := poller.BuildBlocksGraph(beads)
+		d.cachedBlocksMu.Lock()
+		d.cachedBlocks = graph
+		d.cachedBlocksMu.Unlock()
+	} else {
+		// Fast path: merge cached Blocks into label-filtered results so
+		// IsCrucibleCandidate still detects parent beads.
+		d.cachedBlocksMu.RLock()
+		cached := d.cachedBlocks
+		d.cachedBlocksMu.RUnlock()
+		poller.MergeBlocksFromCache(beads, cached)
+	}
 
 	anvilPaths := make(map[string]string, len(cfg.Anvils))
 	for name, anvil := range cfg.Anvils {
@@ -2873,7 +2925,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			d.logger.Info("crucible resumed", "parent", ca.ParentID, "anvil", ca.Anvil)
 
 			// Trigger poll to rediscover the parent and re-enter crucible loop.
-			go d.pollAndDispatch(d.runCtx)
+			go d.pollAndDispatch(d.runCtx, false)
 
 			data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("crucible %s resumed", ca.ParentID)})
 			return ipc.Response{Type: "ok", Payload: data}
@@ -2937,7 +2989,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 
 	case "refresh":
 		go func() {
-			d.pollAndDispatch(d.runCtx)
+			d.pollAndDispatch(d.runCtx, false)
 			if d.bellowsMonitor != nil {
 				d.bellowsMonitor.Refresh()
 			}
@@ -3252,7 +3304,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			_ = d.db.LogEvent(state.EventBeadTagged, fmt.Sprintf("Label %q added to bead %s", tag, tp.BeadID), tp.BeadID, tp.Anvil)
 			refreshCtx, refreshCancel := context.WithTimeout(d.runCtx, 30*time.Second)
 			defer refreshCancel()
-			d.pollAndDispatch(refreshCtx)
+			d.pollAndDispatch(refreshCtx, false)
 			data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("label %q added", tag)})
 			d.completeAsync(reqID, ipc.Response{Type: "ok", Payload: data})
 		}()
@@ -3294,7 +3346,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			_ = d.db.LogEvent(state.EventBeadClosed, fmt.Sprintf("Bead %s closed via TUI", cp.BeadID), cp.BeadID, cp.Anvil)
 			refreshCtx, refreshCancel := context.WithTimeout(d.runCtx, 30*time.Second)
 			defer refreshCancel()
-			d.pollAndDispatch(refreshCtx)
+			d.pollAndDispatch(refreshCtx, false)
 			data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("bead %s closed", cp.BeadID)})
 			d.completeAsync(reqID, ipc.Response{Type: "ok", Payload: data})
 		}()
@@ -3424,7 +3476,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				d.bellowsMonitor.ResetPRState(pr.Anvil, pr.Number)
 				d.bellowsMonitor.Refresh()
 			}
-			go d.pollAndDispatch(d.runCtx)
+			go d.pollAndDispatch(d.runCtx, false)
 
 			_ = d.db.LogEvent(
 				state.EventRetryReset,
@@ -3468,7 +3520,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 					d.logger.Warn("failed to reset bead status after retry reset", "bead", rp.BeadID, "error", err, "output", string(output))
 				}
 			}
-			d.pollAndDispatch(d.runCtx)
+			d.pollAndDispatch(d.runCtx, false)
 			msg := "retry reset"
 			if hasCircuitBreaker {
 				msg = "retry state reset"
@@ -3853,7 +3905,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			_ = d.db.RemovePendingOrphan(rp.BeadID, rp.Anvil)
 			_ = d.db.LogEvent(state.EventBeadRecovered, fmt.Sprintf("Orphan %s recovered by user via Hearth", rp.BeadID), rp.BeadID, rp.Anvil)
 			d.logger.Info("orphan recovered by user", "bead", rp.BeadID, "anvil", rp.Anvil)
-			go d.pollAndDispatch(d.runCtx)
+			go d.pollAndDispatch(d.runCtx, false)
 		case "close":
 			// Use context.Background() so this bd close call is not interrupted
 			// if the daemon is concurrently shutting down. The user explicitly
@@ -3870,7 +3922,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			_ = d.db.LogEvent(state.EventBeadClosed, fmt.Sprintf("Orphan %s closed by user (work completed)", rp.BeadID), rp.BeadID, rp.Anvil)
 			d.logger.Info("orphan closed by user (completed)", "bead", rp.BeadID, "anvil", rp.Anvil)
 			// Refresh queue state so Hearth reflects the closed orphan immediately.
-			go d.pollAndDispatch(d.runCtx)
+			go d.pollAndDispatch(d.runCtx, false)
 		case "discard":
 			// Use context.Background() so this bd close call is not interrupted
 			// if the daemon is concurrently shutting down. The user explicitly
@@ -3887,7 +3939,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			_ = d.db.LogEvent(state.EventBeadClosed, fmt.Sprintf("Orphan %s discarded by user", rp.BeadID), rp.BeadID, rp.Anvil)
 			d.logger.Info("orphan discarded by user", "bead", rp.BeadID, "anvil", rp.Anvil)
 			// Refresh queue state so Hearth reflects the discarded orphan immediately.
-			go d.pollAndDispatch(d.runCtx)
+			go d.pollAndDispatch(d.runCtx, false)
 		default:
 			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("unknown orphan action: %q", rp.Action)})
 			return ipc.Response{Type: "error", Payload: msg}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -528,7 +528,7 @@ exit 0
 
 	// First poll: the fake bd script returns a ready bead but dispatch should be
 	// skipped because today's cost exceeds the limit.
-	d.pollAndDispatch(context.Background())
+	d.pollAndDispatch(context.Background(), true)
 	assert.GreaterOrEqual(t, len(d.lastBeads), 1, "poll should surface the ready bead")
 	// No worker should have been dispatched.
 	_, inFlight := d.activeBeads.Load("COST-1")
@@ -536,13 +536,13 @@ exit 0
 	assert.Equal(t, 1, countCostLimitEvents(), "cost_limit_hit event should be logged once")
 
 	// Second poll: event must NOT be logged again (same calendar day).
-	d.pollAndDispatch(context.Background())
+	d.pollAndDispatch(context.Background(), true)
 	assert.Equal(t, 1, countCostLimitEvents(), "cost_limit_hit must not be logged again on same day")
 
 	// Simulate a daemon restart: reset the in-memory guard but keep the DB event.
 	// The DB-backed deduplication must prevent the notification from firing again.
 	d.costLimitLoggedDate.Store("")
-	d.pollAndDispatch(context.Background())
+	d.pollAndDispatch(context.Background(), true)
 	assert.Equal(t, 1, countCostLimitEvents(), "cost_limit_hit must not be logged after simulated restart when already notified today")
 }
 

--- a/internal/hotreload/hotreload.go
+++ b/internal/hotreload/hotreload.go
@@ -12,6 +12,7 @@
 //   - settings.max_ci_fix_attempts (applied immediately to lifecycle manager)
 //   - settings.max_review_fix_attempts (applied immediately to lifecycle manager)
 //   - settings.max_rebase_attempts (applied immediately to lifecycle manager)
+//   - settings.crucible_poll_interval (change the slow-path Crucible poll cadence)
 //   - settings.copilot_combined_smith_warden (toggle combined mode at runtime)
 //   - settings.copilot_warden_sample_rate (adjust sampling rate at runtime)
 //   - settings.smelter_enabled (enable/disable Smelter at runtime)
@@ -262,6 +263,11 @@ func applyChanges(old, new *config.Config) []string {
 	if oldSmelterEnabled != newSmelterEnabled {
 		changes = append(changes, fmt.Sprintf("smelter_enabled: %v → %v",
 			oldSmelterEnabled, newSmelterEnabled))
+	}
+
+	if old.Settings.CruciblePollInterval != new.Settings.CruciblePollInterval {
+		changes = append(changes, fmt.Sprintf("crucible_poll_interval: %v → %v",
+			old.Settings.CruciblePollInterval, new.Settings.CruciblePollInterval))
 	}
 
 	if old.Settings.SmelterInterval != new.Settings.SmelterInterval {

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -60,6 +60,50 @@ type AnvilResult struct {
 	Err   error
 }
 
+// BlocksGraph maps parent bead IDs to their child bead IDs. It is used to
+// cache parent-child relationships discovered during a slow (unfiltered) poll
+// so that fast (label-filtered) polls can still detect Crucible candidates.
+type BlocksGraph map[string][]string
+
+// BuildBlocksGraph extracts the Blocks mapping from a slice of beads.
+func BuildBlocksGraph(beads []Bead) BlocksGraph {
+	g := make(BlocksGraph)
+	for _, b := range beads {
+		if len(b.Blocks) > 0 {
+			children := make([]string, len(b.Blocks))
+			copy(children, b.Blocks)
+			g[b.ID] = children
+		}
+	}
+	return g
+}
+
+// MergeBlocksFromCache enriches beads with cached parent-child relationships
+// from a previous slow-path poll. For each bead that appears as a parent in
+// the cache, its Blocks field is augmented with cached children not already
+// present. Unlike the per-poll Blocks filter, cached children are NOT filtered
+// to the current poll batch — the Crucible fetches actual children via bd show.
+func MergeBlocksFromCache(beads []Bead, cached BlocksGraph) {
+	if len(cached) == 0 {
+		return
+	}
+	for i := range beads {
+		children, ok := cached[beads[i].ID]
+		if !ok {
+			continue
+		}
+		existing := make(map[string]bool, len(beads[i].Blocks))
+		for _, id := range beads[i].Blocks {
+			existing[id] = true
+		}
+		for _, childID := range children {
+			if !existing[childID] {
+				beads[i].Blocks = append(beads[i].Blocks, childID)
+			}
+		}
+	}
+}
+
 // BeadPoller polls registered anvils for ready beads.
 type BeadPoller struct {
 	anvils map[string]config.AnvilConfig
@@ -76,6 +120,10 @@ type BeadPoller struct {
 	OnAnvilDone func(AnvilResult)
 	// BdReadyLimit is the --limit passed to 'bd ready'. Default: 100.
 	BdReadyLimit int
+	// UseLabelFilter, when true, causes pollAnvil to add '--label <tag>' to
+	// the 'bd ready' command using each anvil's AutoDispatchTag. Anvils
+	// without a tag configured are polled unfiltered.
+	UseLabelFilter bool
 }
 
 // New creates a BeadPoller for the given anvil configurations.
@@ -181,7 +229,11 @@ func (p *BeadPoller) pollAnvil(ctx context.Context, name string, anvil config.An
 	if limit <= 0 {
 		limit = 100
 	}
-	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", "ready", "--json", "--limit", strconv.Itoa(limit)))
+	args := []string{"ready", "--json", "--limit", strconv.Itoa(limit)}
+	if p.UseLabelFilter && anvil.AutoDispatchTag != "" {
+		args = append(args, "--label", anvil.AutoDispatchTag)
+	}
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "bd", args...))
 	cmd.Dir = anvil.Path
 
 	var stderr bytes.Buffer

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -330,6 +330,89 @@ func TestNewStaggered_CalculatesInterval(t *testing.T) {
 	}
 }
 
+func TestBuildBlocksGraph(t *testing.T) {
+	beads := []Bead{
+		{ID: "parent-1", Blocks: []string{"child-a", "child-b"}},
+		{ID: "child-a"},
+		{ID: "child-b"},
+		{ID: "parent-2", Blocks: []string{"child-c"}},
+	}
+
+	graph := BuildBlocksGraph(beads)
+
+	assert.Len(t, graph, 2)
+	assert.ElementsMatch(t, []string{"child-a", "child-b"}, graph["parent-1"])
+	assert.Equal(t, []string{"child-c"}, graph["parent-2"])
+	_, hasChildA := graph["child-a"]
+	assert.False(t, hasChildA, "child-a should not be a key in the graph")
+}
+
+func TestMergeBlocksFromCache(t *testing.T) {
+	t.Run("enriches parent with cached children", func(t *testing.T) {
+		beads := []Bead{
+			{ID: "parent-1"},
+			{ID: "child-a"},
+		}
+		cached := BlocksGraph{
+			"parent-1": {"child-a", "child-b", "child-c"},
+		}
+
+		MergeBlocksFromCache(beads, cached)
+
+		assert.ElementsMatch(t, []string{"child-a", "child-b", "child-c"}, beads[0].Blocks)
+	})
+
+	t.Run("deduplicates existing blocks", func(t *testing.T) {
+		beads := []Bead{
+			{ID: "parent-1", Blocks: []string{"child-a"}},
+		}
+		cached := BlocksGraph{
+			"parent-1": {"child-a", "child-b"},
+		}
+
+		MergeBlocksFromCache(beads, cached)
+
+		assert.ElementsMatch(t, []string{"child-a", "child-b"}, beads[0].Blocks)
+	})
+
+	t.Run("no-op with empty cache", func(t *testing.T) {
+		beads := []Bead{
+			{ID: "parent-1"},
+		}
+
+		MergeBlocksFromCache(beads, nil)
+
+		assert.Empty(t, beads[0].Blocks)
+	})
+
+	t.Run("no-op for beads not in cache", func(t *testing.T) {
+		beads := []Bead{
+			{ID: "standalone"},
+		}
+		cached := BlocksGraph{
+			"parent-1": {"child-a"},
+		}
+
+		MergeBlocksFromCache(beads, cached)
+
+		assert.Empty(t, beads[0].Blocks)
+	})
+}
+
+func TestUseLabelFilter(t *testing.T) {
+	// Verify that UseLabelFilter field is plumbed correctly on the struct.
+	anvils := map[string]config.AnvilConfig{
+		"tagged-anvil": {Path: t.TempDir(), AutoDispatchTag: "forgeReady"},
+		"all-anvil":    {Path: t.TempDir()},
+	}
+
+	p := New(anvils)
+	assert.False(t, p.UseLabelFilter)
+
+	p.UseLabelFilter = true
+	assert.True(t, p.UseLabelFilter)
+}
+
 func TestPoll_StaggerRespectsContextCancellation(t *testing.T) {
 	anvils := map[string]config.AnvilConfig{
 		"anvil-a": {Path: t.TempDir()},


### PR DESCRIPTION
## Changes

- **Two-tier polling for faster bead discovery** - The poller now uses a fast label-filtered path every poll interval and a slow unfiltered path on a separate cadence (configurable via `crucible_poll_interval`, default 3m) to rebuild the Crucible parent-child graph. This reduces no-op poll cycle time by ~3.6x while preserving Crucible candidate detection. (Forge-fbyh)

## Original Issue (feature): Two-tier polling: fast labeled path + slow unfiltered path for crucible reconstruction

Today the poller runs 'bd ready --json --limit 100' every PollInterval (default 30s). Against remote Dolt this takes ~51s standalone (43 ready beads, ~70KB JSON) and 3+ minutes under daemon load (Dolt connection contention from concurrent Smith/Warden bd calls). Polls run effectively back-to-back, and a newly-labeled bead can wait minutes during decompose-heavy cycles. Filtering 'bd ready --label forgeReady --limit 100' is roughly 3.6x faster (~14s, 5KB) because the result set drops from 43 to 16 beads. We can't unconditionally swap to filtered because crucible parent detection (poller.go:204-274) reconstructs Blocks edges from children present in the unfiltered result -- losing children breaks Crucible candidate detection. Proposed two-tier design: (1) Fast path every PollInterval (30s): 'bd ready --json --label <auto_dispatch_tag> --limit <bd_ready_limit>' for normal dispatch. (2) Slow path every CruciblePollInterval (default 3-5min, configurable): existing unfiltered 'bd ready --json --limit <bd_ready_limit>' for Crucible / Blocks reconstruction. Cache the slow-path Blocks graph between fast polls and merge it into fast-path results so IsCrucibleCandidate keeps working. Need to: add new config fields (settings.crucible_poll_interval), refactor BeadPoller.Poll to accept a label filter and a cached Blocks graph, schedule the two timers in pollAndDispatch, ensure hot-reload still wires both. Acceptance: a no-op poll cycle (no dispatches, no decomposes) finishes in <20s on the live munin anvil; decompose cycles unchanged; crucible parents still detected within one slow-path interval. Depends-on: should land after Forge-{A-bead} so the parallelized propagation is in place when the new poll cadence increases the rate of decompose triggers.

---
Bead: Forge-fbyh | Branch: forge/Forge-fbyh
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)