### PR TITLE
Always defer bead close until PR merges, regardless of dependency graph shape (Forge-8p1p)

### DIFF
--- a/changelog.d/Forge-8p1p.md
+++ b/changelog.d/Forge-8p1p.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Always defer bead close until PR merges** - Standalone beads (no graph relationships) previously closed immediately on PR creation, before CI ran or any human review, leading to misleading "open" lists when PRs were rejected or sat unmerged. The pipeline now uniformly defers bead close to the merge-watcher regardless of dependency graph shape, matching the behavior already used for beads with dependents. (Forge-8p1p)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1290,8 +1290,8 @@ func (d *Daemon) handleBellowsNotifications(ctx context.Context, event bellows.P
 }
 
 // handleBeadCloseOnMerge closes the bead when its PR is merged.
-// The pipeline defers bead close when DependentCount > 0, expecting
-// bellows to close it after merge. This handler fulfils that contract.
+// The pipeline always defers bead close until the PR merges, expecting
+// bellows to close it. This handler fulfils that contract.
 // External PRs (ext-*) are skipped — they don't have real beads to close.
 func (d *Daemon) handleBeadCloseOnMerge(ctx context.Context, event bellows.PREvent) {
 	if event.EventType != bellows.EventPRMerged {
@@ -2530,11 +2530,7 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 		}
 	}(bead.Anvil, bead.ID, pr.URL, bead.Title, pr.Number, outcome.Duration)
 
-	if len(bead.Blocks) > 0 || bead.DependentCount > 0 {
-		d.logger.Info("bead has dependents, deferring close until PR merges", "bead", bead.ID, "blocks", len(bead.Blocks), "dependent_count", bead.DependentCount)
-	} else if err := d.closeBead(ctx, bead.ID, anvilPath, "Implemented by Forge"); err != nil {
-		d.logger.Warn("failed to close bead", "bead", bead.ID, "error", err)
-	}
+	d.logger.Info("deferring close until PR merges", "bead", bead.ID, "pr", pr.Number, "pr_url", pr.URL)
 }
 
 // insertPendingWorker writes a minimal WorkerPending row to state.db immediately


### PR DESCRIPTION
## Original Issue (task): Always defer bead close until PR merges, regardless of dependency graph shape

Currently internal/daemon/daemon.go:2533-2537 closes a bead immediately on PR creation if the bead has no dependents and blocks no other beads:

  if len(bead.Blocks) > 0 || bead.DependentCount > 0 {
      d.logger.Info("bead has dependents, deferring close until PR merges", ...)
  } else if err := d.closeBead(ctx, bead.ID, anvilPath, "Implemented by Forge"); err != nil {
      d.logger.Warn("failed to close bead", ...)
  }

Standalone beads (no graph relationships) are closed with reason 'Implemented by Forge' the moment the PR is opened, before CI runs and before any human review. Beads with dependents take the deferred branch and close only after the merge-watcher fires.

This produces inconsistent UX:
- A WCAG epic child bead with one sibling-dependent stays open until merge.
- A self-contained P0 bug fix with no graph relationships closes immediately on PR creation, even if the PR is later rejected, sits unmerged for days, or is force-closed.

Real example 2026-04-30: Heimdall-xb2w (standalone P0 bug, deps=[], dependents=[]) was closed at 13:54:34Z, ~1 second after PR #246 was opened — and ~2 minutes before CI even finished. From a user looking at 'bd list --status=open' the bead reads as 'done' even though the PR is still open and could fail CI / get rejected.

Make the policy uniform: always defer the close to the merge watcher. The merge-watcher path already exists ('closing bead after PR merge' in daemon.go) and is exercised constantly for the dependents-bearing case, so this is a one-line change with no new logic to write.

Drop the conditional at daemon.go:2533 and let every successful pipeline log 'deferring close until PR merges' and rely on the existing merge-watcher to fire closeBead.

---
Bead: Forge-8p1p | Branch: forge/Forge-8p1p
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)