### PR TITLE
Hearth queue snapshot loses unlabeled ready beads between two-tier slow polls (Forge-1soq)

### DIFF
--- a/changelog.d/Forge-1soq.md
+++ b/changelog.d/Forge-1soq.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Hearth queue snapshot retains unlabeled ready beads between fast polls** - The two-tier poller now keeps a separate labeled and unlabeled snapshot per anvil so a fast (label-filtered) poll no longer evicts beads that the slow (unfiltered) poll surfaced. Hearth's Queue panel now shows unlabeled ready beads continuously between slow polls; only beads that genuinely transition out of ready disappear, and only after the next slow poll confirms it. (Forge-1soq)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -171,6 +171,20 @@ type Daemon struct {
 	lastBeads   []poller.Bead
 	lastBeadsMu sync.RWMutex
 
+	// Two-tier bead snapshot, keyed by anvil then bead ID.
+	//   labeledSnapshot   — beads matching the anvil's auto_dispatch_tag.
+	//                       Refreshed by every poll (fast and slow).
+	//   unlabeledSnapshot — beads that do NOT match the anvil's tag but are
+	//                       still ready. Refreshed only by unfiltered (slow)
+	//                       polls, so they remain visible to Hearth between
+	//                       fast polls instead of flickering in and out.
+	// For anvils without an auto_dispatch_tag every poll is unfiltered, so
+	// all of their beads land in the labeled map and the unlabeled map stays
+	// empty.
+	snapshotMu        sync.RWMutex
+	labeledSnapshot   map[string]map[string]poller.Bead
+	unlabeledSnapshot map[string]map[string]poller.Bead
+
 	// Cached Blocks graph from the last slow (unfiltered) poll. Used by
 	// fast (label-filtered) polls to detect Crucible parent beads.
 	cachedBlocks   poller.BlocksGraph
@@ -1688,11 +1702,6 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 	// or via the blocks/blocked_by dependency graph (preferred).
 	poller.ResolveEpicBranches(ctx, beads, anvilPaths)
 
-	// Update cache
-	d.lastBeadsMu.Lock()
-	d.lastBeads = beads
-	d.lastBeadsMu.Unlock()
-
 	for _, r := range results {
 		if r.Err != nil {
 			d.logger.Warn("poll error", "anvil", r.Name, "error", r.Err)
@@ -1700,6 +1709,20 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 			d.logger.Info("poll complete", "anvil", r.Name, "ready", len(r.Beads))
 		}
 	}
+
+	// Update the two-tier snapshot. Fast (label-filtered) polls only refresh
+	// the labeled map for filtered anvils; slow polls refresh both. The merged
+	// view feeds lastBeads (used by IPC and title lookups) and the queue_cache
+	// rows so unlabeled beads stay visible to Hearth between slow polls.
+	d.updateBeadSnapshot(cfg, beads, results, !effectiveFullPoll)
+
+	// Refresh lastBeads with the merged view across all anvils so IPC consumers
+	// (run_bead cache lookup, crucibleParentTitle) see unlabeled beads even
+	// after a fast poll.
+	merged := d.mergedBeadSnapshot()
+	d.lastBeadsMu.Lock()
+	d.lastBeads = merged
+	d.lastBeadsMu.Unlock()
 
 	// Cache queue in SQLite so the Hearth TUI can read it without polling independently.
 	// Only update cache rows for anvils that polled successfully, so failed anvils
@@ -1717,8 +1740,13 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 			succeededSet[a] = struct{}{}
 		}
 
+		// Build queue_cache rows from the merged snapshot, restricted to the
+		// anvils we just polled successfully. This preserves unlabeled beads
+		// from a previous slow poll across intervening fast polls — the bug
+		// fix for Forge-1soq.
+		mergedForCache := d.mergedBeadSnapshotForAnvils(succeededAnvils)
 		var cacheItems []state.QueueItem
