### PR TITLE
Add container/foreground mode flag to forge daemon (Forge-7ux1)

### DIFF
--- a/changelog.d/Forge-7ux1.md
+++ b/changelog.d/Forge-7ux1.md
@@ -1,0 +1,2 @@
+category: Added
+- **FORGE_FOREGROUND env var for container deployments** - Setting `FORGE_FOREGROUND=1` (or `true`/`yes`/`on`) on `forge up` skips the platform-specific detach and runs the daemon in the current process, required when running as PID 1 in a Kubernetes pod. Local behaviour is unchanged when the variable is unset. (Forge-7ux1)

--- a/cmd/forge/daemon.go
+++ b/cmd/forge/daemon.go
@@ -49,12 +49,14 @@ var upCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Start daemon in background by re-executing ourselves with a hidden flag.
+		// Start daemon in background by re-executing ourselves with --foreground.
 		// FORGE_FOREGROUND=1 forces foreground mode without re-execution — required
 		// when running as PID 1 in a container, where detaching would orphan the
 		// daemon goroutines and exit PID 1, killing the container.
+		// CLI flags take precedence: only consult FORGE_FOREGROUND when --foreground
+		// was not explicitly set, so --foreground=false provides an escape hatch.
 		foreground, _ := cmd.Flags().GetBool("foreground")
-		if !foreground && isForegroundEnv() {
+		if !cmd.Flags().Changed("foreground") && isForegroundEnv() {
 			foreground = true
 		}
 		if foreground {

--- a/cmd/forge/daemon.go
+++ b/cmd/forge/daemon.go
@@ -5,15 +5,27 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
+
 	"github.com/Robin831/Forge/internal/daemon"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	upCmd.Flags().Bool("foreground", false, "Run daemon in foreground (for debugging)")
+	upCmd.Flags().Bool("foreground", false, "Run daemon in foreground (for debugging or containers)")
 
 	rootCmd.AddCommand(upCmd)
 	rootCmd.AddCommand(downCmd)
+}
+
+// isForegroundEnv reports whether FORGE_FOREGROUND requests foreground mode.
+// Accepts "1", "true", "yes", "on" (case-insensitive); empty or anything else is false.
+func isForegroundEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("FORGE_FOREGROUND"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 var upCmd = &cobra.Command{
@@ -37,8 +49,14 @@ var upCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Start daemon in background by re-executing ourselves with a hidden flag
+		// Start daemon in background by re-executing ourselves with a hidden flag.
+		// FORGE_FOREGROUND=1 forces foreground mode without re-execution — required
+		// when running as PID 1 in a container, where detaching would orphan the
+		// daemon goroutines and exit PID 1, killing the container.
 		foreground, _ := cmd.Flags().GetBool("foreground")
+		if !foreground && isForegroundEnv() {
+			foreground = true
+		}
 		if foreground {
 			// Run in foreground (used by the background spawn and for debugging)
 			d, err := daemon.New(cfg)


### PR DESCRIPTION
## Changes

- **FORGE_FOREGROUND env var for container deployments** - Setting `FORGE_FOREGROUND=1` (or `true`/`yes`/`on`) on `forge up` skips the platform-specific detach and runs the daemon in the current process, required when running as PID 1 in a Kubernetes pod. Local behaviour is unchanged when the variable is unset. (Forge-7ux1)

## Original Issue: Add container/foreground mode flag to forge daemon

When forge runs as PID 1 in a Kubernetes pod, the daemon must NOT detach into a background process. Detaching orphans the daemon goroutines and exits PID 1, killing the container. Add an FORGE_FOREGROUND=1 environment variable (or equivalent flag) that skips the platform-specific detach in cmd/forge/daemon.go. Existing local behaviour must be unchanged when the env var is unset. This is required infrastructure for the Hearth 2.0 / skybert pod deployment plan.

---
Bead: Forge-7ux1 | Branch: forge/Forge-7ux1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)