### PR TITLE
forge queue retry doesn't resume paused crucibles (in-memory state retained) (Forge-s3d6)

### DIFF
--- a/changelog.d/Forge-s3d6.md
+++ b/changelog.d/Forge-s3d6.md
@@ -1,0 +1,4 @@
+category: Fixed
+- **forge queue retry now resumes paused crucibles** - `forge queue retry` clears the daemon's in-memory paused crucible status and re-applies the anvil's `auto_dispatch_tag` (which `releaseBeadClaim` strips when a pipeline fails), so a paused crucible can re-enter the loop without a daemon restart. (Forge-s3d6)
+- **Hearth crucible resume restores auto_dispatch_tag** - The Hearth "resume" action now re-adds the anvil's `auto_dispatch_tag` to the parent bead so tagged-dispatch anvils can rediscover it via `bd ready`. (Forge-s3d6)
+- **Anvil name lookups are case-insensitive** - `forge queue retry` and the Hearth crucible action handlers canonicalise user-provided anvil names against the configured registry, so passing `--anvil Munin` resolves to the configured `munin` instead of failing with "no retry record found". (Forge-s3d6)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2958,6 +2958,11 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": "parent_id and anvil are required"})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
+		// Canonicalise the user-provided anvil name (case-insensitive) so DB
+		// queries and crucibleStatuses keys match the configured form.
+		if canonical, _, ok := d.resolveAnvilConfig(ca.Anvil); ok {
+			ca.Anvil = canonical
+		}
 
 		switch ca.Action {
 		case "resume":
@@ -2976,13 +2981,15 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				d.logger.Warn("failed to reset dispatch failures for crucible parent", "bead", ca.ParentID, "error", err)
 			}
 
-			// Reset bead status to open and clear assignee so the poller
-			// can rediscover it as a crucible candidate.
+			// Reset bead status to open and clear assignee so the poller can
+			// rediscover it as a crucible candidate. Re-applies the
+			// auto_dispatch_tag that releaseBeadClaim strips on pipeline
+			// failure, otherwise tagged-dispatch anvils never see the bead
+			// again via bd ready.
 			resetCtx, resetCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 			defer resetCancel()