-		for _, b := range beads {
+		for _, b := range mergedForCache {
 			if b.Labels == nil {
 				b.Labels = []string{}
 			}
@@ -4724,6 +4752,141 @@ func (d *Daemon) maybeCloseDecomposedParent(bead poller.Bead, anvilCfg config.An
 	_ = d.db.LogEvent(state.EventBeadAutoClosed,
 		fmt.Sprintf("Parent auto-closed after decomposition into %d children (no dependents)", childCount),
 		beadID, anvil)
+}
+
+// updateBeadSnapshot refreshes the daemon's two-tier bead snapshot from a poll
+// result. The fast (label-filtered) path may only refresh the labeled map for
+// anvils that effectively used the label filter; the unlabeled map stays put
+// so beads picked up by a previous slow poll remain visible to Hearth.
+//
+// fastPoll mirrors pollAndDispatch's effectiveFullPoll inversion: when
+// fastPoll is true, the cycle requested label filtering. Per-anvil filtering
+// is enabled only when the anvil also has a non-empty AutoDispatchTag — anvils
+// without a tag are polled unfiltered even on the fast path, so we treat them
+// as a slow refresh and update both maps.
+//
+// Anvils whose poll returned an error are left untouched so a transient bd
+// failure does not wipe the cached snapshot.
+func (d *Daemon) updateBeadSnapshot(cfg *config.Config, beads []poller.Bead, results []poller.AnvilResult, fastPoll bool) {
+	if cfg == nil {
+		return
+	}
+
+	beadsByAnvil := make(map[string][]poller.Bead, len(results))
+	for _, b := range beads {
+		beadsByAnvil[b.Anvil] = append(beadsByAnvil[b.Anvil], b)
+	}
+
+	d.snapshotMu.Lock()
+	defer d.snapshotMu.Unlock()
+	if d.labeledSnapshot == nil {
+		d.labeledSnapshot = map[string]map[string]poller.Bead{}
+	}
+	if d.unlabeledSnapshot == nil {
+		d.unlabeledSnapshot = map[string]map[string]poller.Bead{}
+	}
+
+	for _, r := range results {
+		if r.Err != nil {
+			continue
+		}
+		anvilCfg, ok := cfg.Anvils[r.Name]
+		if !ok {
+			continue
+		}
+		tag := anvilCfg.AutoDispatchTag
+		// Was this anvil's poll filtered? Only when the global cycle ran in
+		// fast mode AND this anvil had a tag for the poller to filter on.
+		filtered := fastPoll && tag != ""
+
+		labeled := make(map[string]poller.Bead, len(beadsByAnvil[r.Name]))
+		unlabeled := make(map[string]poller.Bead)
+		for _, b := range beadsByAnvil[r.Name] {
+			if tag == "" || beadHasLabel(b, tag) {
+				labeled[b.ID] = b
+			} else {
+				unlabeled[b.ID] = b
+			}
+		}
+		d.labeledSnapshot[r.Name] = labeled
+		if !filtered {
+			// Slow (or effectively slow) refresh: replace the unlabeled map
+			// wholesale so beads that have transitioned out of ready (closed,
+			// claimed, lost a dependency) are evicted.
+			d.unlabeledSnapshot[r.Name] = unlabeled
+		}
+	}
+}
+
+// beadHasLabel reports whether the bead carries the given label (case-insensitive).
+func beadHasLabel(b poller.Bead, label string) bool {
+	for _, l := range b.Labels {
+		if strings.EqualFold(l, label) {
+			return true
+		}
+	}
+	return false
+}
+
+// mergedBeadSnapshot returns the union of labeled and unlabeled snapshots
+// across all anvils, sorted by priority (ascending) then bead ID. Labeled
+// entries take precedence on collision because they reflect the freshest poll.
+func (d *Daemon) mergedBeadSnapshot() []poller.Bead {
+	d.snapshotMu.RLock()
+	defer d.snapshotMu.RUnlock()
+	anvils := make(map[string]struct{}, len(d.labeledSnapshot)+len(d.unlabeledSnapshot))
+	for a := range d.labeledSnapshot {
+		anvils[a] = struct{}{}
+	}
+	for a := range d.unlabeledSnapshot {
+		anvils[a] = struct{}{}
+	}
+	names := make([]string, 0, len(anvils))
+	for a := range anvils {
+		names = append(names, a)
+	}
+	return d.mergedBeadSnapshotLocked(names)
+}
+
+// mergedBeadSnapshotForAnvils returns the union of labeled and unlabeled
+// snapshots restricted to the given anvil names.
+func (d *Daemon) mergedBeadSnapshotForAnvils(anvils []string) []poller.Bead {
+	d.snapshotMu.RLock()
+	defer d.snapshotMu.RUnlock()
+	return d.mergedBeadSnapshotLocked(anvils)
+}
+
+// mergedBeadSnapshotLocked is the lock-free merge implementation. The caller
+// must hold snapshotMu (read or write).
+func (d *Daemon) mergedBeadSnapshotLocked(anvils []string) []poller.Bead {
+	var out []poller.Bead
+	for _, a := range anvils {
+		seen := make(map[string]struct{})
+		if labeled, ok := d.labeledSnapshot[a]; ok {
+			for id, b := range labeled {
+				seen[id] = struct{}{}
+				out = append(out, b)
+			}
+		}
+		if unlabeled, ok := d.unlabeledSnapshot[a]; ok {
+			for id, b := range unlabeled {
+				if _, dup := seen[id]; dup {
+					continue
+				}
+				out = append(out, b)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority < out[j].Priority
+		}
+		if out[i].ID != out[j].ID {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Anvil < out[j].Anvil
+	})
+	return out
 }
 
 // classifyBeadSection determines which queue section a bead belongs to based

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1740,11 +1740,14 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 			succeededSet[a] = struct{}{}
 		}
 
-		// Build queue_cache rows from the merged snapshot, restricted to the
-		// anvils we just polled successfully. This preserves unlabeled beads
-		// from a previous slow poll across intervening fast polls — the bug
-		// fix for Forge-1soq.
-		mergedForCache := d.mergedBeadSnapshotForAnvils(succeededAnvils)
+		// Filter the already-merged+sorted slice to succeeded anvils to avoid a
+		// second merge/sort and extra snapshotMu acquisitions.
+		mergedForCache := make([]poller.Bead, 0, len(merged))
+		for _, b := range merged {
+			if _, ok := succeededSet[b.Anvil]; ok {
+				mergedForCache = append(mergedForCache, b)
+			}
+		}
 		var cacheItems []state.QueueItem
 		for _, b := range mergedForCache {
 			if b.Labels == nil {
@@ -4829,22 +4832,19 @@ func beadHasLabel(b poller.Bead, label string) bool {
 }
 
 // mergedBeadSnapshot returns the union of labeled and unlabeled snapshots
-// across all anvils, sorted by priority (ascending) then bead ID. Labeled
-// entries take precedence on collision because they reflect the freshest poll.
+// across all currently configured anvils, sorted by priority (ascending)
+// then bead ID. Labeled entries take precedence on collision because they
+// reflect the freshest poll.
 func (d *Daemon) mergedBeadSnapshot() []poller.Bead {
+	cfg := d.cfg.Load()
+	names := make([]string, 0, len(cfg.Anvils))
+	for name := range cfg.Anvils {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	d.snapshotMu.RLock()
 	defer d.snapshotMu.RUnlock()
-	anvils := make(map[string]struct{}, len(d.labeledSnapshot)+len(d.unlabeledSnapshot))
-	for a := range d.labeledSnapshot {
-		anvils[a] = struct{}{}
-	}
-	for a := range d.unlabeledSnapshot {
-		anvils[a] = struct{}{}
-	}
-	names := make([]string, 0, len(anvils))
-	for a := range anvils {
-		names = append(names, a)
-	}
 	return d.mergedBeadSnapshotLocked(names)
 }
 

--- a/internal/daemon/snapshot_test.go
+++ b/internal/daemon/snapshot_test.go
@@ -1,0 +1,212 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/poller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// taggedAnvilCfg builds a config with one anvil that uses tagged auto-dispatch
+// against the auto_dispatch_tag. This mirrors the production deployment that
+// surfaced the Forge-1soq flicker.
+func taggedAnvilCfg(name, tag string) *config.Config {
+	return &config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			name: {
+				AutoDispatch:    "tagged",
+				AutoDispatchTag: tag,
+			},
+		},
+	}
+}
+
+func bead(id, anvil string, labels ...string) poller.Bead {
+	return poller.Bead{ID: id, Anvil: anvil, Title: id, Labels: labels}
+}
+
+func successResult(name string, beads []poller.Bead) poller.AnvilResult {
+	return poller.AnvilResult{Name: name, Beads: beads}
+}
+
+// collectIDs returns just the IDs of the merged snapshot, sorted as the merge
+// already sorts (priority then id). Useful for set-style comparisons.
+func collectIDs(beads []poller.Bead) []string {
+	out := make([]string, 0, len(beads))
+	for _, b := range beads {
+		out = append(out, b.ID)
+	}
+	return out
+}
+
+// TestSnapshot_FastPollRetainsUnlabeledFromSlowPoll is the regression test for
+// Forge-1soq: a fast (label-filtered) poll must not evict beads that a prior
+// slow poll surfaced unlabeled.
+func TestSnapshot_FastPollRetainsUnlabeledFromSlowPoll(t *testing.T) {
+	cfg := taggedAnvilCfg("anvil-a", "forgeReady")
+	d := &Daemon{}
+
+	// Slow poll returns one labeled and one unlabeled bead.
+	slowBeads := []poller.Bead{
+		bead("LBL-1", "anvil-a", "forgeReady"),
+		bead("UNL-1", "anvil-a"),
+	}
+	d.updateBeadSnapshot(cfg, slowBeads, []poller.AnvilResult{successResult("anvil-a", slowBeads)}, false)
+
+	got := d.mergedBeadSnapshotForAnvils([]string{"anvil-a"})
+	require.ElementsMatch(t, []string{"LBL-1", "UNL-1"}, collectIDs(got),
+		"slow poll should populate both labeled and unlabeled maps")
+
+	// Fast poll returns only the labeled bead.
+	fastBeads := []poller.Bead{bead("LBL-1", "anvil-a", "forgeReady")}
+	d.updateBeadSnapshot(cfg, fastBeads, []poller.AnvilResult{successResult("anvil-a", fastBeads)}, true)
+
+	got = d.mergedBeadSnapshotForAnvils([]string{"anvil-a"})
+	require.ElementsMatch(t, []string{"LBL-1", "UNL-1"}, collectIDs(got),
+		"fast poll must NOT evict the unlabeled bead surfaced by the prior slow poll")
+}
+
+// TestSnapshot_SlowPollEvictsMissingUnlabeled verifies that an unlabeled bead
+// disappears from the snapshot only after a confirming slow poll where it is
+// no longer present in the unfiltered set.
+func TestSnapshot_SlowPollEvictsMissingUnlabeled(t *testing.T) {
+	cfg := taggedAnvilCfg("anvil-a", "forgeReady")
+	d := &Daemon{}
+
+	// First slow poll: labeled + unlabeled bead present.
+	first := []poller.Bead{
+		bead("LBL-1", "anvil-a", "forgeReady"),
+		bead("UNL-1", "anvil-a"),
+	}
+	d.updateBeadSnapshot(cfg, first, []poller.AnvilResult{successResult("anvil-a", first)}, false)
+
+	// Fast poll: only labeled — unlabeled must remain visible.
+	fast := []poller.Bead{bead("LBL-1", "anvil-a", "forgeReady")}
+	d.updateBeadSnapshot(cfg, fast, []poller.AnvilResult{successResult("anvil-a", fast)}, true)
+	require.Contains(t, collectIDs(d.mergedBeadSnapshotForAnvils([]string{"anvil-a"})), "UNL-1",
+		"unlabeled bead must survive a fast poll")
+
+	// Second slow poll: UNL-1 has transitioned out (closed / claimed / blocked)
+	// and is no longer in the unfiltered result. It must be evicted now.
+	second := []poller.Bead{bead("LBL-1", "anvil-a", "forgeReady")}
+	d.updateBeadSnapshot(cfg, second, []poller.AnvilResult{successResult("anvil-a", second)}, false)
+
+	got := collectIDs(d.mergedBeadSnapshotForAnvils([]string{"anvil-a"}))
+	require.ElementsMatch(t, []string{"LBL-1"}, got,
+		"slow poll must evict unlabeled beads that no longer appear in the unfiltered result")
+}
+
+// TestSnapshot_LabeledTakesPrecedenceOnCollision verifies that when a bead
+// appears in both maps (e.g. it gained the label between slow and fast polls),
+// the merged view emits it once with the labeled-map data.
+func TestSnapshot_LabeledTakesPrecedenceOnCollision(t *testing.T) {
+	cfg := taggedAnvilCfg("anvil-a", "forgeReady")
+	d := &Daemon{}
+
+	// Slow poll: bead is unlabeled. Title intentionally differs so we can
+	// detect which map the merged entry came from.
+	slow := []poller.Bead{
+		{ID: "BD-1", Anvil: "anvil-a", Title: "old-unlabeled"},
+	}
+	d.updateBeadSnapshot(cfg, slow, []poller.AnvilResult{successResult("anvil-a", slow)}, false)
+
+	// Fast poll: same bead now carries the tag with a fresher title.
+	fast := []poller.Bead{
+		{ID: "BD-1", Anvil: "anvil-a", Title: "fresh-labeled", Labels: []string{"forgeReady"}},
+	}
+	d.updateBeadSnapshot(cfg, fast, []poller.AnvilResult{successResult("anvil-a", fast)}, true)
+
+	got := d.mergedBeadSnapshotForAnvils([]string{"anvil-a"})
+	require.Len(t, got, 1, "bead must not appear twice")
+	assert.Equal(t, "fresh-labeled", got[0].Title, "labeled map should win on collision")
+}
+
+// TestSnapshot_FailedAnvilPollLeavesSnapshotUntouched verifies that a transient
+// bd error does not wipe the cached snapshot for that anvil.
+func TestSnapshot_FailedAnvilPollLeavesSnapshotUntouched(t *testing.T) {
+	cfg := taggedAnvilCfg("anvil-a", "forgeReady")
+	d := &Daemon{}
+
+	// Seed a snapshot.
+	seed := []poller.Bead{
+		bead("LBL-1", "anvil-a", "forgeReady"),
+		bead("UNL-1", "anvil-a"),
+	}
+	d.updateBeadSnapshot(cfg, seed, []poller.AnvilResult{successResult("anvil-a", seed)}, false)
+
+	// Simulate a failing poll (no beads, error result).
+	failed := poller.AnvilResult{Name: "anvil-a", Err: assertErrTransient{}}
+	d.updateBeadSnapshot(cfg, nil, []poller.AnvilResult{failed}, true)
+
+	got := d.mergedBeadSnapshotForAnvils([]string{"anvil-a"})
+	assert.ElementsMatch(t, []string{"LBL-1", "UNL-1"}, collectIDs(got),
+		"failed poll must not wipe snapshot for the affected anvil")
+}
+
+// TestSnapshot_NoTagAnvilUsesLabeledMapOnly verifies that anvils without an
+// AutoDispatchTag are always treated as fully refreshed (since their polls
+// are never label-filtered), so the unlabeled map stays empty for them.
+func TestSnapshot_NoTagAnvilUsesLabeledMapOnly(t *testing.T) {
+	cfg := &config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			"anvil-untagged": {
+				AutoDispatch: "all",
+				// No AutoDispatchTag.
+			},
+		},
+	}
+	d := &Daemon{}
+
+	beads := []poller.Bead{
+		bead("BD-1", "anvil-untagged"),
+		bead("BD-2", "anvil-untagged", "forgeReady"),
+	}
+	// Even when fastPoll=true, the per-anvil filtered flag is false because
+	// the poller does not apply --label without a tag. Both beads should land
+	// in the labeled map and the snapshot should stay consistent.
+	d.updateBeadSnapshot(cfg, beads, []poller.AnvilResult{successResult("anvil-untagged", beads)}, true)
+
+	got := d.mergedBeadSnapshotForAnvils([]string{"anvil-untagged"})
+	require.ElementsMatch(t, []string{"BD-1", "BD-2"}, collectIDs(got))
+
+	d.snapshotMu.RLock()
+	defer d.snapshotMu.RUnlock()
+	assert.Empty(t, d.unlabeledSnapshot["anvil-untagged"],
+		"unlabeled map must stay empty for anvils without an auto_dispatch_tag")
+	assert.Len(t, d.labeledSnapshot["anvil-untagged"], 2,
+		"both beads should be tracked in the labeled map")
+}
+
+// TestSnapshot_MergeAcrossAnvils verifies that the mergedBeadSnapshot helper
+// returns beads across multiple anvils, deterministically ordered.
+func TestSnapshot_MergeAcrossAnvils(t *testing.T) {
+	cfg := &config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			"anvil-a": {AutoDispatch: "tagged", AutoDispatchTag: "forgeReady"},
+			"anvil-b": {AutoDispatch: "tagged", AutoDispatchTag: "forgeReady"},
+		},
+	}
+	d := &Daemon{}
+
+	all := []poller.Bead{
+		{ID: "A-1", Anvil: "anvil-a", Priority: 1, Labels: []string{"forgeReady"}},
+		{ID: "A-2", Anvil: "anvil-a", Priority: 3},
+		{ID: "B-1", Anvil: "anvil-b", Priority: 2, Labels: []string{"forgeReady"}},
+	}
+	results := []poller.AnvilResult{
+		successResult("anvil-a", []poller.Bead{all[0], all[1]}),
+		successResult("anvil-b", []poller.Bead{all[2]}),
+	}
+	d.updateBeadSnapshot(cfg, all, results, false)
+
+	got := d.mergedBeadSnapshot()
+	// Sorted by priority, then ID.
+	require.Equal(t, []string{"A-1", "B-1", "A-2"}, collectIDs(got))
+}
+
+// assertErrTransient is a sentinel error used in the failed-poll test.
+type assertErrTransient struct{}
+
+func (assertErrTransient) Error() string { return "transient" }

