### PR TITLE
Smith cwd leak: 'cd ..' from worktree subdir escapes into parent repo and commits to main (Forge-v48n)

### DIFF
--- a/changelog.d/Forge-v48n.md
+++ b/changelog.d/Forge-v48n.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Smith cwd-escape protection** - Pin every AI agent subprocess to its worktree via GIT_DIR, GIT_WORK_TREE, and GIT_CEILING_DIRECTORIES so that a stray `cd ..` in a tool_use bash command can no longer escape into the parent anvil and commit to its main branch. Inherited git env vars are also stripped so a stale value cannot leak into non-worktree spawns (schematic, wicket, warden-learn). (Forge-v48n)

--- a/internal/smith/smith.go
+++ b/internal/smith/smith.go
@@ -185,32 +185,7 @@ func SpawnWithProvider(ctx context.Context, worktreePath, promptText, logDir str
 	// is omitted (detects piped input and runs non-interactively).
 	cmd.Stdin = strings.NewReader(promptText)
 
-	// Strip CLAUDECODE so claude doesn't refuse to run inside another session.
-	// Also strip any keys that will be overridden by per-provider env vars so
-	// we don't end up with duplicate entries (behavior for duplicates is not
-	// guaranteed across platforms, notably Windows).
-	env := os.Environ()
-	filtered := env[:0:0]
-	for _, e := range env {
-		if strings.HasPrefix(e, "CLAUDECODE=") {
-			continue
-		}
-		skip := false
-		for k := range pv.Env {
-			if strings.HasPrefix(e, k+"=") {
-				skip = true
-				break
-			}
-		}
-		if !skip {
-			filtered = append(filtered, e)
-		}
-	}
-	// Apply per-provider environment variable overrides (e.g. for Ollama backend).
-	for k, v := range pv.Env {
-		filtered = append(filtered, k+"="+v)
-	}
-	cmd.Env = filtered
+	cmd.Env = buildChildEnv(os.Environ(), pv.Env, worktree.GitEnv(worktreePath))
 	executil.HideWindow(cmd)
 	executil.SetProcessGroup(cmd)
 
@@ -648,6 +623,53 @@ func readAll(r io.Reader, buf *strings.Builder, logFile *os.File) {
 		buf.WriteString("\n")
 		fmt.Fprintln(logFile, "[stderr] ", line)
 	}
+}
+
+// buildChildEnv assembles the environment for an AI agent subprocess.
+//
+// It strips CLAUDECODE (so claude does not refuse to run inside another
+// session), strips any keys that the provider will set (avoiding cross-platform
+// duplicate-entry ambiguity), and unconditionally strips GIT_DIR /
+// GIT_WORK_TREE / GIT_CEILING_DIRECTORIES so an inherited value cannot leak
+// into the child:
+//   - Worktree spawns: gitEnv re-injects values pinning git to the worktree.
+//     A stray "cd .." in a tool_use bash command cannot escape into the parent
+//     anvil and commit to its main branch.
+//   - Non-worktree spawns (schematic/wicket tempdirs): gitEnv is nil, so no
+//     git env is set. An inherited GIT_DIR pointing to the parent process's
+//     repo must not survive — otherwise an escaped Smith could still target
+//     the anvil's checkout.
+//
+// providerEnv overrides go in last so they take precedence over inherited
+// values, and worktree gitEnv goes after provider env so that providers cannot
+// shadow our git confinement.
+func buildChildEnv(parentEnv []string, providerEnv map[string]string, gitEnv []string) []string {
+	out := make([]string, 0, len(parentEnv)+len(providerEnv)+len(gitEnv))
+	for _, e := range parentEnv {
+		if strings.HasPrefix(e, "CLAUDECODE=") {
+			continue
+		}
+		if strings.HasPrefix(e, "GIT_DIR=") ||
+			strings.HasPrefix(e, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(e, "GIT_CEILING_DIRECTORIES=") {
+			continue
+		}
+		skip := false
+		for k := range providerEnv {
+			if strings.HasPrefix(e, k+"=") {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, e)
+		}
+	}
+	for k, v := range providerEnv {
+		out = append(out, k+"="+v)
+	}
+	out = append(out, gitEnv...)
+	return out
 }
 
 // truncate shortens a string to maxLen, adding "..." if truncated.

--- a/internal/smith/smith_test.go
+++ b/internal/smith/smith_test.go
@@ -286,6 +286,106 @@ func TestWaitWithExitTimeout_TimeoutKillError(t *testing.T) {
 	assert.Equal(t, 1, got.ExitCode, "exit code must not be normalized for a non-success session")
 }
 
+// TestBuildChildEnv_StripsInheritedGitVars is the core regression assertion
+// for Forge-v48n: GIT_DIR / GIT_WORK_TREE / GIT_CEILING_DIRECTORIES from the
+// daemon's own environment must NEVER reach the AI agent subprocess. If they
+// did, a child running git from any cwd could resolve back to whatever repo
+// the daemon was started in (or a stale worktree) instead of the worktree we
+// just bound it to.
+func TestBuildChildEnv_StripsInheritedGitVars(t *testing.T) {
+	parent := []string{
+		"PATH=/usr/bin",
+		"GIT_DIR=/some/stale/.git",
+		"GIT_WORK_TREE=/some/stale",
+		"GIT_CEILING_DIRECTORIES=/",
+		"CLAUDECODE=1",
+		"HOME=/home/user",
+	}
+	got := buildChildEnv(parent, nil, nil)
+
+	for _, e := range got {
+		if strings.HasPrefix(e, "GIT_DIR=") ||
+			strings.HasPrefix(e, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(e, "GIT_CEILING_DIRECTORIES=") ||
+			strings.HasPrefix(e, "CLAUDECODE=") {
+			t.Errorf("inherited variable %q must be stripped", e)
+		}
+	}
+
+	want := map[string]bool{"PATH=/usr/bin": false, "HOME=/home/user": false}
+	for _, e := range got {
+		if _, ok := want[e]; ok {
+			want[e] = true
+		}
+	}
+	for k, found := range want {
+		if !found {
+			t.Errorf("expected %q to survive, but it was filtered out", k)
+		}
+	}
+}
+
+// TestBuildChildEnv_WorktreeGitEnvWins verifies that when the parent process
+// has a stale GIT_DIR but a worktree gitEnv is provided, the child sees ONLY
+// the worktree's git env — not the parent's stale value.
+func TestBuildChildEnv_WorktreeGitEnvWins(t *testing.T) {
+	parent := []string{
+		"GIT_DIR=/parent/repo/.git",
+		"GIT_WORK_TREE=/parent/repo",
+	}
+	gitEnv := []string{
+		"GIT_DIR=/anvil/.git/worktrees/bead",
+		"GIT_WORK_TREE=/anvil/.workers/bead",
+		"GIT_CEILING_DIRECTORIES=/anvil/.workers",
+	}
+	got := buildChildEnv(parent, nil, gitEnv)
+
+	gitDirCount := 0
+	gitWorkTreeCount := 0
+	for _, e := range got {
+		if strings.HasPrefix(e, "GIT_DIR=") {
+			gitDirCount++
+			if e != "GIT_DIR=/anvil/.git/worktrees/bead" {
+				t.Errorf("unexpected GIT_DIR value: %q", e)
+			}
+		}
+		if strings.HasPrefix(e, "GIT_WORK_TREE=") {
+			gitWorkTreeCount++
+			if e != "GIT_WORK_TREE=/anvil/.workers/bead" {
+				t.Errorf("unexpected GIT_WORK_TREE value: %q", e)
+			}
+		}
+	}
+	if gitDirCount != 1 {
+		t.Errorf("expected exactly one GIT_DIR entry, got %d", gitDirCount)
+	}
+	if gitWorkTreeCount != 1 {
+		t.Errorf("expected exactly one GIT_WORK_TREE entry, got %d", gitWorkTreeCount)
+	}
+}
+
+// TestBuildChildEnv_ProviderEnvOverrides verifies that provider-supplied env
+// values replace any inherited entry with the same key, ensuring per-provider
+// overrides (e.g. Ollama backend host) reach the child cleanly.
+func TestBuildChildEnv_ProviderEnvOverrides(t *testing.T) {
+	parent := []string{"OLLAMA_HOST=stale", "PATH=/usr/bin"}
+	providerEnv := map[string]string{"OLLAMA_HOST": "http://localhost:11434"}
+	got := buildChildEnv(parent, providerEnv, nil)
+
+	hostCount := 0
+	for _, e := range got {
+		if strings.HasPrefix(e, "OLLAMA_HOST=") {
+			hostCount++
+			if e != "OLLAMA_HOST=http://localhost:11434" {
+				t.Errorf("unexpected OLLAMA_HOST value: %q", e)
+			}
+		}
+	}
+	if hostCount != 1 {
+		t.Errorf("expected exactly one OLLAMA_HOST entry, got %d", hostCount)
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -683,6 +683,46 @@ func ValidateWorktreeDir(worktreePath string) error {
 	return fmt.Errorf("directory %s is inside a git repository but lacks a valid worktree .git file: %w", worktreePath, gitFileErr)
 }
 
+// GitEnv returns the git environment variables that confine git operations to
+// the given worktree even when the child process changes directory away from
+// it. Smith runs claude inside <anvil>/.workers/<bead-id>/, which is a
+// subdirectory of the anvil repo; without these variables, a stray "cd .." in
+// a tool_use bash command can walk cwd into the anvil and have git apply add /
+// commit / push to the parent repo's currently-checked-out branch (typically
+// main). Setting GIT_DIR + GIT_WORK_TREE binds every child git invocation to
+// the worktree regardless of cwd. GIT_CEILING_DIRECTORIES is added as belt-
+// and-suspenders so that even if a nested shell unsets GIT_DIR, git's repo
+// discovery cannot walk up past .workers/ into the parent repo.
+//
+// The returned slice is suitable for appending directly to a Cmd.Env. If
+// worktreePath is not a valid git worktree (e.g. an os.MkdirTemp dir used by
+// schematic / wicket / warden-learn) the function returns nil so that those
+// non-repo runs are unaffected.
+func GitEnv(worktreePath string) []string {
+	gitdir, err := resolveValidatedGitDir(worktreePath)
+	if err != nil {
+		return nil
+	}
+	abs, err := filepath.Abs(worktreePath)
+	if err != nil {
+		abs = worktreePath
+	}
+	env := []string{
+		"GIT_DIR=" + gitdir,
+		"GIT_WORK_TREE=" + abs,
+	}
+	// GIT_CEILING_DIRECTORIES is best-effort defense-in-depth: if a nested
+	// shell unsets GIT_DIR and the cwd is somewhere inside the worktree
+	// subtree, the ceiling stops git's upward walk at .workers/ before it
+	// can reach the anvil's .git directory. It does NOT protect when cwd
+	// itself escapes to the anvil root (git checks cwd before ascending),
+	// but in that case the explicit GIT_DIR above is what wins.
+	if parent := filepath.Dir(abs); parent != "" && parent != abs {
+		env = append(env, "GIT_CEILING_DIRECTORIES="+parent)
+	}
+	return env
+}
+
 // sanitizePath converts a bead ID to a safe directory/branch name.
 // E.g., "Forge-n1g.4.1" → "Forge-n1g.4.1" (dots are fine in git branches).
 // Slashes and other problematic chars are replaced.

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -453,8 +453,12 @@ func resolveValidatedGitDir(dir string) (string, error) {
 	if !filepath.IsAbs(gitdir) {
 		gitdir = filepath.Join(dir, gitdir)
 	}
-	if _, err := os.Stat(gitdir); err != nil {
-		return "", err
+	info, statErr := os.Stat(gitdir)
+	if statErr != nil {
+		return "", statErr
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("gitdir %q is not a directory", gitdir)
 	}
 	return gitdir, nil
 }
@@ -705,7 +709,7 @@ func GitEnv(worktreePath string) []string {
 	}
 	abs, err := filepath.Abs(worktreePath)
 	if err != nil {
-		abs = worktreePath
+		return nil
 	}
 	env := []string{
 		"GIT_DIR=" + gitdir,

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -716,7 +716,7 @@ func TestGitEnv_ConfinesGitFromOutsideWorktree(t *testing.T) {
 	}
 	cmd = exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Dir = anvilDir
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(envWithoutGitVars(), env...)
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("confined git rev-parse: %v\n%s", err, out)
@@ -741,7 +741,7 @@ func TestGitEnv_ConfinesGitFromOutsideWorktree(t *testing.T) {
 	// landed on the parent repo's checked-out branch.
 	cmd = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = anvilDir
-	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(envWithoutGitVars(), env...)
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("confined git rev-parse --abbrev-ref HEAD: %v\n%s", err, out)
@@ -751,6 +751,26 @@ func TestGitEnv_ConfinesGitFromOutsideWorktree(t *testing.T) {
 		t.Errorf("git --abbrev-ref HEAD with GitEnv from anvil dir = %q; want worktree branch %q",
 			branch, wt.Branch)
 	}
+}
+
+// envWithoutGitVars returns os.Environ() with GIT_DIR, GIT_WORK_TREE, and
+// GIT_CEILING_DIRECTORIES removed, so that appending our own values is
+// deterministic even when the host shell has those vars set.
+func envWithoutGitVars() []string {
+	skip := map[string]bool{
+		"GIT_DIR":               true,
+		"GIT_WORK_TREE":         true,
+		"GIT_CEILING_DIRECTORIES": true,
+	}
+	base := os.Environ()
+	out := make([]string, 0, len(base))
+	for _, e := range base {
+		key, _, _ := strings.Cut(e, "=")
+		if !skip[key] {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // gitOutput runs a git command and returns trimmed stdout.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -604,6 +604,155 @@ func TestRemove_PreservesSymlinkTarget(t *testing.T) {
 	}
 }
 
+// TestGitEnv_NonWorktreeReturnsNil ensures we don't inject GIT_DIR/GIT_WORK_TREE
+// into a child process whose cwd is not a real worktree (e.g. an os.MkdirTemp
+// dir used by schematic/wicket/warden-learn). Doing so would shape the env
+// for a non-repo run, which we want to leave untouched.
+func TestGitEnv_NonWorktreeReturnsNil(t *testing.T) {
+	if env := GitEnv(t.TempDir()); env != nil {
+		t.Errorf("GitEnv on non-worktree dir: expected nil, got %v", env)
+	}
+}
+
+// TestGitEnv_RealWorktreeSetsAllVars verifies that GitEnv on a real worktree
+// returns GIT_DIR, GIT_WORK_TREE, and GIT_CEILING_DIRECTORIES with values that
+// confine a child git invocation to the worktree.
+func TestGitEnv_RealWorktreeSetsAllVars(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	mgr := NewManager()
+	wt, err := mgr.CreateWithOptions(context.Background(), anvilDir, "git-env-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	env := GitEnv(wt.Path)
+	if len(env) == 0 {
+		t.Fatal("GitEnv on real worktree returned empty slice")
+	}
+
+	got := map[string]string{}
+	for _, e := range env {
+		i := strings.IndexByte(e, '=')
+		if i < 0 {
+			t.Fatalf("malformed env entry %q", e)
+		}
+		got[e[:i]] = e[i+1:]
+	}
+
+	// GIT_WORK_TREE must equal the absolute worktree path.
+	absWt, err := filepath.Abs(wt.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["GIT_WORK_TREE"] != absWt {
+		t.Errorf("GIT_WORK_TREE = %q; want %q", got["GIT_WORK_TREE"], absWt)
+	}
+
+	// GIT_DIR must be a valid directory (the worktree's gitdir under
+	// <anvil>/.git/worktrees/<name>) — never the worktree's own .git file.
+	gitdir := got["GIT_DIR"]
+	if gitdir == "" {
+		t.Fatal("GIT_DIR not set")
+	}
+	info, err := os.Stat(gitdir)
+	if err != nil {
+		t.Errorf("GIT_DIR points to missing path %q: %v", gitdir, err)
+	} else if !info.IsDir() {
+		t.Errorf("GIT_DIR %q is not a directory", gitdir)
+	}
+
+	// GIT_CEILING_DIRECTORIES must point to the parent of the worktree root
+	// (i.e. .workers/), so that ascending repo discovery cannot reach the
+	// anvil's .git directory above it.
+	if got["GIT_CEILING_DIRECTORIES"] != filepath.Dir(absWt) {
+		t.Errorf("GIT_CEILING_DIRECTORIES = %q; want %q",
+			got["GIT_CEILING_DIRECTORIES"], filepath.Dir(absWt))
+	}
+}
+
+// TestGitEnv_ConfinesGitFromOutsideWorktree is the regression test for the
+// Fhi.Metadata-k41dx incident: a Smith escaped its worktree via "cd .." and
+// committed 5 stray files on the parent anvil's main branch. With GitEnv
+// applied to a child process, running git from a directory outside the
+// worktree must still target the worktree's gitdir/work-tree, not the
+// parent repo.
+func TestGitEnv_ConfinesGitFromOutsideWorktree(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	mgr := NewManager()
+	ctx := context.Background()
+	wt, err := mgr.CreateWithOptions(ctx, anvilDir, "escape-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	// Sanity: without our env vars, running git from the anvil resolves to
+	// the anvil's checkout (the dangerous default we're protecting against).
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = anvilDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("baseline git rev-parse: %v\n%s", err, out)
+	}
+	baselineTop, err := filepath.EvalSymlinks(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedAnvil, err := filepath.EvalSymlinks(anvilDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baselineTop != resolvedAnvil {
+		t.Fatalf("baseline rev-parse: expected anvil %q, got %q", resolvedAnvil, baselineTop)
+	}
+
+	// With GitEnv, running git from the anvil dir (i.e. one level above the
+	// worktree, equivalent to a "cd ../.." escape from a worktree subdir)
+	// must resolve --show-toplevel back to the worktree.
+	env := GitEnv(wt.Path)
+	if env == nil {
+		t.Fatal("GitEnv returned nil for valid worktree")
+	}
+	cmd = exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = anvilDir
+	cmd.Env = append(os.Environ(), env...)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("confined git rev-parse: %v\n%s", err, out)
+	}
+	confinedTop, err := filepath.EvalSymlinks(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedWt, err := filepath.EvalSymlinks(wt.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confinedTop != resolvedWt {
+		t.Errorf("git --show-toplevel with GitEnv from anvil dir = %q; want worktree %q "+
+			"(regression: Smith escape from worktree subdir would commit to anvil main)",
+			confinedTop, resolvedWt)
+	}
+
+	// Running git rev-parse --abbrev-ref HEAD from the anvil dir with GitEnv
+	// must report the worktree's branch, not the anvil's main. This is the
+	// invariant that prevents the Fhi.Metadata-k41dx scenario where commits
+	// landed on the parent repo's checked-out branch.
+	cmd = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = anvilDir
+	cmd.Env = append(os.Environ(), env...)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("confined git rev-parse --abbrev-ref HEAD: %v\n%s", err, out)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch != wt.Branch {
+		t.Errorf("git --abbrev-ref HEAD with GitEnv from anvil dir = %q; want worktree branch %q",
+			branch, wt.Branch)
+	}
+}
+
 // gitOutput runs a git command and returns trimmed stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()


### PR DESCRIPTION
## Original Issue (bug): Smith cwd leak: 'cd ..' from worktree subdir escapes into parent repo and commits to main

The Smith sandbox runs claude inside the worktree at <anvil-path>/.workers/<bead-id>/. Because the worktree is a subdirectory of the parent repo, a stray 'cd ..' (or two) in a tool_use bash command can walk cwd out of the worktree and into the parent repo's working tree before the next sandbox cwd reset. If Smith then runs 'git add' / 'git commit' in that escaped state, the commit lands on the parent repo's currently-checked-out branch (typically main).

Real incident on 2026-04-29 with Fhi.Metadata-k41dx: Smith committed 6096ce760 ('chore: replace eslint-plugin-react with @eslint-react/eslint-plugin') on Fhi.Metadata main, containing 5 stray files (.beads/config.yaml, .claude/scheduled_tasks.lock, three .workers/Fhi.Metadata-{455rp,k41dx,rt9ni} submodule gitlinks). The actual bead work was correctly committed/pushed on forge/Fhi.Metadata-k41dx, but the parent main was poisoned locally. Smith escalated NEEDS_HUMAN because worker rules forbid it from running git reset on the parent repo.

Smith logs from internal/smith and tool_use traces show the trigger pattern: a 'cd ..' issued from a deep subdir like client/ to reach the worktree root, but with one extra level. On Windows this is especially likely because the prompt-rendered worktree path is long and easy to misjudge.

Hardening options to consider (pick one or combine):
1. Reject git mutations whose --git-dir is outside the worktree — wrap git in a sandbox shim that requires GIT_DIR / GIT_WORK_TREE to point inside <worktree-root>.
2. Refuse cwd transitions above the worktree root in the bash sandbox (the smith deny_patterns / sandbox layer already validates commands; extend it to validate cwd).
3. Set GIT_DIR=<worktree>/.git and GIT_WORK_TREE=<worktree> in the spawned smith env, so even an escaped cwd can't accidentally target the parent repo's git config.
4. Move worktrees out of the parent repo (sibling dir like <anvil-path>-worktrees/<bead-id>) — biggest blast-radius reduction, but a structural change.

Option 3 is the cheapest and most precise: env vars ride with the process, override repo discovery, and wouldn't hurt legitimate same-worktree work.

---
Bead: Forge-v48n | Branch: forge/Forge-v48n
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)