### PR TITLE
IPC client 3s read deadline too short for bd-backed handlers (force-run, queue, run_bead) (Forge-14t7)

### DIFF
--- a/changelog.d/Forge-14t7.md
+++ b/changelog.d/Forge-14t7.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **IPC client per-command read deadlines** - Replaced the hardcoded 3s response timeout with a per-command `ReadTimeout` so bd-backed handlers (run_bead, force-run, merge_pr, resolve_orphan, crucible_action, pr_action) no longer fail with `reading response: i/o timeout` when bd against remote Dolt takes 10-30s. Trivial commands (status, view_logs) still use the 3s default; long-running commands opt into the 2-minute `BdBackedReadTimeout`. (Forge-14t7)

--- a/cmd/forge/hearth.go
+++ b/cmd/forge/hearth.go
@@ -169,8 +169,9 @@ var hearthCmd = &cobra.Command{
 				Anvil:    anvil,
 			})
 			resp, err := client.Send(ipc.Command{
-				Type:    "merge_pr",
-				Payload: json.RawMessage(payload),
+				Type:        "merge_pr",
+				Payload:     json.RawMessage(payload),
+				ReadTimeout: ipc.BdBackedReadTimeout,
 			})
 			if err != nil {
 				return err
@@ -227,8 +228,9 @@ var hearthCmd = &cobra.Command{
 				Action:   action,
 			})
 			resp, err := client.Send(ipc.Command{
-				Type:    "pr_action",
-				Payload: json.RawMessage(payload),
+				Type:        "pr_action",
+				Payload:     json.RawMessage(payload),
+				ReadTimeout: ipc.BdBackedReadTimeout,
 			})
 			if err != nil {
 				return "", err
@@ -308,8 +310,9 @@ var hearthCmd = &cobra.Command{
 				ForceRun: true,
 			})
 			resp, err := client.Send(ipc.Command{
-				Type:    "run_bead",
-				Payload: json.RawMessage(payload),
+				Type:        "run_bead",
+				Payload:     json.RawMessage(payload),
+				ReadTimeout: ipc.BdBackedReadTimeout,
 			})
 			if err != nil {
 				return err
@@ -360,8 +363,9 @@ var hearthCmd = &cobra.Command{
 				Action:   action,
 			})
 			resp, err := client.Send(ipc.Command{
-				Type:    "crucible_action",
-				Payload: json.RawMessage(payload),
+				Type:        "crucible_action",
+				Payload:     json.RawMessage(payload),
+				ReadTimeout: ipc.BdBackedReadTimeout,
 			})
 			if err != nil {
 				return err
@@ -464,8 +468,9 @@ var hearthCmd = &cobra.Command{
 				Action: action,
 			})
 			resp, err := client.Send(ipc.Command{
-				Type:    "resolve_orphan",
-				Payload: json.RawMessage(payload),
+				Type:        "resolve_orphan",
+				Payload:     json.RawMessage(payload),
+				ReadTimeout: ipc.BdBackedReadTimeout,
 			})
 			if err != nil {
 				return err

--- a/cmd/forge/queue.go
+++ b/cmd/forge/queue.go
@@ -109,8 +109,9 @@ var queueRunCmd = &cobra.Command{
 		})
 
 		resp, err := client.Send(ipc.Command{
-			Type:    "run_bead",
-			Payload: payload,
+			Type:        "run_bead",
+			Payload:     payload,
+			ReadTimeout: ipc.BdBackedReadTimeout,
 		})
 		if err != nil {
 			return fmt.Errorf("sending command: %w", err)

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -33,6 +33,38 @@ import (
 type Command struct {
 	Type    string          `json:"type"`    // "status", "kill_worker", "refresh", "queue", "run_bead", "set_clarification", "clear_clarification"
 	Payload json.RawMessage `json:"payload"` // Type-specific data
+	// ReadTimeout is an optional client-side timeout for reading the response.
+	// Zero uses DefaultReadTimeout. Long-running commands that go through bd or
+	// gh (e.g. run_bead) should set BdBackedReadTimeout. This field is not sent
+	// on the wire — it only influences Client.Send's read deadline.
+	ReadTimeout time.Duration `json:"-"`
+}
+
+// Per-command read-deadline presets applied by Client.Send.
+const (
+	// DefaultReadTimeout is used when a Command leaves ReadTimeout unset. It is
+	// tuned for fast daemon-local handlers (status, view_logs, DB-only ops).
+	DefaultReadTimeout = 3 * time.Second
+
+	// BdBackedReadTimeout covers handlers that synchronously shell out to bd
+	// (bd show / bd ready) before replying. bd against remote Dolt plus
+	// GitHub auto-sync can take 20-30s per call; run_bead may chain multiple
+	// such calls. Two minutes leaves headroom while still bounding a hung
+	// daemon well under executil.DefaultBdTimeout (5 min).
+	BdBackedReadTimeout = 2 * time.Minute
+)
+
+// defaultReadTimeout is the value applied when Command.ReadTimeout is zero.
+// It mirrors DefaultReadTimeout at runtime but lives in a var so tests can
+// shrink it (see testOverrideDefaultReadTimeout) to keep suite runtime bounded.
+var defaultReadTimeout = DefaultReadTimeout
+
+// testOverrideDefaultReadTimeout swaps the default read timeout, returning the
+// previous value so tests can restore it with defer.
+func testOverrideDefaultReadTimeout(d time.Duration) time.Duration {
+	prev := defaultReadTimeout
+	defaultReadTimeout = d
+	return prev
 }
 
 // Response is a message sent from the daemon to a client.
@@ -529,7 +561,11 @@ func (c *Client) Send(cmd Command) (*Response, error) {
 		return nil, fmt.Errorf("sending command: %w", err)
 	}
 
-	_ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	readTimeout := cmd.ReadTimeout
+	if readTimeout <= 0 {
+		readTimeout = defaultReadTimeout
+	}
+	_ = c.conn.SetReadDeadline(time.Now().Add(readTimeout))
 	scanner := bufio.NewScanner(c.conn)
 	scanner.Buffer(make([]byte, 64*1024), 64*1024)
 	if !scanner.Scan() {

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -56,16 +56,8 @@ const (
 
 // defaultReadTimeout is the value applied when Command.ReadTimeout is zero.
 // It mirrors DefaultReadTimeout at runtime but lives in a var so tests can
-// shrink it (see testOverrideDefaultReadTimeout) to keep suite runtime bounded.
+// override it directly to keep suite runtime bounded.
 var defaultReadTimeout = DefaultReadTimeout
-
-// testOverrideDefaultReadTimeout swaps the default read timeout, returning the
-// previous value so tests can restore it with defer.
-func testOverrideDefaultReadTimeout(d time.Duration) time.Duration {
-	prev := defaultReadTimeout
-	defaultReadTimeout = d
-	return prev
-}
 
 // Response is a message sent from the daemon to a client.
 type Response struct {

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -185,8 +185,9 @@ func drainOne(conn net.Conn, timeout time.Duration) <-chan error {
 func TestClientSend_CustomReadTimeoutSucceedsAfterSlowResponse(t *testing.T) {
 	// Shrink the default so this test fails correctly if Client.Send forgets
 	// to honor the per-command ReadTimeout override.
-	prev := testOverrideDefaultReadTimeout(50 * time.Millisecond)
-	defer testOverrideDefaultReadTimeout(prev)
+	prev := defaultReadTimeout
+	defaultReadTimeout = 50 * time.Millisecond
+	defer func() { defaultReadTimeout = prev }()
 
 	client, server := newPipeClient()
 	defer client.Close()
@@ -232,8 +233,9 @@ func TestClientSend_CustomReadTimeoutSucceedsAfterSlowResponse(t *testing.T) {
 // rather than waiting for the bd-backed timeout.
 func TestClientSend_DefaultReadTimeoutFiresOnSlowResponse(t *testing.T) {
 	// Shrink the default just for this test so we don't wait 3 real seconds.
-	prev := testOverrideDefaultReadTimeout(150 * time.Millisecond)
-	defer testOverrideDefaultReadTimeout(prev)
+	prev := defaultReadTimeout
+	defaultReadTimeout = 150 * time.Millisecond
+	defer func() { defaultReadTimeout = prev }()
 
 	client, server := newPipeClient()
 	defer client.Close()

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -2,6 +2,8 @@ package ipc
 
 import (
 	"encoding/json"
+	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -149,6 +151,150 @@ func TestQueuedResponse_EmptyID(t *testing.T) {
 	_, err := NewQueuedResponse("", "msg")
 	if err == nil {
 		t.Fatal("expected error for empty requestID, got nil")
+	}
+}
+
+// newPipeClient wires an in-memory net.Pipe to a Client. The returned server
+// side is the far end of the pipe — tests can read the command off it, sleep,
+// and write the response to exercise the Client.Send read deadline.
+func newPipeClient() (*Client, net.Conn) {
+	clientSide, serverSide := net.Pipe()
+	return &Client{conn: clientSide}, serverSide
+}
+
+// drainOne reads a single chunk from the pipe so Client.Send's write can
+// proceed. The synchronous net.Pipe blocks the write until a reader drains
+// it, so any test that doesn't intend to parse the command still needs this.
+// Errors are reported via the returned channel so we don't call t.Fatalf from
+// a non-test goroutine.
+func drainOne(conn net.Conn, timeout time.Duration) <-chan error {
+	ch := make(chan error, 1)
+	go func() {
+		_ = conn.SetReadDeadline(time.Now().Add(timeout))
+		buf := make([]byte, 4096)
+		_, err := conn.Read(buf)
+		ch <- err
+	}()
+	return ch
+}
+
+// TestClientSend_CustomReadTimeoutSucceedsAfterSlowResponse mirrors the
+// failure mode in the bead: a bd-backed handler that takes longer than the
+// old hardcoded 3s. With an explicit ReadTimeout the client waits long enough
+// to see the successful response.
+func TestClientSend_CustomReadTimeoutSucceedsAfterSlowResponse(t *testing.T) {
+	// Shrink the default so this test fails correctly if Client.Send forgets
+	// to honor the per-command ReadTimeout override.
+	prev := testOverrideDefaultReadTimeout(50 * time.Millisecond)
+	defer testOverrideDefaultReadTimeout(prev)
+
+	client, server := newPipeClient()
+	defer client.Close()
+	defer server.Close()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		_ = server.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 4096)
+		if _, err := server.Read(buf); err != nil {
+			writeDone <- err
+			return
+		}
+		// Wait longer than the (shrunken) default — proves ReadTimeout applied.
+		time.Sleep(300 * time.Millisecond)
+		resp := Response{Type: "ok", Payload: json.RawMessage(`{"message":"slow ok"}`)}
+		data, _ := json.Marshal(resp)
+		data = append(data, '\n')
+		_ = server.SetWriteDeadline(time.Now().Add(2 * time.Second))
+		_, err := server.Write(data)
+		writeDone <- err
+	}()
+
+	resp, err := client.Send(Command{Type: "slow", ReadTimeout: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("Send with generous ReadTimeout failed: %v", err)
+	}
+	if resp.Type != "ok" {
+		t.Fatalf("expected ok, got %s", resp.Type)
+	}
+	select {
+	case srvErr := <-writeDone:
+		if srvErr != nil {
+			t.Fatalf("server write: %v", srvErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server goroutine did not finish")
+	}
+}
+
+// TestClientSend_DefaultReadTimeoutFiresOnSlowResponse verifies the default
+// remains snappy so trivial commands fail quickly when the daemon is hung
+// rather than waiting for the bd-backed timeout.
+func TestClientSend_DefaultReadTimeoutFiresOnSlowResponse(t *testing.T) {
+	// Shrink the default just for this test so we don't wait 3 real seconds.
+	prev := testOverrideDefaultReadTimeout(150 * time.Millisecond)
+	defer testOverrideDefaultReadTimeout(prev)
+
+	client, server := newPipeClient()
+	defer client.Close()
+	defer server.Close()
+
+	// Drain the command from the pipe so Client.Send's write unblocks; never
+	// write a response so the read deadline must fire on its own.
+	drainErr := drainOne(server, 2*time.Second)
+
+	start := time.Now()
+	_, err := client.Send(Command{Type: "status"}) // no ReadTimeout → default
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timeout") && !strings.Contains(err.Error(), "deadline") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("default timeout fired after %v, expected well under 1s", elapsed)
+	}
+	if de := <-drainErr; de != nil {
+		// Expected: once the client closes the conn in defer, the drain read
+		// may return EOF; we only care that it didn't hang.
+		_ = de
+	}
+}
+
+// TestClientSend_ShortExplicitTimeoutIsBounded ensures a truly unresponsive
+// daemon fails within the caller's requested budget rather than hanging
+// indefinitely — the scenario the bead calls out as "genuinely dead daemon".
+func TestClientSend_ShortExplicitTimeoutIsBounded(t *testing.T) {
+	client, server := newPipeClient()
+	defer client.Close()
+	defer server.Close()
+
+	drainErr := drainOne(server, 2*time.Second)
+
+	start := time.Now()
+	_, err := client.Send(Command{Type: "status", ReadTimeout: 250 * time.Millisecond})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("explicit 250ms timeout fired after %v — should be bounded", elapsed)
+	}
+	<-drainErr
+}
+
+// TestCommand_ReadTimeoutNotSerialized keeps the new field client-only:
+// the daemon (and the JSON on the wire) must not see a nonzero field for
+// commands that don't care about it.
+func TestCommand_ReadTimeoutNotSerialized(t *testing.T) {
+	cmd := Command{Type: "run_bead", ReadTimeout: BdBackedReadTimeout}
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "ReadTimeout") || strings.Contains(string(data), "read_timeout") {
+		t.Fatalf("ReadTimeout must not appear on the wire, got %s", string(data))
 	}
 }
 


### PR DESCRIPTION
## Changes

- **IPC client per-command read deadlines** - Replaced the hardcoded 3s response timeout with a per-command `ReadTimeout` so bd-backed handlers (run_bead, force-run, merge_pr, resolve_orphan, crucible_action, pr_action) no longer fail with `reading response: i/o timeout` when bd against remote Dolt takes 10-30s. Trivial commands (status, view_logs) still use the 3s default; long-running commands opt into the 2-minute `BdBackedReadTimeout`. (Forge-14t7)

## Original Issue (bug): IPC client 3s read deadline too short for bd-backed handlers (force-run, queue, run_bead)

Forge CLI/hearth commands that go through ipc.Client.Send() fail with 'reading response: i/o timeout' when the daemon takes more than 3 seconds to respond, which is routine for anything calling bd against a remote Dolt.

## Observed

User triggered force-run on Fhi.Metadata-41rgj from hearth; got 'Failed to force-run Fhi.Metadata-41rgj: reading response: i/o timeout'.

## Root cause

internal/ipc/ipc.go:532:

    _ = c.conn.SetReadDeadline(time.Now().Add(3 * time.Second))

The client hardcodes a 3-second read deadline for all responses. But the daemon's run_bead handler (internal/daemon/daemon.go:3096+) synchronously performs substantial bd work before replying, including for ForceRun=true:

1. crucible.FetchBead -> bd show
2. poller.PollSingle -> bd ready (fallback path)
3. isBeadClarificationNeeded -> SQLite
4. GetRetry / ResetDispatchFailures -> SQLite
5. poller.ResolveEpicBranches -> more bd show / bd ready
6. worker.CanSpawn -> SQLite

Every bd subprocess is allowed up to DefaultBdTimeout = 5 * time.Minute (executil/executil.go:16) because bd against remote Dolt plus GitHub auto-sync can take 20-30s per write. The 3s client deadline is therefore mismatched with the synchronous work the handler can legitimately do.

Same issue likely affects other commands that touch bd from the daemon — anything wired through ipc.Client.Send() inherits the 3s read cap.

## Fix direction

Pick one:

- **Per-command deadlines** — Command carries a suggested timeout, Client applies it. 3s is fine for status/subscribe-ack, run_bead gets ~2 min, kill_worker somewhere in between. Simplest, preserves single-round-trip protocol.
- **Async dispatch for bd-backed commands** — Daemon acknowledges the command immediately (fast path: 'queued') and does the bd work in a goroutine, streaming progress/events via subscribe. More plumbing but also fixes UX for long operations.
- **Bump the global read deadline** to match DefaultBdTimeout. Keeps the API surface unchanged but means a truly unresponsive daemon hangs the CLI for 5 minutes. Not recommended.

Per-command deadlines is the cleanest minimal change — run_bead handlers are the main offender.

## Files

- internal/ipc/ipc.go — Client.Send (line 520), hardcoded deadlines at 527 (write 5s) and 532 (read 3s)
- internal/daemon/daemon.go — run_bead handler (line 3096+), synchronous bd calls
- cmd/forge/queue.go — forge queue run / force-run callers
- cmd/forge/hearth.go:298 — OnForceRunBead TUI callback

## Acceptance

- Force-run from hearth or 'forge queue run --force' succeeds against a bead that requires bd show + ResolveEpicBranches, even when bd against remote Dolt takes 10-30s
- Trivial commands (status) still feel snappy and don't wait for long deadlines
- Test covers: run_bead handler that sleeps 10s still yields a successful response on the client
- Test covers: genuinely dead daemon (connection hang) still fails within a reasonable bound, not indefinitely

---
Bead: Forge-14t7 | Branch: forge/Forge-14t7
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)