### PR TITLE
Dedupe queue_cache items before writing (Forge-6e6k)

### DIFF
--- a/changelog.d/Forge-6e6k.md
+++ b/changelog.d/Forge-6e6k.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **queue_cache writer no longer wedges on bead transitions** - Dedupe `(bead_id, anvil)` pairs in the daemon's poll-cycle cache writer before passing them to `ReplaceQueueCacheForAnvils`. Previously, a bead briefly appearing in both the merged ready snapshot and `PollInProgress` results would trigger a UNIQUE constraint violation, roll back the surrounding transaction, and freeze `queue_cache` on stale rows indefinitely. The dedupe prefers the in-progress entry on collision since it reflects the more current state. (Forge-6e6k)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1803,7 +1803,7 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 			})
 		}
 
-		if err := d.db.ReplaceQueueCacheForAnvils(succeededAnvils, cacheItems); err != nil {
+		if err := d.db.ReplaceQueueCacheForAnvils(succeededAnvils, dedupeCacheItems(cacheItems)); err != nil {
 			d.logger.Warn("failed to cache queue", "error", err)
 		}
 	}
@@ -4758,6 +4758,41 @@ func (d *Daemon) maybeCloseDecomposedParent(bead poller.Bead, anvilCfg config.An
 	_ = d.db.LogEvent(state.EventBeadAutoClosed,
 		fmt.Sprintf("Parent auto-closed after decomposition into %d children (no dependents)", childCount),
 		beadID, anvil)
+}
+
+// dedupeCacheItems collapses duplicate (BeadID, Anvil) pairs into a single
+// row, preferring the entry that appears later in the slice. The cache writer
+// concatenates ready beads (from the merged snapshot) with in-progress beads
+// (from a fresh PollInProgress) and a bead can briefly appear in both during
+// bd's claim/release transitions. Without this dedupe, the second INSERT
+// inside ReplaceQueueCacheForAnvils violates the (bead_id, anvil) UNIQUE
+// constraint, the surrounding transaction rolls back, and queue_cache stays
+// frozen on stale rows until the race resolves on its own.
+//
+// Callers append in-progress entries after ready entries, so "last write
+// wins" naturally preserves the in-progress section when both exist for the
+// same bead — that's the more current state.
+func dedupeCacheItems(items []state.QueueItem) []state.QueueItem {
+	if len(items) == 0 {
+		return items
+	}
+	type key struct {
+		beadID, anvil string
+	}
+	seen := make(map[key]int, len(items))
+	for i, it := range items {
+		seen[key{it.BeadID, it.Anvil}] = i
+	}
+	if len(seen) == len(items) {
+		return items
+	}
+	out := make([]state.QueueItem, 0, len(seen))
+	for i, it := range items {
+		if seen[key{it.BeadID, it.Anvil}] == i {
+			out = append(out, it)
+		}
+	}
+	return out
 }
 
 // updateBeadSnapshot refreshes the daemon's two-tier bead snapshot from a poll

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3085,3 +3085,64 @@ func TestReleaseBeadClaim(t *testing.T) {
 		assert.NoFileExists(t, calledFile, "bd must not be called when releaseClaim is false")
 	})
 }
+
+func TestDedupeCacheItems(t *testing.T) {
+	t.Run("no duplicates returns input unchanged", func(t *testing.T) {
+		in := []state.QueueItem{
+			{BeadID: "Forge-1", Anvil: "forge", Section: state.QueueSectionUnlabeled},
+			{BeadID: "Forge-2", Anvil: "forge", Section: state.QueueSectionReady},
+			{BeadID: "Hytte-1", Anvil: "hytte", Section: state.QueueSectionUnlabeled},
+		}
+		out := dedupeCacheItems(in)
+		assert.Len(t, out, 3)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("ready+in_progress collision keeps in_progress", func(t *testing.T) {
+		// Caller appends in_progress entries after ready entries, so
+		// last-write-wins must preserve the in_progress row.
+		in := []state.QueueItem{
+			{BeadID: "Forge-1", Anvil: "forge", Section: state.QueueSectionReady, Title: "ready-row"},
+			{BeadID: "Forge-2", Anvil: "forge", Section: state.QueueSectionReady},
+			{BeadID: "Forge-1", Anvil: "forge", Section: state.QueueSectionInProgress, Title: "in-progress-row"},
+		}
+		out := dedupeCacheItems(in)
+		assert.Len(t, out, 2)
+		// Find the Forge-1 entry and verify it's the in-progress one.
+		var found *state.QueueItem
+		for i := range out {
+			if out[i].BeadID == "Forge-1" {
+				found = &out[i]
+			}
+		}
+		if assert.NotNil(t, found, "Forge-1 must survive dedupe") {
+			assert.Equal(t, state.QueueSectionInProgress, found.Section)
+			assert.Equal(t, "in-progress-row", found.Title)
+		}
+	})
+
+	t.Run("same bead id on different anvils kept separately", func(t *testing.T) {
+		in := []state.QueueItem{
+			{BeadID: "shared-1", Anvil: "forge", Section: state.QueueSectionReady},
+			{BeadID: "shared-1", Anvil: "hytte", Section: state.QueueSectionReady},
+		}
+		out := dedupeCacheItems(in)
+		assert.Len(t, out, 2)
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.Empty(t, dedupeCacheItems(nil))
+		assert.Empty(t, dedupeCacheItems([]state.QueueItem{}))
+	})
+
+	t.Run("multiple duplicates collapse to last occurrence", func(t *testing.T) {
+		in := []state.QueueItem{
+			{BeadID: "Forge-1", Anvil: "forge", Title: "first"},
+			{BeadID: "Forge-1", Anvil: "forge", Title: "second"},
+			{BeadID: "Forge-1", Anvil: "forge", Title: "third"},
+		}
+		out := dedupeCacheItems(in)
+		assert.Len(t, out, 1)
+		assert.Equal(t, "third", out[0].Title)
+	})
+}


### PR DESCRIPTION
## Summary

- Add `dedupeCacheItems` helper to collapse `(BeadID, Anvil)` collisions before passing to `ReplaceQueueCacheForAnvils`
- Apply at the daemon's poll-cycle cache-write call site
- Last-write-wins ordering preserves the in-progress entry when both ready and in-progress versions of a bead show up in the same cycle (since callers append in-progress after ready)

Without this, a bead briefly appearing in both lists during bd's claim/release transitions caused a UNIQUE constraint violation on `queue_cache(bead_id, anvil)`. The surrounding transaction rolled back, the cache stayed frozen on stale rows, and Hearth showed already-closed beads with no warning.

## Test plan

- [x] `go test ./internal/daemon/ -run TestDedupeCacheItems -v` — 5 subtests pass (no-dup passthrough, ready+in_progress collision, cross-anvil same id, empty input, multi-duplicate collapse)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Verify on the affected anvil after deploy: `queue_cache.updated_at` stays within one poll interval of the most recent `poll complete` log line, and constraint-violation warnings stop appearing in daemon logs
- [ ] Manual recovery if needed: `sqlite3 ~/.forge/state.db "DELETE FROM queue_cache WHERE anvil = '<name>';"`

Bead: Forge-6e6k

🤖 Generated with [Claude Code](https://claude.com/claude-code)