### PR TITLE
Add per-anvil conventions injection slot to Smith prompt template (Forge-lr5j)

### DIFF
--- a/changelog.d/Forge-lr5j.md
+++ b/changelog.d/Forge-lr5j.md
@@ -1,0 +1,2 @@
+category: Added
+- **Per-anvil conventions injection in Smith prompt** - Smith now reads `.forge/conventions.md` from each anvil and injects it as a `## Project Rules (Non-Negotiable)` section between Instructions and Escalation, giving project-specific rules a proactive upfront slot instead of relying on reactive lookups into appended AGENTS.md/CLAUDE.md context. (Forge-lr5j)

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -96,10 +96,11 @@ func (b *Builder) Build(ctx BeadContext) (string, error) {
 
 	// Gather repo context files
 	data := templateData{
-		Bead:     ctx,
-		AgentsMD: readFileSafe(filepath.Join(ctx.AnvilPath, "AGENTS.md")),
-		ClaudeMD: readFileSafe(filepath.Join(ctx.AnvilPath, "CLAUDE.md")),
-		ReadmeMD: readFileSafe(filepath.Join(ctx.AnvilPath, "README.md")),
+		Bead:          ctx,
+		AgentsMD:      readFileSafe(filepath.Join(ctx.AnvilPath, "AGENTS.md")),
+		ClaudeMD:      readFileSafe(filepath.Join(ctx.AnvilPath, "CLAUDE.md")),
+		ReadmeMD:      readFileSafe(filepath.Join(ctx.AnvilPath, "README.md")),
+		ConventionsMD: readFileSafe(filepath.Join(ctx.AnvilPath, ".forge", "conventions.md")),
 	}
 
 	var buf bytes.Buffer
@@ -140,10 +141,11 @@ func LoadCustomTemplate(anvilPath string) string {
 
 // templateData is the full set of data available to the prompt template.
 type templateData struct {
-	Bead     BeadContext
-	AgentsMD string
-	ClaudeMD string
-	ReadmeMD string
+	Bead          BeadContext
+	AgentsMD      string
+	ClaudeMD      string
+	ReadmeMD      string
+	ConventionsMD string
 }
 
 // wardenRulesPlaceholder is a sentinel string that is never valid prompt
@@ -236,6 +238,12 @@ environment for other workers.
 6. **Push your branch** to the remote: git push -u origin {{.Bead.Branch}}
 7. **Do not create a PR** — that will be handled by the orchestrator
 8. **Do not close the bead** — the orchestrator closes it automatically after the PR merges
+{{- if .ConventionsMD}}
+
+## Project Rules (Non-Negotiable)
+
+{{.ConventionsMD}}
+{{- end}}
 
 ## Escalation — When to Ask for Human Help
 

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -286,6 +286,126 @@ func TestBuild_ExternalRefGhShorthandRendered(t *testing.T) {
 	assert.Contains(t, result, "gh-42")
 }
 
+func TestBuild_ConventionsRenderedWhenFilePresent(t *testing.T) {
+	anvilDir := t.TempDir()
+	forgeDir := filepath.Join(anvilDir, ".forge")
+	require.NoError(t, os.MkdirAll(forgeDir, 0o755))
+
+	conventions := "- Bilingual changelog fragments required (en + nb).\n- All stories must have a Storybook file.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(forgeDir, "conventions.md"), []byte(conventions), 0o644))
+
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-conv-present",
+		Title:        "Test with conventions",
+		Description:  "Do the thing",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-conv-present",
+		AnvilName:    "test-anvil",
+		AnvilPath:    anvilDir,
+		WorktreePath: t.TempDir(),
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "## Project Rules (Non-Negotiable)")
+	assert.Contains(t, result, "Bilingual changelog fragments required")
+	assert.Contains(t, result, "All stories must have a Storybook file.")
+}
+
+func TestBuild_ConventionsPositionedBetweenInstructionsAndEscalation(t *testing.T) {
+	anvilDir := t.TempDir()
+	forgeDir := filepath.Join(anvilDir, ".forge")
+	require.NoError(t, os.MkdirAll(forgeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(forgeDir, "conventions.md"), []byte("- rule one\n"), 0o644))
+
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-conv-pos",
+		Title:        "Test conventions position",
+		Description:  "Do the thing",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-conv-pos",
+		AnvilName:    "test-anvil",
+		AnvilPath:    anvilDir,
+		WorktreePath: t.TempDir(),
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	instructionsIdx := strings.Index(result, "## Instructions")
+	conventionsIdx := strings.Index(result, "## Project Rules (Non-Negotiable)")
+	escalationIdx := strings.Index(result, "## Escalation")
+
+	require.GreaterOrEqual(t, instructionsIdx, 0, "## Instructions section must be present")
+	require.GreaterOrEqual(t, conventionsIdx, 0, "## Project Rules section must be present")
+	require.GreaterOrEqual(t, escalationIdx, 0, "## Escalation section must be present")
+
+	assert.Greater(t, conventionsIdx, instructionsIdx,
+		"Project Rules should appear after Instructions")
+	assert.Less(t, conventionsIdx, escalationIdx,
+		"Project Rules should appear before Escalation")
+}
+
+func TestBuild_ConventionsOmittedWhenFileAbsent(t *testing.T) {
+	// Anvil directory exists but has no .forge/conventions.md file.
+	anvilDir := t.TempDir()
+
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-conv-absent",
+		Title:        "Test without conventions",
+		Description:  "Do the thing",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-conv-absent",
+		AnvilName:    "test-anvil",
+		AnvilPath:    anvilDir,
+		WorktreePath: t.TempDir(),
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	assert.NotContains(t, result, "## Project Rules (Non-Negotiable)")
+}
+
+func TestBuild_ConventionsContentNotTemplateExpanded(t *testing.T) {
+	// Conventions content containing Go template directives must appear
+	// literally in the rendered prompt — Go's text/template does not
+	// re-process substituted values, but we assert the behavior explicitly
+	// so future refactors cannot silently break this invariant.
+	anvilDir := t.TempDir()
+	forgeDir := filepath.Join(anvilDir, ".forge")
+	require.NoError(t, os.MkdirAll(forgeDir, 0o755))
+
+	conventions := "Use the placeholder {{.SomeField}} and the directive {{if foo}}bar{{end}} verbatim.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(forgeDir, "conventions.md"), []byte(conventions), 0o644))
+
+	b := NewBuilder()
+	ctx := BeadContext{
+		BeadID:       "test-conv-no-expand",
+		Title:        "Test conventions template injection",
+		Description:  "Verify template directives are not expanded",
+		IssueType:    "task",
+		Priority:     3,
+		Branch:       "forge/test-conv-no-expand",
+		AnvilName:    "test-anvil",
+		AnvilPath:    anvilDir,
+		WorktreePath: t.TempDir(),
+	}
+
+	result, err := b.Build(ctx)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "{{.SomeField}}")
+	assert.Contains(t, result, "{{if foo}}bar{{end}}")
+}
+
 func TestBuild_ExternalRefOmittedWhenEmpty(t *testing.T) {
 	b := NewBuilder()
 	ctx := BeadContext{


### PR DESCRIPTION
## Changes

- **Per-anvil conventions injection in Smith prompt** - Smith now reads `.forge/conventions.md` from each anvil and injects it as a `## Project Rules (Non-Negotiable)` section between Instructions and Escalation, giving project-specific rules a proactive upfront slot instead of relying on reactive lookups into appended AGENTS.md/CLAUDE.md context. (Forge-lr5j)

## Original Issue (feature): Add per-anvil conventions injection slot to Smith prompt template

Why: Anvils with project-specific conventions (bilingual changelogs, i18n, Storybook coverage, forbidden libs) currently have to either (a) put everything in appended AGENTS.md / CLAUDE.md where agents consult it reactively rather than proactively, or (b) fork the whole prompt template via LoadCustomTemplate to inject rules upfront, which creates maintenance drift every time the forge default changes.

Evidence: Fhi.Metadata bead 4v75k (PR FHIDev/Munin#2480). Smith correctly produced bilingual changelog fragments because the default template has an explicit Changelog Fragment section (internal/prompt/prompt.go lines 278-302) that agents reconcile against CLAUDE.md. But Smith skipped Storybook coverage entirely because nothing upfront in the default template prompts the agent to check for it, even though the project CLAUDE.md and AGENTS.md both mandate it. The rule was present in appended reference material, but cross-cutting when X then also do Y rules in appended context are unreliable - the agent has to notice the trigger while focused on something else.

What:
- Add a ConventionsMD field to BeadContext and templateData in internal/prompt/prompt.go
- In Build(), read .forge/conventions.md from the anvil root alongside the existing AGENTS.md / CLAUDE.md / README.md reads
- Inject into the default template as a new "## Project Rules (Non-Negotiable)" section placed AFTER "## Instructions" and BEFORE "## Escalation" - i.e. in the upfront proactive-checklist zone, not appended as reference material
- Section is skipped entirely (including the header) when the file does not exist - same pattern as AgentsMD / ClaudeMD
- Add a test in prompt_test.go verifying (1) the file is read from the anvil root, (2) the section renders in the correct position when the file exists, (3) the section is absent when the file does not exist, (4) the content is not interpreted as a template (no {{}} expansion)

Reference: see the diagnosis session at https://github.com/FHIDev/Munin/pull/2480 review comments for the full write-up.

---
Bead: Forge-lr5j | Branch: forge/Forge-lr5j
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)