-			statusCmd := executil.HideWindow(exec.CommandContext(resetCtx, "bd", "update", ca.ParentID, "--status=open", "--assignee=", "--json"))
-			statusCmd.Dir = anvilCfg.Path
-			if output, err := statusCmd.CombinedOutput(); err != nil {
+			output, err := d.restoreBeadAfterPause(resetCtx, ca.ParentID, anvilCfg)
+			if err != nil {
 				d.logger.Warn("failed to reset crucible parent status", "bead", ca.ParentID, "error", err, "output", string(output))
 				msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to reset crucible parent status: %v (%s)", err, string(output))})
 				return ipc.Response{Type: "error", Payload: msg}
@@ -3525,6 +3532,14 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
+		// Canonicalise the user-provided anvil name (case-insensitive) so DB
+		// queries below match records that were stored under the configured
+		// key, regardless of how the user typed it on the CLI.
+		if rp.Anvil != "" {
+			if canonical, _, ok := d.resolveAnvilConfig(rp.Anvil); ok {
+				rp.Anvil = canonical
+			}
+		}
 		// Exhausted PR retry: DB-only, no bd shelling required.
 		if rp.PRID > 0 {
 			pr, err := d.db.GetPRByID(rp.PRID)
@@ -3581,14 +3596,27 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		}
 		reqID, _ := d.reqTracker.Track()
 		go func() {
+			bdUpdateOK := false
 			if anvilCfg, ok := d.cfg.Load().Anvils[rp.Anvil]; ok && anvilCfg.Path != "" {
 				resetCtx, resetCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 				defer resetCancel()
-				statusCmd := executil.HideWindow(exec.CommandContext(resetCtx, "bd", "update", rp.BeadID, "--status=open", "--assignee=", "--json"))
-				statusCmd.Dir = anvilCfg.Path
-				if output, err := statusCmd.CombinedOutput(); err != nil {
+				// Mirrors the crucible_action resume path: re-apply the
+				// auto_dispatch_tag that releaseBeadClaim strips on pipeline
+				// failure, otherwise tagged-dispatch anvils never see the bead
+				// again via bd ready.
+				output, err := d.restoreBeadAfterPause(resetCtx, rp.BeadID, anvilCfg)
+				if err != nil {
 					d.logger.Warn("failed to reset bead status after retry reset", "bead", rp.BeadID, "error", err, "output", string(output))
+				} else {
+					bdUpdateOK = true
 				}
+			}
+			// Clear the in-memory paused crucible status so the parent can
+			// re-enter the crucible loop without a daemon restart. Mirrors
+			// the crucible_action resume path. Only do this once bd update
+			// succeeded so we don't drop UI state on a transient bd failure.
+			if bdUpdateOK {
+				d.crucibleStatuses.Delete(rp.Anvil + "/" + rp.BeadID)
 			}
 			d.pollAndDispatch(d.runCtx, false)
 			msg := "retry reset"
@@ -4519,6 +4547,44 @@ func (d *Daemon) recordDispatchFailure(beadID, anvil, reason string, releaseClai
 			}
 		}(beadID, anvil, reason, count)
 	}
+}
+
+// resolveAnvilConfig performs a case-insensitive lookup of an anvil by name
+// against the current config and returns the canonical key, its config, and
+// whether a match was found. Handlers that accept a user-provided anvil name
+// (e.g. from the CLI) should canonicalise the name before any DB query so a
+// caller passing "Munin" still matches the configured "munin".
+func (d *Daemon) resolveAnvilConfig(name string) (string, config.AnvilConfig, bool) {
+	if name == "" {
+		return "", config.AnvilConfig{}, false
+	}
+	anvils := d.cfg.Load().Anvils
+	if cfg, ok := anvils[name]; ok {
+		return name, cfg, true
+	}
+	lower := strings.ToLower(name)
+	for k, v := range anvils {
+		if strings.ToLower(k) == lower {
+			return k, v, true
+		}
+	}
+	return "", config.AnvilConfig{}, false
+}
+
+// restoreBeadAfterPause sets a bead back to status=open with no assignee and,
+// if the anvil uses an auto_dispatch_tag, re-applies that label. This is the
+// inverse of releaseBeadClaim and is used by the manual retry/resume paths
+// (forge queue retry, Hearth crucible resume) so beads on tagged anvils
+// become visible to bd ready again instead of sitting silently un-tagged.
+func (d *Daemon) restoreBeadAfterPause(ctx context.Context, beadID string, anvilCfg config.AnvilConfig) ([]byte, error) {
+	args := []string{"update", beadID, "--status=open", "--assignee="}
+	if anvilCfg.AutoDispatchTag != "" {
+		args = append(args, "--add-label="+anvilCfg.AutoDispatchTag)
+	}
+	args = append(args, "--json")
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "bd", args...))
+	cmd.Dir = anvilCfg.Path
+	return cmd.CombinedOutput()
 }
 
 // releaseBeadClaim releases a claimed bead back to open status and strips the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4563,10 +4563,24 @@ func (d *Daemon) resolveAnvilConfig(name string) (string, config.AnvilConfig, bo
 		return name, cfg, true
 	}
 	lower := strings.ToLower(name)
