### PR TITLE
PR 'Changes' section leaks warden verdict when changelog fragments use suffixed filenames (Forge-2dnw)

### DIFF
--- a/changelog.d/Forge-2dnw.md
+++ b/changelog.d/Forge-2dnw.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **PR 'Changes' section no longer leaks warden verdict** - Changelog fragment lookup now globs suffixed filenames (e.g. `<beadID>-technical.en.md`) in addition to the plain `<beadID>.md` / `<beadID>.en.md` convention, and warden approval text is rendered under a separate `## Reviewer's approval notes` heading instead of masquerading as a changelog bullet under `## Changes`. (Forge-2dnw)

--- a/internal/crucible/crucible.go
+++ b/internal/crucible/crucible.go
@@ -197,11 +197,13 @@ func Run(ctx context.Context, p Params) *Result {
 
 			// If parent produced changes, create a PR and merge into the feature branch.
 			if parentHasWork && parentOutcome.Branch != "" {
-				var changeSummary string
+				// Keep the warden verdict out of '## Changes' — route it to the
+				// reviewer-notes section when no changelog fragment exists.
+				var parentChangelogSummary, parentReviewerNotes string
 				if parentOutcome.ChangelogSummary != "" {
-					changeSummary = parentOutcome.ChangelogSummary
+					parentChangelogSummary = parentOutcome.ChangelogSummary
 				} else if parentOutcome.ReviewResult != nil && parentOutcome.ReviewResult.Summary != "" {
-					changeSummary = parentOutcome.ReviewResult.Summary
+					parentReviewerNotes = parentOutcome.ReviewResult.Summary
 				}
 
 				pr, err := p.createPR(ctx, vcs.CreateParams{
@@ -214,7 +216,8 @@ func Run(ctx context.Context, p Params) *Result {
 					BeadTitle:       p.ParentBead.Title,
 					BeadDescription: p.ParentBead.Description,
 					BeadType:        p.ParentBead.IssueType,
-					ChangeSummary:   changeSummary,
+					ChangeSummary:   parentChangelogSummary,
+					ReviewerNotes:   parentReviewerNotes,
 					ExternalRef:     p.ParentBead.ExternalRef,
 				})
 				if err != nil {
@@ -410,12 +413,14 @@ func Run(ctx context.Context, p Params) *Result {
 			}
 		}
 
-		// Build change summary preferring the changelog fragment, falling back to Warden review.
-		var childChangeSummary string
+		// Prefer the author-written changelog fragment for '## Changes'; fall
+		// back to the warden verdict under a distinct reviewer-notes section
+		// so review-speak does not masquerade as a changelog bullet.
+		var childChangelogSummary, childReviewerNotes string
 		if childResult.ChangelogSummary != "" {
-			childChangeSummary = childResult.ChangelogSummary
+			childChangelogSummary = childResult.ChangelogSummary
 		} else if childResult.ReviewResult != nil && childResult.ReviewResult.Summary != "" {
-			childChangeSummary = childResult.ReviewResult.Summary
+			childReviewerNotes = childResult.ReviewResult.Summary
 		}
 
 		// Create PR from child branch → feature branch.
@@ -429,7 +434,8 @@ func Run(ctx context.Context, p Params) *Result {
 			BeadTitle:       child.Title,
 			BeadDescription: child.Description,
 			BeadType:        child.IssueType,
-			ChangeSummary:   childChangeSummary,
+			ChangeSummary:   childChangelogSummary,
+			ReviewerNotes:   childReviewerNotes,
 			ExternalRef:     child.ExternalRef,
 		})
 		if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2434,13 +2434,15 @@ normalPipeline:
 func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome, bead poller.Bead, anvilPath, workerID string) {
 	d.logger.Info("pipeline succeeded", "bead", bead.ID, "branch", outcome.Branch, "iterations", outcome.Iterations)
 
-	// Build a change summary for the PR description.
-	// Priority: ChangelogSummary > ReviewResult.Summary.
-	var changeSummary string
+	// Build the PR body's summary sections.
+	// ChangeSummary is reserved for the author-written changelog fragment;
+	// the warden verdict is routed to ReviewerNotes so it never leaks into
+	// the '## Changes' section when no fragment exists.
+	var changelogSummary, reviewerNotes string
 	if outcome.ChangelogSummary != "" {
-		changeSummary = outcome.ChangelogSummary
+		changelogSummary = outcome.ChangelogSummary
 	} else if outcome.ReviewResult != nil && outcome.ReviewResult.Summary != "" {
-		changeSummary = outcome.ReviewResult.Summary
+		reviewerNotes = outcome.ReviewResult.Summary
 	}
 
 	// Last-chance lookup: fetch the latest external_ref from bd in case it
@@ -2460,7 +2462,8 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 		BeadTitle:       bead.Title,
 		BeadDescription: bead.Description,
 		BeadType:        bead.IssueType,
-		ChangeSummary:   changeSummary,
+		ChangeSummary:   changelogSummary,
+		ReviewerNotes:   reviewerNotes,
 		ExternalRef:     externalRef,
 	})
 	if err != nil {
@@ -5432,9 +5435,15 @@ func (d *Daemon) handleWardenRerun(beadID, anvil, branch string, anvilCfg config
 			d.logger.Warn("warden_rerun: push failed (may already be up-to-date)", "error", pushErr)
 		}
 
-		var changeSummary string
-		if result.Summary != "" {
-			changeSummary = result.Summary
+		// Prefer a changelog fragment (if the rerun worktree has one) for the
+		// '## Changes' section and keep the warden verdict in ReviewerNotes so
+		// review-speak never appears under '## Changes'.
+		var changelogSummary, reviewerNotes string
+		if wt != nil {
+			changelogSummary = pipeline.ExtractChangelogSummary(wt.Path, beadID)
+		}
+		if changelogSummary == "" && result.Summary != "" {
+			reviewerNotes = result.Summary
 		}
 
 		pr, err := d.vcsForAnvil(anvil).CreatePR(ctx, vcs.CreateParams{
@@ -5446,7 +5455,8 @@ func (d *Daemon) handleWardenRerun(beadID, anvil, branch string, anvilCfg config
 			AnvilName:       anvil,
 			BeadTitle:       title,
 			BeadDescription: description,
-			ChangeSummary:   changeSummary,
+			ChangeSummary:   changelogSummary,
+			ReviewerNotes:   reviewerNotes,
 			ExternalRef:     rerunExternalRef,
 		})
 		if err != nil {
@@ -5517,6 +5527,14 @@ func (d *Daemon) handleApproveAsIs(beadID, anvil, branch string, anvilCfg config
 		baseBranch = beads[0].EpicBranch
 	}
 
+	// Prefer a changelog fragment for '## Changes' when the worktree has one;
+	// otherwise leave the section empty and record the manual-bypass note as
+	// a reviewer note instead of polluting the changelog section.
+	var approveChangelogSummary, approveReviewerNotes string
+	if approveChangelogSummary = pipeline.ExtractChangelogSummary(wt.Path, beadID); approveChangelogSummary == "" {
+		approveReviewerNotes = "Approved as-is (manual bypass)"
+	}
+
 	pr, err := d.vcsForAnvil(anvil).CreatePR(ctx, vcs.CreateParams{
 		WorktreePath:    anvilCfg.Path,
 		BeadID:          beadID,
@@ -5526,7 +5544,8 @@ func (d *Daemon) handleApproveAsIs(beadID, anvil, branch string, anvilCfg config
 		AnvilName:       anvil,
 		BeadTitle:       title,
 		BeadDescription: description,
-		ChangeSummary:   "Approved as-is (manual bypass)",
+		ChangeSummary:   approveChangelogSummary,
+		ReviewerNotes:   approveReviewerNotes,
 		ExternalRef:     approveExtRef,
 	})
 	if err != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -1441,7 +1442,7 @@ func Run(ctx context.Context, p Params) *Outcome {
 				logIngotErr(workerID, "approved", ingot.UpdateIngotStatus(p.DB.Conn(), p.Bead.ID, p.AnvilName, ingot.StatusApproved))
 			}
 
-			outcome.ChangelogSummary = extractChangelogSummary(wt.Path, p.Bead.ID)
+			outcome.ChangelogSummary = ExtractChangelogSummary(wt.Path, p.Bead.ID)
 
 			// Ensure the branch is pushed to the remote before the worktree
 			// is cleaned up. Smith is instructed to push, but as a safety net
@@ -1881,16 +1882,30 @@ func copyFile(src, dst string) (err error) {
 	return nil
 }
 
-// extractChangelogSummary attempts to parse a Smith changelog fragment from the worktree
-// and returns the bullet points as a single string. It falls back to .en.md if necessary.
-func extractChangelogSummary(wtPath, beadID string) string {
-	// Try the primary fragment.
-	if frag, err := changelog.ParseFragment(filepath.Join(wtPath, "changelog.d", beadID+".md")); err == nil {
-		return strings.Join(frag.Bullets, "\n")
+// ExtractChangelogSummary attempts to parse a Smith changelog fragment from the
+// worktree and returns the bullet points as a single string. It searches a
+// prioritized set of filename patterns so repositories that use suffixed
+// fragment names (e.g. <beadID>-technical.en.md) are covered in addition to the
+// canonical <beadID>.md / <beadID>.en.md variants. English fragments win over
+// Norwegian when both are present.
+func ExtractChangelogSummary(wtPath, beadID string) string {
+	dir := filepath.Join(wtPath, "changelog.d")
+	patterns := []string{
+		beadID + ".en.md",
+		beadID + ".md",
+		beadID + "-*.en.md",
+		beadID + "-*.md",
+		beadID + ".nb.md",
+		beadID + "-*.nb.md",
 	}
-	// Fallback to the legacy .en.md extension if the primary fragment is missing or invalid.
-	if frag, err := changelog.ParseFragment(filepath.Join(wtPath, "changelog.d", beadID+".en.md")); err == nil {
-		return strings.Join(frag.Bullets, "\n")
+	for _, p := range patterns {
+		matches, _ := filepath.Glob(filepath.Join(dir, p))
+		sort.Strings(matches) // deterministic pick when multiple files match
+		for _, path := range matches {
+			if frag, err := changelog.ParseFragment(path); err == nil && len(frag.Bullets) > 0 {
+				return strings.Join(frag.Bullets, "\n")
+			}
+		}
 	}
 	return ""
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1886,16 +1886,17 @@ func copyFile(src, dst string) (err error) {
 // worktree and returns the bullet points as a single string. It searches a
 // prioritized set of filename patterns so repositories that use suffixed
 // fragment names (e.g. <beadID>-technical.en.md) are covered in addition to the
-// canonical <beadID>.md / <beadID>.en.md variants. English fragments win over
-// Norwegian when both are present.
+// canonical exact-name variants. The canonical <beadID>.md is preferred over
+// the legacy <beadID>.en.md fallback, plain <beadID>.nb.md remains lower
+// priority, and suffixed variants are checked last.
 func ExtractChangelogSummary(wtPath, beadID string) string {
 	dir := filepath.Join(wtPath, "changelog.d")
 	patterns := []string{
-		beadID + ".en.md",
 		beadID + ".md",
-		beadID + "-*.en.md",
-		beadID + "-*.md",
+		beadID + ".en.md",
 		beadID + ".nb.md",
+		beadID + "-*.md",
+		beadID + "-*.en.md",
 		beadID + "-*.nb.md",
 	}
 	for _, p := range patterns {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1750,3 +1750,91 @@ func TestCombinedMode_FallbackProvider_RunsNormalWarden(t *testing.T) {
 	assert.True(t, outcome.Success)
 	assert.True(t, wardenCalled, "real Warden must run when Smith fell back to a non-Copilot provider")
 }
+
+// writeFragment writes a changelog fragment with the given filename in the
+// worktree's changelog.d directory.
+func writeFragment(t *testing.T, wtPath, filename, content string) {
+	t.Helper()
+	dir := filepath.Join(wtPath, "changelog.d")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644))
+}
+
+// TestExtractChangelogSummary covers the full matrix of fragment filename
+// variants that real anvils produce, including the Munin-style suffixed names
+// that used to fall through to the warden verdict fallback.
+func TestExtractChangelogSummary(t *testing.T) {
+	const bead = "Forge-abcd"
+	const enBullet = "- **Plain EN bullet** - detail. (Forge-abcd)"
+	const plainBullet = "- **Plain bullet** - detail. (Forge-abcd)"
+	const techEnBullet = "- **Technical EN bullet** - detail. (Forge-abcd)"
+	const techNbBullet = "- **Technical NB bullet** - detalj. (Forge-abcd)"
+	const nbBullet = "- **Plain NB bullet** - detalj. (Forge-abcd)"
+	const header = "category: Added\n"
+
+	t.Run("plain .md fragment", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFragment(t, dir, bead+".md", header+plainBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Plain bullet")
+	})
+
+	t.Run("plain .en.md fragment", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFragment(t, dir, bead+".en.md", header+enBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Plain EN bullet")
+	})
+
+	t.Run("suffixed -technical.en.md fragment (Munin convention)", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFragment(t, dir, bead+"-technical.en.md", header+techEnBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Technical EN bullet",
+			"Munin-style -technical.en.md fragment must be picked up (was previously leaking warden verdict)")
+	})
+
+	t.Run("English preferred over Norwegian for plain fragments", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFragment(t, dir, bead+".en.md", header+enBullet+"\n")
+		writeFragment(t, dir, bead+".nb.md", header+nbBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Plain EN bullet")
+		assert.NotContains(t, got, "Plain NB bullet")
+	})
+
+	t.Run("English preferred over Norwegian for suffixed fragments", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFragment(t, dir, bead+"-technical.en.md", header+techEnBullet+"\n")
+		writeFragment(t, dir, bead+"-technical.nb.md", header+techNbBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Technical EN bullet")
+		assert.NotContains(t, got, "Technical NB bullet")
+	})
+
+	t.Run("no fragment returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("fragment with zero bullets falls through", func(t *testing.T) {
+		dir := t.TempDir()
+		// A category-only fragment with no bullets must not masquerade as a
+		// successful match; the next pattern should win instead.
+		writeFragment(t, dir, bead+".en.md", "category: Added\n")
+		writeFragment(t, dir, bead+"-technical.en.md", header+techEnBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Technical EN bullet",
+			"zero-bullet fragment must not short-circuit the pattern search")
+	})
+
+	t.Run("plain .md preferred over suffixed variant", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFragment(t, dir, bead+".md", header+plainBullet+"\n")
+		writeFragment(t, dir, bead+"-technical.en.md", header+techEnBullet+"\n")
+		got := ExtractChangelogSummary(dir, bead)
+		assert.Contains(t, got, "Plain bullet")
+		assert.NotContains(t, got, "Technical EN bullet")
+	})
+}

--- a/internal/vcs/github/github.go
+++ b/internal/vcs/github/github.go
@@ -822,9 +822,18 @@ func commitSubject(ctx context.Context, worktreePath, branch string) string {
 func buildDefaultBody(p vcs.CreateParams) string {
 	var b strings.Builder
 
+	// The '## Changes' section is reserved for the author-written changelog
+	// fragment. Warden/reviewer notes are rendered below under a distinct
+	// heading to avoid making review-speak look like a changelog bullet.
 	if p.ChangeSummary != "" {
 		b.WriteString("## Changes\n\n")
 		b.WriteString(p.ChangeSummary)
+		b.WriteString("\n\n")
+	}
+
+	if p.ReviewerNotes != "" {
+		b.WriteString("## Reviewer's approval notes\n\n")
+		b.WriteString(p.ReviewerNotes)
 		b.WriteString("\n\n")
 	}
 

--- a/internal/vcs/github/github_test.go
+++ b/internal/vcs/github/github_test.go
@@ -117,6 +117,38 @@ func TestBuildDefaultBody(t *testing.T) {
 			absent: []string{
 				"## Changes",
 				"## Original Issue",
+				"## Reviewer's approval notes",
+			},
+		},
+		{
+			name: "reviewer notes render under separate heading, never under ## Changes",
+			params: vcs.CreateParams{
+				BeadID:        "Forge-abc4",
+				Branch:        "forge/Forge-abc4",
+				ReviewerNotes: "Clean documentation-only lift of Dieter Rams design principles.",
+			},
+			contains: []string{
+				"## Reviewer's approval notes",
+				"Clean documentation-only lift",
+				"Bead: Forge-abc4 | Branch: forge/Forge-abc4",
+			},
+			absent: []string{
+				"## Changes",
+			},
+		},
+		{
+			name: "both change summary and reviewer notes render in their own sections",
+			params: vcs.CreateParams{
+				BeadID:        "Forge-abc5",
+				Branch:        "forge/Forge-abc5",
+				ChangeSummary: "- **Widget** - Added widget.",
+				ReviewerNotes: "LGTM with minor nits.",
+			},
+			contains: []string{
+				"## Changes",
+				"- **Widget** - Added widget.",
+				"## Reviewer's approval notes",
+				"LGTM with minor nits.",
 			},
 		},
 	}
@@ -132,6 +164,26 @@ func TestBuildDefaultBody(t *testing.T) {
 			}
 		})
 	}
+
+	// Regression: a warden verdict passed as ReviewerNotes must never appear
+	// inside the '## Changes' section. This is the root of the bug the bead
+	// was filed for — review-speak leaking under Changes when no changelog
+	// fragment is available.
+	t.Run("warden verdict never leaks into ## Changes", func(t *testing.T) {
+		body := buildDefaultBody(vcs.CreateParams{
+			BeadID:        "Forge-leak",
+			Branch:        "forge/Forge-leak",
+			ReviewerNotes: "Clean documentation-only lift of Dieter Rams design principles.",
+		})
+		changesIdx := strings.Index(body, "## Changes")
+		assert.Equal(t, -1, changesIdx, "no '## Changes' section should be emitted when only ReviewerNotes is set")
+		notesIdx := strings.Index(body, "## Reviewer's approval notes")
+		assert.NotEqual(t, -1, notesIdx, "reviewer notes heading must be present")
+		// The verdict text must live under the reviewer-notes heading, not
+		// anywhere above a '## Changes' heading that doesn't exist.
+		verdictIdx := strings.Index(body, "Clean documentation-only lift")
+		assert.Greater(t, verdictIdx, notesIdx, "verdict text must follow reviewer notes heading")
+	})
 }
 
 // makeTestRepo creates a temporary git repository with a single commit using

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -84,10 +84,18 @@ func InjectClosesLine(body, externalRef string) string {
 func buildPRBody(p CreateParams) string {
 	var b strings.Builder
 
-	// Lead with change summary (English, from Warden review) when available.
+	// Lead with the author-written change summary (changelog fragment) when
+	// available. The warden verdict is intentionally NOT rendered here — it
+	// lives in a separate section below so reviewers can tell the two apart.
 	if p.ChangeSummary != "" {
 		b.WriteString("## Changes\n\n")
 		b.WriteString(p.ChangeSummary)
+		b.WriteString("\n\n")
+	}
+
+	if p.ReviewerNotes != "" {
+		b.WriteString("## Reviewer's approval notes\n\n")
+		b.WriteString(p.ReviewerNotes)
 		b.WriteString("\n\n")
 	}
 
@@ -238,8 +246,15 @@ type CreateParams struct {
 	BeadDescription string
 	// BeadType is the bead's issue type (bug, feature, task, etc.).
 	BeadType string
-	// ChangeSummary is a summary of what changed (from warden review or diff stat).
+	// ChangeSummary is the author-written summary of what changed. It is
+	// rendered under the '## Changes' heading in the PR body and is sourced
+	// from a parsed changelog fragment — never from the warden review verdict.
 	ChangeSummary string
+	// ReviewerNotes is an approval/review-speak summary produced by the Warden
+	// (or any other reviewer) to be rendered under a separate heading. It is
+	// intentionally kept distinct from ChangeSummary so warden verdicts do not
+	// leak into the '## Changes' section when a changelog fragment is missing.
+	ReviewerNotes string
 	// ExternalRef is an optional external tracker reference (e.g. "gh-42" or a
 	// GitHub issue URL). When it identifies a GitHub issue, buildPRBody injects
 	// a "Closes #N" line so the PR auto-closes the issue on merge.

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -395,6 +395,33 @@ func TestBuildPRBody_ExternalRef(t *testing.T) {
 	})
 }
 
+func TestBuildPRBody_ReviewerNotes(t *testing.T) {
+	t.Run("reviewer notes render under dedicated heading, not under Changes", func(t *testing.T) {
+		body := buildPRBody(CreateParams{
+			BeadID:        "Forge-test",
+			Branch:        "forge/test",
+			ReviewerNotes: "LGTM — clean refactor.",
+		})
+		assert.NotContains(t, body, "## Changes",
+			"reviewer notes alone must not cause a '## Changes' section to appear")
+		assert.Contains(t, body, "## Reviewer's approval notes")
+		assert.Contains(t, body, "LGTM — clean refactor.")
+	})
+
+	t.Run("change summary and reviewer notes both render in their own sections", func(t *testing.T) {
+		body := buildPRBody(CreateParams{
+			BeadID:        "Forge-test",
+			Branch:        "forge/test",
+			ChangeSummary: "- **Widget** - Added widget.",
+			ReviewerNotes: "Approved.",
+		})
+		assert.Contains(t, body, "## Changes")
+		assert.Contains(t, body, "- **Widget** - Added widget.")
+		assert.Contains(t, body, "## Reviewer's approval notes")
+		assert.Contains(t, body, "Approved.")
+	})
+}
+
 func TestMergeabilityFromStatus(t *testing.T) {
 	s := &PRStatus{
 		Mergeable:         "CONFLICTING",


### PR DESCRIPTION
## Changes

- **PR 'Changes' section no longer leaks warden verdict** - Changelog fragment lookup now globs suffixed filenames (e.g. `<beadID>-technical.en.md`) in addition to the plain `<beadID>.md` / `<beadID>.en.md` convention, and warden approval text is rendered under a separate `## Reviewer's approval notes` heading instead of masquerading as a changelog bullet under `## Changes`. (Forge-2dnw)

## Original Issue (bug): PR 'Changes' section leaks warden verdict when changelog fragments use suffixed filenames

Forge-generated PR bodies put warden's approval verdict under '## Changes' whenever the repo's changelog fragments don't match the exact filename patterns extractChangelogSummary looks for. Reviewers see evaluative review-speak ('Clean documentation-only lift...') where they expect a concrete changelog bullet ('Added X to file Y').

## Observed

PR FHIDev/Munin#2488 (bead Fhi.Metadata-6j80o):

    ## Changes
    Clean documentation-only lift of Dieter Rams design principles and the
    KildeDetail prototype/production boundaries table, with correct bilingual
    changelog fragments.

That text is the warden's approve-verdict summary. The actual changelog fragment (which is what should have rendered there) is at changelog.d/Fhi.Metadata-6j80o-technical.en.md:

    - **Agent design guidance** - Added `.github/instructions/design.instructions.md` with Dieter Rams' 10 principles and a project risk matrix, plus a "KildeDetail Storybook - Prototype vs. Production Boundaries" section in `client.instructions.md` ... (Fhi.Metadata-6j80o)

Author-written, concrete, file-level. Exactly what reviewers want under Changes.

## Root cause

internal/pipeline/pipeline.go:1884 - extractChangelogSummary:

    if frag, err := changelog.ParseFragment(filepath.Join(wtPath, "changelog.d", beadID+".md")); err == nil {
        return strings.Join(frag.Bullets, "\n")
    }
    if frag, err := changelog.ParseFragment(filepath.Join(wtPath, "changelog.d", beadID+".en.md")); err == nil {
        return strings.Join(frag.Bullets, "\n")
    }
    return ""

Only matches <beadID>.md or <beadID>.en.md. Munin convention is <beadID>-technical.en.md / <beadID>-technical.nb.md (also some plain <beadID>.en.md / <beadID>.nb.md). Glob is blind to the suffixed filenames - fragment ignored, fallback in daemon.go:2442 fires:

    } else if outcome.ReviewResult != nil && outcome.ReviewResult.Summary != "" {
        changeSummary = outcome.ReviewResult.Summary
    }

Warden summary then flows into internal/vcs/github/github.go:825 under the '## Changes' header. Every PR from the Munin anvil is affected.

## Fix

Two small changes, complementary:

### A. Broaden extractChangelogSummary to glob the whole naming space

Replace strict path lookups with a prioritized glob list that prefers English, handles plain and suffixed variants, and picks the first non-empty bullet set:

    func extractChangelogSummary(wtPath, beadID string) string {
        dir := filepath.Join(wtPath, "changelog.d")
        patterns := []string{
            beadID + ".en.md",
            beadID + ".md",
            beadID + "-*.en.md",
            beadID + "-*.md",
            beadID + ".nb.md",
            beadID + "-*.nb.md",
        }
        for _, p := range patterns {
            matches, _ := filepath.Glob(filepath.Join(dir, p))
            sort.Strings(matches) // deterministic pick
            for _, path := range matches {
                if frag, err := changelog.ParseFragment(path); err == nil && len(frag.Bullets) > 0 {
                    return strings.Join(frag.Bullets, "\n")
                }
            }
        }
        return ""
    }

Tests: cover <beadID>.md, <beadID>.en.md, <beadID>-technical.en.md, and English-preferred-over-Norwegian when both exist.

### D. Don't promote warden verdict to '## Changes' - relabel the fallback

In internal/vcs/github/github.go buildDefaultBody (and gitea.go / gitlab.go equivalents), thread a provenance flag through vcs.CreateParams (or split into ChangelogSummary + ReviewerNotes fields). Render:

- ChangelogSummary -> '## Changes'
- ReviewerNotes    -> '## Reviewer's approval notes' (or similar)
- Neither present  -> omit the section entirely

Plumbing: in daemon.go:2437-2444 split the current single changeSummary assignment into two fields on CreateParams; in vcs/vcs.go add ReviewerNotes alongside ChangeSummary.

## Files

- internal/pipeline/pipeline.go:1884 - extractChangelogSummary (the glob)
- internal/daemon/daemon.go:2437-2463, :5449, :5529 - ChangeSummary assignment sites
- internal/vcs/vcs.go:241 - ChangeSummary field (add ReviewerNotes)
- internal/vcs/github/github.go:822-856 - buildDefaultBody rendering
- internal/vcs/gitea.go / gitlab.go - same pattern
- internal/pipeline/pipeline_test.go - fragment-matching tests

## Acceptance

- Regenerated PR body for a Munin bead with a <beadID>-technical.en.md fragment puts the fragment bullets under '## Changes', not warden text.
- A bead with NO changelog fragment produces a PR body with either no Changes section, or a separate '## Reviewer's approval notes' section carrying the warden verdict - never '## Changes: <warden-speak>'.
- Existing behavior preserved for anvils that use the plain <beadID>.md / <beadID>.en.md convention.
- Unit tests cover: plain, .en.md, -technical.en.md, English-preferred, no-fragment, fragment-with-zero-bullets.

## Out of scope

- Per-anvil changelog_pattern config - overkill once the glob covers the known variants. Revisit only if a new repo uses a scheme the glob can't catch.
- Smith-generated PR descriptions - deferred; fragment content is higher quality than auto-generated text so long as A works.
- Git diff --stat as an auto-Changes source - duplicates GitHub's Files Changed tab.

---
Bead: Forge-2dnw | Branch: forge/Forge-2dnw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)