### PR TITLE
DecodeJSON misreads bd stdout when leading noise starts with '[' (e.g. [mysql] i/o timeout) (Forge-6wzl)

### DIFF
--- a/changelog.d/Forge-6wzl.md
+++ b/changelog.d/Forge-6wzl.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **DecodeJSON tolerates leading bracket noise from bd** - `executil.DecodeJSON` now scans every `{` (then every `[`) candidate position and decodes the first one that succeeds, so output like `[mysql] ... i/o timeout` followed by valid JSON no longer breaks schematic decomposition. Errors when no JSON is found include a bounded snippet of the raw output. (Forge-6wzl)

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -19,50 +19,85 @@ const DefaultBdTimeout = 5 * time.Minute
 // so a misbehaving subprocess can't blow up logs or downstream UIs.
 const jsonSnippetLimit = 200
 
+// maxJSONCandidates bounds the number of decode attempts in the slow path to
+// avoid O(n*m) work on outputs with many braces/brackets.
+const maxJSONCandidates = 16
+
+// maxJSONScanBytes bounds how many bytes are scanned for JSON candidates so a
+// misbehaving subprocess can't cause unbounded memory/CPU use.
+const maxJSONScanBytes = 64 * 1024
+
 // DecodeJSON decodes one JSON value from subprocess output that may contain
 // leading or trailing non-JSON noise (log lines, diagnostics, etc.).
 //