+	var (
+		matchedKey string
+		matchedCfg config.AnvilConfig
+		found      bool
+	)
 	for k, v := range anvils {
-		if strings.ToLower(k) == lower {
-			return k, v, true
+		if strings.ToLower(k) != lower {
+			continue
 		}
+		if found {
+			return "", config.AnvilConfig{}, false
+		}
+		matchedKey = k
+		matchedCfg = v
+		found = true
+	}
+	if found {
+		return matchedKey, matchedCfg, true
 	}
 	return "", config.AnvilConfig{}, false
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Robin831/Forge/internal/bellows"
 	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/crucible"
 	"github.com/Robin831/Forge/internal/ipc"
 	"github.com/Robin831/Forge/internal/lifecycle"
 	"github.com/Robin831/Forge/internal/poller"
@@ -924,7 +925,7 @@ func TestHandleIPC_RetryBead_ClearsCrucibleStatusOnSuccess(t *testing.T) {
 
 	// Seed the in-memory paused crucible status — this is what `forge queue
 	// retry` previously failed to clear, leaving the daemon stuck.
-	d.crucibleStatuses.Store("munin/"+beadID, "paused")
+	d.crucibleStatuses.Store("munin/"+beadID, crucible.Status{Phase: "paused"})
 
 	// Mixed-case anvil name on the payload — exercises both the
 	// case-insensitive lookup and the canonical key threading.
@@ -993,7 +994,7 @@ func TestHandleIPC_RetryBead_PreservesCrucibleStatusOnBdFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, broke)
 
-	d.crucibleStatuses.Store(anvil+"/"+beadID, "paused")
+	d.crucibleStatuses.Store(anvil+"/"+beadID, crucible.Status{Phase: "paused"})
 
 	payload, _ := json.Marshal(ipc.RetryBeadPayload{BeadID: beadID, Anvil: anvil})
 	resp := d.handleIPC(ipc.Command{Type: "retry_bead", Payload: payload})
@@ -1052,7 +1053,7 @@ func TestHandleIPC_CrucibleAction_Resume_RestoresAutoDispatchTag(t *testing.T) {
 	})
 
 	const parentID = "BD-PARENT"
-	d.crucibleStatuses.Store("munin/"+parentID, "paused")
+	d.crucibleStatuses.Store("munin/"+parentID, crucible.Status{Phase: "paused"})
 
 	// Resume via Hearth using a mixed-case anvil name to also exercise
 	// the canonicalisation path.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -826,6 +826,256 @@ func TestHandleIPC_RetryBead_NonBeadPR(t *testing.T) {
 	assert.Equal(t, 0, pr2.RebaseCount)
 }
 
