### PR TITLE
Add Unblock-File workaround to install.ps1 (Forge-9u3j)

### DIFF
--- a/changelog.d/Forge-9u3j.md
+++ b/changelog.d/Forge-9u3j.md
@@ -1,0 +1,2 @@
+category: Changed
+- **install.ps1 unblocks downloaded binary on Windows** - Call `Unblock-File` after extracting `forge.exe` to strip the Zone.Identifier NTFS stream that triggers repeated Windows Defender scans. Wrapped in try/catch so installation continues if the call fails. (Forge-9u3j)

--- a/install.ps1
+++ b/install.ps1
@@ -193,7 +193,15 @@ try {
 
     Copy-Item -Path $ExtractedBinary.FullName -Destination $BinaryPath -Force
 
-    if ($OS -ne "windows") {
+    if ($OS -eq "windows") {
+        # Strip the Zone.Identifier NTFS stream so Defender doesn't treat the
+        # binary as downloaded-from-internet on every launch. Best-effort.
+        try {
+            Unblock-File -Path $BinaryPath -ErrorAction Stop
+        } catch {
+            Write-Host "   Warning: Unblock-File failed — $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    } else {
         # Ensure the forge binary is executable on Unix-like systems.
         & chmod +x -- $BinaryPath
     }


### PR DESCRIPTION
## Changes

- **install.ps1 unblocks downloaded binary on Windows** - Call `Unblock-File` after extracting `forge.exe` to strip the Zone.Identifier NTFS stream that triggers repeated Windows Defender scans. Wrapped in try/catch so installation continues if the call fails. (Forge-9u3j)

## Original Issue (task): Add Unblock-File workaround to install.ps1

Modify install.ps1 to call Unblock-File on the downloaded forge.exe after extraction. This removes the Zone.Identifier NTFS stream that triggers Defender scanning. Add the call after the binary is extracted/moved to its final location, wrapped in a try/catch so the installer continues if Unblock-File fails. This is the immediate no-cost mitigation and is independent of the signing work — it should ship first as a stopgap. Test by running install.ps1 on a fresh Windows machine and confirming reduced Defender interaction.

---
Bead: Forge-9u3j | Branch: forge/Forge-9u3j
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)