-// It first tries to decode the whole output. On failure it walks every '{'
-// position (then every '[' position) and attempts to decode starting there,
-// returning the first candidate that succeeds. This handles cases where bd
-// emits diagnostic lines like "[mysql] ... i/o timeout" or Go map prints
-// such as "debug: map[key:{inner}]" before the real JSON payload.
+// It first tries to decode the whole output. On failure it walks top-level
+// '{' positions (then top-level '[' positions) using bytes.IndexByte in a
+// streaming loop, returning the first candidate that succeeds. Only positions
+// at start-of-input or preceded by whitespace are considered, so nested
+// objects inside arrays are not treated as standalone top-level values.
+// The scan is bounded to maxJSONScanBytes bytes and maxJSONCandidates attempts.
 func DecodeJSON(data []byte, v any) error {
 	// Fast path: output is well-formed JSON (json.Decoder tolerates trailing
 	// data after a complete value, so trailing log lines are fine).
-	if err := tryDecodeJSON(data, v); err == nil {
+	fastErr := tryDecodeJSON(data, v)
+	if fastErr == nil {
 		return nil
 	}
 
-	// Slow path: scan for candidate JSON start positions. Prefer '{' over '['
-	// because bd emits JSON objects for create/update/show operations; arrays
+	// Slow path: scan for candidate top-level JSON start positions. Prefer
+	// '{' over '[' because bd emits JSON objects for most operations; arrays
 	// are only used by a handful of list endpoints.
-	for _, idx := range jsonCandidateOffsets(data, '{') {
-		if err := tryDecodeJSON(data[idx:], v); err == nil {
-			return nil
-		}
-	}
-	for _, idx := range jsonCandidateOffsets(data, '[') {
-		if err := tryDecodeJSON(data[idx:], v); err == nil {
-			return nil
-		}
+	if scanForJSON(data, '{', v) || scanForJSON(data, '[', v) {
+		return nil
 	}
 
-	return fmt.Errorf("decoding JSON from subprocess output: no valid JSON found; output snippet: %q", jsonSnippet(data, jsonSnippetLimit))
+	return fmt.Errorf("decoding JSON from subprocess output: no valid JSON found (%w); output snippet: %q",
+		fastErr, jsonSnippet(data, jsonSnippetLimit))
+}
+
+// scanForJSON iterates over top-level occurrences of byte b in data using
+// bytes.IndexByte, attempting to decode each as JSON into v. Returns true on
+// first success. Bounded by maxJSONScanBytes and maxJSONCandidates.
+func scanForJSON(data []byte, b byte, v any) bool {
+	scan := data
+	if len(scan) > maxJSONScanBytes {
+		scan = scan[:maxJSONScanBytes]
+	}
+	attempts := 0
+	for off := 0; off < len(scan); {
+		rel := bytes.IndexByte(scan[off:], b)
+		if rel < 0 {
+			break
+		}
+		abs := off + rel
+		if isTopLevelCandidate(scan, abs) {
+			if tryDecodeJSON(scan[abs:], v) == nil {
+				return true
+			}
+			attempts++
+			if attempts >= maxJSONCandidates {
+				break
+			}
+		}
+		off = abs + 1
+	}
+	return false
+}
+
+// isTopLevelCandidate reports whether the byte at idx could be the start of a
+// top-level JSON value: position 0 or preceded by whitespace. This prevents
+// nested objects (e.g. '{' inside '[{...}]') from being decoded as standalone
+// top-level values, which would mask upstream contract regressions.
+func isTopLevelCandidate(data []byte, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	prev := data[idx-1]
+	return prev == ' ' || prev == '\t' || prev == '\n' || prev == '\r'
 }
 
 func tryDecodeJSON(data []byte, v any) error {
 	return json.NewDecoder(bytes.NewReader(data)).Decode(v)
-}
-
-func jsonCandidateOffsets(data []byte, b byte) []int {
-	var out []int
-	for i := 0; i < len(data); i++ {
-		if data[i] == b {
-			out = append(out, i)
-		}
-	}
-	return out
 }
 
 func jsonSnippet(data []byte, max int) string {

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -15,29 +15,61 @@ import (
 // timeout must be generous enough to accommodate that latency.
 const DefaultBdTimeout = 5 * time.Minute
 
+// jsonSnippetLimit caps the raw output included in DecodeJSON error messages
+// so a misbehaving subprocess can't blow up logs or downstream UIs.
+const jsonSnippetLimit = 200
+
 // DecodeJSON decodes one JSON value from subprocess output that may contain
 // leading or trailing non-JSON noise (log lines, diagnostics, etc.).
-// It uses json.NewDecoder which tolerates trailing data after the JSON value,
-// and falls back to scanning for the first '{' or '[' to handle leading noise.
+//
+// It first tries to decode the whole output. On failure it walks every '{'
+// position (then every '[' position) and attempts to decode starting there,
+// returning the first candidate that succeeds. This handles cases where bd
+// emits diagnostic lines like "[mysql] ... i/o timeout" or Go map prints
+// such as "debug: map[key:{inner}]" before the real JSON payload.
 func DecodeJSON(data []byte, v any) error {
-	// Fast path: output starts with JSON (tolerates trailing noise).
-	dec := json.NewDecoder(bytes.NewReader(data))
-	fastErr := dec.Decode(v)
-	if fastErr == nil {
+	// Fast path: output is well-formed JSON (json.Decoder tolerates trailing
+	// data after a complete value, so trailing log lines are fine).
+	if err := tryDecodeJSON(data, v); err == nil {
 		return nil
 	}
 
-	// Slow path: skip leading noise by finding the first JSON delimiter.
-	if idx := bytes.IndexAny(data, "{["); idx > 0 {
-		dec = json.NewDecoder(bytes.NewReader(data[idx:]))
-		if err := dec.Decode(v); err == nil {
+	// Slow path: scan for candidate JSON start positions. Prefer '{' over '['
+	// because bd emits JSON objects for create/update/show operations; arrays
+	// are only used by a handful of list endpoints.
+	for _, idx := range jsonCandidateOffsets(data, '{') {
+		if err := tryDecodeJSON(data[idx:], v); err == nil {
 			return nil
-		} else {
-			return fmt.Errorf("decoding JSON from subprocess output: %w", err)
+		}
+	}
+	for _, idx := range jsonCandidateOffsets(data, '[') {
+		if err := tryDecodeJSON(data[idx:], v); err == nil {
+			return nil
 		}
 	}
 
-	return fmt.Errorf("decoding JSON from subprocess output: %w", fastErr)
+	return fmt.Errorf("decoding JSON from subprocess output: no valid JSON found; output snippet: %q", jsonSnippet(data, jsonSnippetLimit))
+}
+
+func tryDecodeJSON(data []byte, v any) error {
+	return json.NewDecoder(bytes.NewReader(data)).Decode(v)
+}
+
+func jsonCandidateOffsets(data []byte, b byte) []int {
+	var out []int
+	for i := 0; i < len(data); i++ {
+		if data[i] == b {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func jsonSnippet(data []byte, max int) string {
+	if len(data) <= max {
+		return string(data)
+	}
+	return string(data[:max]) + "..."
 }
 
 // HideWindow configures cmd to not create a visible console window.

--- a/internal/executil/executil_test.go
+++ b/internal/executil/executil_test.go
@@ -73,11 +73,11 @@ func TestDecodeJSON(t *testing.T) {
 			wantID: "real",
 		},
 		{
-			// Caller asked for an object but bd returned an array. The scanner
-			// walks past the leading '[' and finds the inner object.
-			name:   "JSON array into struct extracts first object",
-			input:  "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
-			wantID: "xyz",
+			// Caller asked for an object but bd returned an array. Treat this as
+			// a contract error rather than extracting a nested object.
+			name:    "JSON array into struct returns error",
+			input:   "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
+			wantErr: true,
 		},
 	}
 

--- a/internal/executil/executil_test.go
+++ b/internal/executil/executil_test.go
@@ -1,6 +1,7 @@
 package executil
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -51,9 +52,32 @@ func TestDecodeJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "JSON array into struct",
-			input:   "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
-			wantErr: true,
+			// bd's mysql driver writes diagnostics like
+			// "[mysql] 2026/04/20 13:51:06 packets.go:58 read tcp ...: i/o timeout"
+			// to stdout when the Dolt port-forward flaps. The leading '[' used
+			// to break the slow path because bytes.IndexAny returned 0.
+			name:   "mysql noise prefix",
+			input:  "[mysql] 2026/04/20 13:51:06 packets.go:58 read tcp 127.0.0.1:64547->127.0.0.1:3306: i/o timeout\nWarning: failed to add dependency ...\n{\"id\":\"Fhi.Metadata-gob8k\"}\n",
+			wantID: "Fhi.Metadata-gob8k",
+		},
+		{
+			name:   "timestamped noise prefix",
+			input:  "[2026-04-20 13:51:06] warning foo\n{\"id\":\"abc\"}\n",
+			wantID: "abc",
+		},
+		{
+			// First '{' is inside a Go map print and isn't valid JSON on its
+			// own — the scanner must advance past it to the real payload.
+			name:   "first brace is decoy",
+			input:  "debug: map[key:{inner}]\n{\"id\":\"real\"}\n",
+			wantID: "real",
+		},
+		{
+			// Caller asked for an object but bd returned an array. The scanner
+			// walks past the leading '[' and finds the inner object.
+			name:   "JSON array into struct extracts first object",
+			input:  "[{\"id\":\"xyz\"}]\ntrailing stuff\n",
+			wantID: "xyz",
 		},
 	}
 
@@ -74,6 +98,55 @@ func TestDecodeJSON(t *testing.T) {
 				t.Errorf("ID = %q, want %q", got.ID, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestDecodeJSON_NoValidJSONIncludesSnippet(t *testing.T) {
+	type obj struct {
+		ID string `json:"id"`
+	}
+	input := "[mysql] total garbage no json here\n"
+	var got obj
+	err := DecodeJSON([]byte(input), &got)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no valid JSON found") {
+		t.Errorf("error %q does not mention failure mode", msg)
+	}
+	if !strings.Contains(msg, "[mysql]") {
+		t.Errorf("error %q does not include raw output snippet", msg)
+	}
+}
+
+func TestDecodeJSON_LongInputSnippetTruncated(t *testing.T) {
+	type obj struct {
+		ID string `json:"id"`
+	}
+	// 500 bytes of noise, no JSON anywhere.
+	input := strings.Repeat("x", 500)
+	var got obj
+	err := DecodeJSON([]byte(input), &got)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "...") {
+		t.Errorf("expected truncation marker in error, got: %v", err)
+	}
+}
+
+func TestDecodeJSON_ArrayWithNoisePrefix(t *testing.T) {
+	type item struct {
+		Name string `json:"name"`
+	}
+	input := "[mysql] some warning\n[{\"name\":\"first\"},{\"name\":\"second\"}]\n"
+	var got []item
+	if err := DecodeJSON([]byte(input), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "first" || got[1].Name != "second" {
+		t.Errorf("got %+v, want [{first} {second}]", got)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **DecodeJSON tolerates leading bracket noise from bd** - `executil.DecodeJSON` now scans every `{` (then every `[`) candidate position and decodes the first one that succeeds, so output like `[mysql] ... i/o timeout` followed by valid JSON no longer breaks schematic decomposition. Errors when no JSON is found include a bounded snippet of the raw output. (Forge-6wzl)

## Original Issue (bug): DecodeJSON misreads bd stdout when leading noise starts with '[' (e.g. [mysql] i/o timeout)

When bd talks to a flaky Dolt (e.g. port-forward drop) it retries internally and eventually produces valid JSON, but it first spits diagnostic lines like '[mysql] 2026/04/20 13:51:06 packets.go:58 read tcp 127.0.0.1:64547->127.0.0.1:3306: i/o timeout' to stdout. Forge's executil.DecodeJSON fails to parse these outputs, breaking schematic decomposition even when bd ultimately succeeded.

## Observed failure

Schematic for Fhi.Metadata-d2xrc and Fhi.Metadata-g8jjw on 2026-04-20 13:51-13:57 hit 'parsing sub-bead ID from output: decoding JSON from subprocess output: invalid character m looking for beginning of value'. Root cause was kubectl port-forward to Dolt flapping during that window. The actual bd stdout was:

    [mysql] 2026/04/20 13:51:06 packets.go:58 read tcp 127.0.0.1:64547->127.0.0.1:3306: i/o timeout
    Warning: failed to add dependency ...
    { "id": "Fhi.Metadata-gob8k", ... }

## Root cause

internal/executil/executil.go:31:

    if idx := bytes.IndexAny(data, "{["); idx > 0 {

Two problems:

1. IndexAny returns 0 when the first char of the noise is '['. The 'idx > 0' check is false, so the slow path is skipped and we return the fast-path parse error.
2. Even if the check were '>= 0', the decoder starting at '[mysql]' fails because '[mysql]' is not valid JSON. The current slow path only tries the first bracket-like character — any decoy poisons the decode.

## Fix

Scan every '{' (and optionally '[') position in the output and attempt to decode at each candidate until one succeeds. Prefer '{' over '[' as the primary candidate since bd emits JSON objects for create/update/show operations. Return a helpful error including a bounded snippet of the raw output when all candidates fail.

## Acceptance

- Add test cases to internal/executil/executil_test.go covering:
  - Output starting with '[mysql] ... i/o timeout\n ... {...valid json...}'
  - Output starting with '[2026-04-20 13:51:06] warning ... {...valid json...}'
  - Output with multiple '{' where the first is inside a noise line (e.g. part of a Go map print) and the second is the real payload
  - Purely invalid output (no parseable JSON anywhere) still returns a clear error
- schematic.createSubBeads succeeds on bd output that has [mysql] leading noise before the JSON object
- No regression in existing fast-path behavior for clean JSON output

---
Bead: Forge-6wzl | Branch: forge/Forge-6wzl
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)