+// TestResolveAnvilConfig verifies the case-insensitive anvil lookup helper.
+// Users typing the anvil name on the CLI may not match the configured key
+// exactly (e.g. "Munin" vs "munin"); the helper resolves these to the
+// canonical config key so DB queries and crucibleStatuses keys line up.
+func TestResolveAnvilConfig(t *testing.T) {
+	d := &Daemon{}
+	d.cfg.Store(&config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			"munin":   {Path: "/tmp/munin"},
+			"Heimdall": {Path: "/tmp/heimdall"},
+		},
+	})
+
+	t.Run("exact match wins", func(t *testing.T) {
+		name, cfg, ok := d.resolveAnvilConfig("munin")
+		require.True(t, ok)
+		assert.Equal(t, "munin", name)
+		assert.Equal(t, "/tmp/munin", cfg.Path)
+	})
+
+	t.Run("case-insensitive match", func(t *testing.T) {
+		name, cfg, ok := d.resolveAnvilConfig("Munin")
+		require.True(t, ok)
+		assert.Equal(t, "munin", name, "should canonicalise to lowercase configured key")
+		assert.Equal(t, "/tmp/munin", cfg.Path)
+	})
+
+	t.Run("case-insensitive match preserves configured case", func(t *testing.T) {
+		name, _, ok := d.resolveAnvilConfig("heimdall")
+		require.True(t, ok)
+		assert.Equal(t, "Heimdall", name, "should canonicalise to the configured (mixed-case) key")
+	})
+
+	t.Run("unknown anvil returns false", func(t *testing.T) {
+		_, _, ok := d.resolveAnvilConfig("unknown")
+		assert.False(t, ok)
+	})
+
+	t.Run("empty name returns false", func(t *testing.T) {
+		_, _, ok := d.resolveAnvilConfig("")
+		assert.False(t, ok)
+	})
+}
+
+// TestHandleIPC_RetryBead_ClearsCrucibleStatusOnSuccess verifies that the
+// retry_bead handler clears the in-memory crucibleStatuses entry after the
+// bd update succeeds, so a paused crucible re-enters the loop without a
+// daemon restart. Uses a mixed-case anvil name on the payload to also
+// exercise the case-insensitive lookup so the DB retry record (stored
+// under the canonical configured key) is reset, the crucibleStatuses key
+// matches, and the bd update is dispatched against the canonical path.
+func TestHandleIPC_RetryBead_ClearsCrucibleStatusOnSuccess(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Fake bd script that records its arguments and exits 0 on `update`.
+	bdLog := filepath.Join(tmpDir, "bd-args.log")
+	var bdScript, bdContent string
+	if runtime.GOOS == "windows" {
+		bdScript = filepath.Join(tmpDir, "bd.bat")
+		bdContent = "@echo off\r\necho %*>>\"" + bdLog + "\"\r\nif \"%1\"==\"update\" (\r\n  echo {\"id\":\"%2\",\"status\":\"open\"}\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n"
+	} else {
+		bdScript = filepath.Join(tmpDir, "bd")
+		bdContent = "#!/bin/sh\necho \"$@\" >> \"" + bdLog + "\"\nif [ \"$1\" = \"update\" ]; then\n  echo '{\"id\":\"'\"$2\"'\",\"status\":\"open\"}'\n  exit 0\nfi\nexit 1\n"
+	}
+	require.NoError(t, os.WriteFile(bdScript, []byte(bdContent), 0o755))
+
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	dbPath := filepath.Join(tmpDir, "state.db")
+	db, err := state.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:            db,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		worktreeMgr:   worktree.NewManager(),
+		promptBuilder: prompt.NewBuilder(),
+		runCtx:        context.Background(),
+		reqTracker:    *ipc.NewRequestTracker("test-"),
+	}
+	d.cfg.Store(&config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			"munin": {Path: tmpDir, AutoDispatchTag: "forgeReady"},
+		},
+	})
+
+	const beadID = "BD-CRUCIBLE"
+	_, broke, err := db.IncrementDispatchFailures(beadID, "munin", 1, "test failure")
+	require.NoError(t, err)
+	require.True(t, broke)
+
+	// Seed the in-memory paused crucible status — this is what `forge queue
+	// retry` previously failed to clear, leaving the daemon stuck.
+	d.crucibleStatuses.Store("munin/"+beadID, "paused")
+
+	// Mixed-case anvil name on the payload — exercises both the
+	// case-insensitive lookup and the canonical key threading.
+	payload, _ := json.Marshal(ipc.RetryBeadPayload{BeadID: beadID, Anvil: "Munin"})
+	resp := d.handleIPC(ipc.Command{Type: "retry_bead", Payload: payload})
+	assert.Equal(t, "queued", resp.Type)
+
+	// The DB ResetRetry runs synchronously before the goroutine starts —
+	// confirms the case-insensitive canonicalisation matched the configured
+	// "munin" key. Without canonicalisation, ResetRetry would have used
+	// "Munin" and matched zero rows.
+	r, err := db.GetRetry(beadID, "munin")
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.False(t, r.NeedsHuman, "needs_human should be cleared synchronously")
+	assert.Equal(t, 0, r.DispatchFailures)
+
+	// Wait for the async goroutine to finish (it calls completeAsync at the
+	// end, which removes the request from the tracker).
+	require.Eventually(t, func() bool {
+		return d.reqTracker.Pending() == 0
+	}, 5*time.Second, 10*time.Millisecond, "async goroutine never completed")
+
+	// crucibleStatuses entry must have been deleted on bd success — keyed by
+	// the canonical "munin", not the user-typed "Munin".
+	_, stillPresent := d.crucibleStatuses.Load("munin/" + beadID)
+	assert.False(t, stillPresent, "crucibleStatuses entry should be cleared after retry_bead succeeds")
+
+	// And the bd update must have re-applied the auto_dispatch_tag.
+	logBytes, err := os.ReadFile(bdLog)
+	require.NoError(t, err)
+	logged := string(logBytes)
+	assert.Contains(t, logged, "update "+beadID, "bd update should target the bead")
+	assert.Contains(t, logged, "--add-label=forgeReady",
+		"bd update should re-apply the auto_dispatch_tag that releaseBeadClaim strips")
+}
+
+// TestHandleIPC_RetryBead_PreservesCrucibleStatusOnBdFailure verifies that
+// when the bd update fails (e.g. anvil missing from config), the in-memory
+// crucibleStatuses entry is left alone so the UI doesn't drop paused state
+// on a transient shell error.
+func TestHandleIPC_RetryBead_PreservesCrucibleStatusOnBdFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "state.db")
+	db, err := state.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:            db,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		worktreeMgr:   worktree.NewManager(),
+		promptBuilder: prompt.NewBuilder(),
+		runCtx:        context.Background(),
+		reqTracker:    *ipc.NewRequestTracker("test-"),
+	}
+	// Empty anvil config — the goroutine will skip the bd update entirely.
+	d.cfg.Store(&config.Config{})
+
+	const beadID = "BD-NOBD"
+	const anvil = "missing-anvil"
+	_, broke, err := db.IncrementDispatchFailures(beadID, anvil, 1, "test failure")
+	require.NoError(t, err)
+	require.True(t, broke)
+
+	d.crucibleStatuses.Store(anvil+"/"+beadID, "paused")
+
+	payload, _ := json.Marshal(ipc.RetryBeadPayload{BeadID: beadID, Anvil: anvil})
+	resp := d.handleIPC(ipc.Command{Type: "retry_bead", Payload: payload})
+	assert.Equal(t, "queued", resp.Type)
+
+	require.Eventually(t, func() bool {
+		return d.reqTracker.Pending() == 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	_, stillPresent := d.crucibleStatuses.Load(anvil + "/" + beadID)
+	assert.True(t, stillPresent, "crucibleStatuses entry should be preserved when bd update did not succeed")
+}
+
+// TestHandleIPC_CrucibleAction_Resume_RestoresAutoDispatchTag verifies that
+// the crucible_action resume path re-applies the anvil's auto_dispatch_tag
+// (which releaseBeadClaim strips when a pipeline fails). Without this, the
+// bead returns to status=open but stays invisible to bd ready on
+// tagged-dispatch anvils.
+func TestHandleIPC_CrucibleAction_Resume_RestoresAutoDispatchTag(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	bdLog := filepath.Join(tmpDir, "bd-args.log")
+	var bdScript, bdContent string
+	if runtime.GOOS == "windows" {
+		bdScript = filepath.Join(tmpDir, "bd.bat")
+		bdContent = "@echo off\r\necho %*>>\"" + bdLog + "\"\r\nif \"%1\"==\"update\" (\r\n  echo {\"id\":\"%2\",\"status\":\"open\"}\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n"
+	} else {
+		bdScript = filepath.Join(tmpDir, "bd")
+		bdContent = "#!/bin/sh\necho \"$@\" >> \"" + bdLog + "\"\nif [ \"$1\" = \"update\" ]; then\n  echo '{\"id\":\"'\"$2\"'\",\"status\":\"open\"}'\n  exit 0\nfi\nexit 1\n"
+	}
+	require.NoError(t, os.WriteFile(bdScript, []byte(bdContent), 0o755))
+
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmpDir+string(os.PathListSeparator)+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	dbPath := filepath.Join(tmpDir, "state.db")
+	db, err := state.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:            db,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		worktreeMgr:   worktree.NewManager(),
+		promptBuilder: prompt.NewBuilder(),
+		runCtx:        context.Background(),
+		reqTracker:    *ipc.NewRequestTracker("test-"),
+	}
+	d.cfg.Store(&config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			"munin": {Path: tmpDir, AutoDispatchTag: "forgeReady"},
+		},
+	})
+
+	const parentID = "BD-PARENT"
+	d.crucibleStatuses.Store("munin/"+parentID, "paused")
+
+	// Resume via Hearth using a mixed-case anvil name to also exercise
+	// the canonicalisation path.
+	payload, _ := json.Marshal(ipc.CrucibleActionPayload{
+		ParentID: parentID,
+		Anvil:    "Munin",
+		Action:   "resume",
+	})
+	resp := d.handleIPC(ipc.Command{Type: "crucible_action", Payload: payload})
+	assert.Equal(t, "ok", resp.Type)
+
+	logBytes, err := os.ReadFile(bdLog)
+	require.NoError(t, err)
+	logged := string(logBytes)
+	assert.Contains(t, logged, "update "+parentID)
+	assert.Contains(t, logged, "--add-label=forgeReady",
+		"crucible resume must re-apply the auto_dispatch_tag")
+
+	// The paused entry should be cleared after a successful resume.
+	_, stillPresent := d.crucibleStatuses.Load("munin/" + parentID)
+	assert.False(t, stillPresent)
+}
+
 func TestHandleIPC_DismissBead(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-test-*")
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

- **forge queue retry now resumes paused crucibles** - `forge queue retry` clears the daemon's in-memory paused crucible status and re-applies the anvil's `auto_dispatch_tag` (which `releaseBeadClaim` strips when a pipeline fails), so a paused crucible can re-enter the loop without a daemon restart. (Forge-s3d6)
- **Hearth crucible resume restores auto_dispatch_tag** - The Hearth "resume" action now re-adds the anvil's `auto_dispatch_tag` to the parent bead so tagged-dispatch anvils can rediscover it via `bd ready`. (Forge-s3d6)
- **Anvil name lookups are case-insensitive** - `forge queue retry` and the Hearth crucible action handlers canonicalise user-provided anvil names against the configured registry, so passing `--anvil Munin` resolves to the configured `munin` instead of failing with "no retry record found". (Forge-s3d6)

## Original Issue (bug): forge queue retry doesn't resume paused crucibles (in-memory state retained)

When a Smith escalates and a crucible is paused (event: crucible_paused), running 'forge queue retry <parent-id> --anvil <name>' clears the dispatch circuit-breaker but does NOT clear the daemon's in-memory crucibleStatuses map and does NOT trigger a re-poll. Result: bead status becomes open, but daemon still considers the crucible paused, so the parent never re-enters the crucible loop until the daemon is restarted (or the user opens 'forge hearth' and uses the per-row 'resume' action which goes through the IPC 'crucible_action' path).

Two code paths diverge:
- internal/daemon/daemon.go 'crucible_action' (Hearth → resume): ResetDispatchFailures + bd update --status=open --assignee= + d.crucibleStatuses.Delete(...) + go d.pollAndDispatch(...). Correct.
- internal/daemon/daemon.go 'retry_bead' (forge queue retry): ResetRetry + bd update --status=open --assignee=. Missing the crucibleStatuses.Delete and pollAndDispatch.

Repro from real incident on 2026-04-29: Fhi.Metadata-k41dx escalated NEEDS_HUMAN at 09:06 (worktree cwd leak landed a stray commit on parent main). Pipeline failed, crucible paused. After dropping the stray commit on parent main and running 'forge queue retry Fhi.Metadata-k41dx --anvil munin', the crucible remained paused — no dispatch attempts, no re-discovery.

---
Bead: Forge-s3d6 | Branch: forge/Forge-s3d6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)