--- a/internal/daemon/snapshot_test.go
+++ b/internal/daemon/snapshot_test.go
@@ -189,6 +189,7 @@ func TestSnapshot_MergeAcrossAnvils(t *testing.T) {
 		},
 	}
 	d := &Daemon{}
+	d.cfg.Store(cfg)
 
 	all := []poller.Bead{
 		{ID: "A-1", Anvil: "anvil-a", Priority: 1, Labels: []string{"forgeReady"}},


### PR DESCRIPTION
## Changes

- **Hearth queue snapshot retains unlabeled ready beads between fast polls** - The two-tier poller now keeps a separate labeled and unlabeled snapshot per anvil so a fast (label-filtered) poll no longer evicts beads that the slow (unfiltered) poll surfaced. Hearth's Queue panel now shows unlabeled ready beads continuously between slow polls; only beads that genuinely transition out of ready disappear, and only after the next slow poll confirms it. (Forge-1soq)

## Original Issue (bug): Hearth queue snapshot loses unlabeled ready beads between two-tier slow polls

After Forge-fbyh (two-tier polling) merged, Hearth's Queue panel only shows the latest fast-poll result. Fast polls run every poll_interval (default 30s) with --label <auto_dispatch_tag>, so they only return labeled (forgeReady) beads. The slow poll runs every crucible_poll_interval (default 3m, lowered to 60s on this deployment as a workaround) and returns the full unfiltered set, which briefly brings unlabeled ready beads back into the queue display before the next fast poll wipes them out again. The flicker has been observable: 'I mostly see Ready and In Progress, not all the unlabeled ready beads. I see them sometimes, sometimes not.' Root cause: the daemon overwrites its queue snapshot on every poll regardless of which tier produced it, so unlabeled beads are evicted as soon as a fast poll returns. The two tiers should compose, not race: the fast path should refresh only the labeled subset of the snapshot; the slow path should refresh both. Proposed fix: in the daemon's queue-snapshot update path (after Poll() returns) keep two maps -- a 'labeled' map refreshed by every poll, and an 'unlabeled' map refreshed only by unfiltered polls. Render the union for IPC/Hearth consumers. When the slow path runs and an old unlabeled bead is no longer present in the unfiltered set (closed / claimed / lost the dependency), drop it from the unlabeled map. Approx 30 LOC change in internal/daemon/daemon.go around the snapshot-update site after pollAndDispatch's call to BeadPoller.Poll. Acceptance: after enabling two-tier polling, the Queue panel in Hearth shows unlabeled ready beads continuously between slow polls; only beads that genuinely transitioned out of ready (closed, in_progress, blocked) disappear, and only after the next slow poll confirms it. Workaround in place: settings.crucible_poll_interval=60s (was 3m). Once this fix lands, the workaround can revert to the original 3m default to save bd ready calls. Depends on Forge-fbyh.

---
Bead: Forge-1soq | Branch: forge/Forge-1soq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)