### PR TITLE
Forge worktree management leaves stale core.worktree in main repo (Forge-d6j5)

### DIFF
--- a/changelog.d/Forge-d6j5.md
+++ b/changelog.d/Forge-d6j5.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Stale `core.worktree` self-heal in worktree manager** - Worktree creation and removal now detect and unset a stale `core.worktree` setting on the main repo when it points to a removed-or-empty worker path. The stale value caused `git status --porcelain` to fail with exit 128, which in turn broke Go's VCS stamping during `go build` from any worker. (Forge-d6j5)

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -451,11 +451,14 @@ func installBeadsRedirect(anvilPath, worktreePath string) error {
 // and continue.
 func CleanStaleCoreWorktree(ctx context.Context, anvilPath string) error {
 	value, err := readCoreWorktree(ctx, anvilPath)
-	if err != nil || value == "" {
-		// Not set, or git could not read the config — nothing to do.
+	if err != nil {
+		return fmt.Errorf("reading core.worktree: %w", err)
+	}
+	if value == "" {
 		return nil
 	}
-	if !isStaleWorktreePath(value) {
+	resolved := resolveWorktreePath(anvilPath, value)
+	if !isStaleWorktreePath(resolved) {
 		return nil
 	}
 	if err := unsetCoreWorktree(ctx, anvilPath); err != nil {
@@ -466,14 +469,77 @@ func CleanStaleCoreWorktree(ctx context.Context, anvilPath string) error {
 	return nil
 }
 
+// localGitEnv returns the process environment with Forge-set git overrides
+// stripped so that git commands discover the repo from cmd.Dir rather than
+// from inherited GIT_DIR / GIT_WORK_TREE values.
+func localGitEnv() []string {
+	skip := map[string]bool{
+		"GIT_DIR":                 true,
+		"GIT_WORK_TREE":           true,
+		"GIT_CEILING_DIRECTORIES": true,
+	}
+	base := os.Environ()
+	out := make([]string, 0, len(base))
+	for _, e := range base {
+		key, _, _ := strings.Cut(e, "=")
+		if !skip[key] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// anvilGitEnv returns an environment suitable for git commands that should
+// operate on anvilPath. It strips any inherited GIT_DIR / GIT_WORK_TREE /
+// GIT_CEILING_DIRECTORIES overrides (Forge sets these in worktree subprocesses)
+// and then pins GIT_WORK_TREE to anvilPath. The pinned GIT_WORK_TREE overrides
+// any core.worktree value in .git/config so git does not try to chdir to a
+// possibly-missing path before the command even runs.
+func anvilGitEnv(anvilPath string) []string {
+	out := localGitEnv()
+	out = append(out, "GIT_WORK_TREE="+anvilPath)
+	return out
+}
+
+// anvilGitConfigFile returns the path to the main repo's .git/config file.
+// For a standard (non-bare) repository, this is always <anvilPath>/.git/config.
+// We locate it directly from the filesystem to avoid running git commands that
+// would fail when core.worktree is set to a missing path.
+func anvilGitConfigFile(anvilPath string) string {
+	return filepath.Join(anvilPath, ".git", "config")
+}
+
+// resolveWorktreePath resolves a core.worktree config value to an absolute
+// filesystem path. Git interprets relative values relative to the repo's
+// gitdir (the .git directory), not the process working directory. We resolve
+// the gitdir from the filesystem rather than via git to avoid failures when
+// core.worktree itself is already broken.
+func resolveWorktreePath(anvilPath, value string) string {
+	if filepath.IsAbs(value) {
+		return value
+	}
+	// For a standard repo the gitdir is <anvilPath>/.git. We check directly
+	// rather than running `git rev-parse --git-dir` because git may refuse to
+	// start when core.worktree points to a missing directory.
+	gitDir := filepath.Join(anvilPath, ".git")
+	if info, err := os.Stat(gitDir); err != nil || !info.IsDir() {
+		// Non-standard layout — fall back to resolving relative to anvilPath.
+		return filepath.Join(anvilPath, value)
+	}
+	return filepath.Join(gitDir, value)
+}
+
 // readCoreWorktree returns the value of core.worktree from the main repo's
-// .git/config, or "" if the key is unset. It uses `git config --local` so
-// it reads only the main repo's config, not any per-worktree overlay.
+// .git/config, or "" if the key is unset. It uses `git config --file` to
+// read the config file directly, bypassing git's working-tree validation so
+// the function succeeds even when core.worktree already points to a missing
+// path (which would cause `git config --local` to exit 128).
 func readCoreWorktree(ctx context.Context, anvilPath string) (string, error) {
 	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "config", "--local", "--get", "core.worktree"))
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "config", "--file", anvilGitConfigFile(anvilPath), "--get", "core.worktree"))
 	cmd.Dir = anvilPath
+	cmd.Env = anvilGitEnv(anvilPath)
 	out, err := cmd.Output()
 	if err != nil {
 		// Exit code 1 from `git config --get` means the key is unset; treat as no value.
@@ -486,13 +552,15 @@ func readCoreWorktree(ctx context.Context, anvilPath string) (string, error) {
 }
 
 // unsetCoreWorktree removes the core.worktree key from the main repo's
-// .git/config. Tolerates "key not set" (exit code 5) — the result we want is
-// already true.
+// .git/config. Uses `git config --file` to write the config file directly,
+// bypassing git's working-tree validation. Tolerates "key not set" (exit
+// code 5) — the result we want is already true.
 func unsetCoreWorktree(ctx context.Context, anvilPath string) error {
 	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "config", "--local", "--unset", "core.worktree"))
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "config", "--file", anvilGitConfigFile(anvilPath), "--unset", "core.worktree"))
 	cmd.Dir = anvilPath
+	cmd.Env = anvilGitEnv(anvilPath)
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 5 {
 			return nil
@@ -594,6 +662,7 @@ func CurrentBranch(ctx context.Context, repoPath string) (string, error) {
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "rev-parse", "--abbrev-ref", "HEAD"))
 	cmd.Dir = repoPath
+	cmd.Env = localGitEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
@@ -669,6 +738,7 @@ func gitCmdOut(ctx context.Context, dir string, out io.Writer, args ...string) e
 
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", args...))
 	cmd.Dir = dir
+	cmd.Env = localGitEnv()
 	cmd.Stdout = out
 	cmd.Stderr = out
 
@@ -787,6 +857,7 @@ func ValidateWorktreeDir(worktreePath string) error {
 	defer cancel()
 	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "rev-parse", "--git-dir"))
 	cmd.Dir = worktreePath
+	cmd.Env = localGitEnv()
 	if err := cmd.Run(); err != nil {
 		// Not inside any git repository — safe to proceed.
 		return nil

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -116,6 +116,17 @@ func (m *Manager) CreateWithOptions(ctx context.Context, anvilPath, beadID strin
 		return nil, fmt.Errorf("creating workers directory: %w", err)
 	}
 
+	// Self-heal any pre-existing stale core.worktree setting on the main repo
+	// before we run any git commands that would touch it. A stale value
+	// pointing to a removed worker path breaks `git status --porcelain`
+	// (exit 128 "must be run in a work tree"), which in turn breaks Go's
+	// VCS stamping during `go build` from this worktree.
+	if err := CleanStaleCoreWorktree(ctx, anvilPath); err != nil {
+		// Non-fatal: log and continue. If the unset truly fails, downstream
+		// git commands will surface a clearer error.
+		slog.Warn("worktree: failed to clean stale core.worktree", "anvil", anvilPath, "error", err)
+	}
+
 	// If worktree directory already exists, check whether it is a valid git
 	// worktree. If so, reset it to a clean state and reuse it. If not (e.g.
 	// leftover directory from a failed run), remove it so we can create fresh.
@@ -372,6 +383,15 @@ func (m *Manager) Remove(ctx context.Context, anvilPath string, wt *Worktree) er
 	// was just created. Remote branch cleanup is handled by GitHub's auto-delete
 	// setting or by Bellows after PR merge.
 
+	// Belt-and-braces: ensure no stale core.worktree setting is left on the
+	// main repo pointing at the path we just removed. `git worktree remove`
+	// does not write core.worktree, but older Forge versions or external
+	// tooling may have done so; this keeps the main repo healthy regardless.
+	if err := CleanStaleCoreWorktree(ctx, anvilPath); err != nil {
+		slog.Warn("worktree: failed to clean stale core.worktree after remove",
+			"anvil", anvilPath, "error", err)
+	}
+
 	return nil
 }
 
@@ -410,6 +430,94 @@ func installBeadsRedirect(anvilPath, worktreePath string) error {
 
 	redirectFile := filepath.Join(worktreeBeadsDir, "redirect")
 	return os.WriteFile(redirectFile, []byte(mainBeadsDir+"\n"), 0o644)
+}
+
+// CleanStaleCoreWorktree removes a stale core.worktree setting from the main
+// repository's .git/config when it points to a path that no longer exists or
+// is empty. Such a stale setting breaks tooling that resolves the main repo's
+// gitdir — notably Go's VCS stamping, which cd's into the main repo via the
+// worktree's .git pointer and runs `git status --porcelain`. When core.worktree
+// points to a missing/empty path, that command fails with exit 128
+// ("fatal: this operation must be run in a work tree"), which in turn breaks
+// `go build` for any worker. Forge itself does not set core.worktree on the
+// main repo (per-worktree values live in .git/worktrees/<name>/config.worktree
+// and are managed by `git worktree add`), but older Forge versions, manual git
+// invocations, or third-party tools may have written one. This helper is the
+// idempotent self-heal.
+//
+// The check is conservative: it only unsets when the configured path is
+// missing or empty. A path that exists with content is left alone, in case it
+// was set deliberately by the user. Errors are non-fatal — callers should log
+// and continue.
+func CleanStaleCoreWorktree(ctx context.Context, anvilPath string) error {
+	value, err := readCoreWorktree(ctx, anvilPath)
+	if err != nil || value == "" {
+		// Not set, or git could not read the config — nothing to do.
+		return nil
+	}
+	if !isStaleWorktreePath(value) {
+		return nil
+	}
+	if err := unsetCoreWorktree(ctx, anvilPath); err != nil {
+		return fmt.Errorf("unsetting stale core.worktree=%q: %w", value, err)
+	}
+	slog.Info("worktree: unset stale core.worktree on main repo",
+		"anvil", anvilPath, "stale_value", value)
+	return nil
+}
+
+// readCoreWorktree returns the value of core.worktree from the main repo's
+// .git/config, or "" if the key is unset. It uses `git config --local` so
+// it reads only the main repo's config, not any per-worktree overlay.
+func readCoreWorktree(ctx context.Context, anvilPath string) (string, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "config", "--local", "--get", "core.worktree"))
+	cmd.Dir = anvilPath
+	out, err := cmd.Output()
+	if err != nil {
+		// Exit code 1 from `git config --get` means the key is unset; treat as no value.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// unsetCoreWorktree removes the core.worktree key from the main repo's
+// .git/config. Tolerates "key not set" (exit code 5) — the result we want is
+// already true.
+func unsetCoreWorktree(ctx context.Context, anvilPath string) error {
+	cmdCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "config", "--local", "--unset", "core.worktree"))
+	cmd.Dir = anvilPath
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 5 {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// isStaleWorktreePath reports whether path is missing on disk or is an empty
+// directory. Both conditions break `git status --porcelain` against the main
+// repo when configured as core.worktree.
+func isStaleWorktreePath(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return os.IsNotExist(err)
+	}
+	if !info.IsDir() {
+		return true
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) == 0
 }
 
 // resolveBaseRef determines whether the repo uses origin/main or origin/master.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -773,6 +773,169 @@ func envWithoutGitVars() []string {
 	return out
 }
 
+// TestCleanStaleCoreWorktree_UnsetsMissingPath verifies that
+// CleanStaleCoreWorktree removes a core.worktree setting that points to a
+// path which no longer exists on disk.
+func TestCleanStaleCoreWorktree_UnsetsMissingPath(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir, "main")
+
+	// Seed a stale core.worktree pointing at a path that doesn't exist.
+	stale := filepath.Join(t.TempDir(), "removed-worker")
+	runGit(t, dir, "config", "core.worktree", stale)
+
+	if err := CleanStaleCoreWorktree(context.Background(), dir); err != nil {
+		t.Fatalf("CleanStaleCoreWorktree: %v", err)
+	}
+
+	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Errorf("core.worktree should be unset, but got %q", strings.TrimSpace(string(out)))
+	}
+}
+
+// TestCleanStaleCoreWorktree_UnsetsEmptyDir verifies that
+// CleanStaleCoreWorktree removes a core.worktree setting that points to an
+// existing-but-empty directory. An empty directory triggers the same
+// `git status --porcelain` exit-128 failure as a missing path.
+func TestCleanStaleCoreWorktree_UnsetsEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir, "main")
+
+	emptyDir := t.TempDir() // exists but contains nothing
+	runGit(t, dir, "config", "core.worktree", emptyDir)
+
+	if err := CleanStaleCoreWorktree(context.Background(), dir); err != nil {
+		t.Fatalf("CleanStaleCoreWorktree: %v", err)
+	}
+
+	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
+	cmd.Dir = dir
+	if err := cmd.Run(); err == nil {
+		t.Error("core.worktree should be unset when value points to an empty directory")
+	}
+}
+
+// TestCleanStaleCoreWorktree_PreservesValidPath verifies that
+// CleanStaleCoreWorktree leaves a core.worktree value alone when it points to
+// a directory that exists and is non-empty. We treat such a value as
+// potentially intentional and only self-heal the clearly-broken cases.
+func TestCleanStaleCoreWorktree_PreservesValidPath(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir, "main")
+
+	validDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(validDir, "marker"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "config", "core.worktree", validDir)
+
+	if err := CleanStaleCoreWorktree(context.Background(), dir); err != nil {
+		t.Fatalf("CleanStaleCoreWorktree: %v", err)
+	}
+
+	got := gitOutput(t, dir, "config", "--local", "--get", "core.worktree")
+	if got != validDir {
+		t.Errorf("core.worktree was modified: got %q, want %q", got, validDir)
+	}
+}
+
+// TestCleanStaleCoreWorktree_NoOpWhenUnset verifies that
+// CleanStaleCoreWorktree returns nil and makes no change when core.worktree
+// is not set at all (the common case).
+func TestCleanStaleCoreWorktree_NoOpWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir, "main")
+
+	if err := CleanStaleCoreWorktree(context.Background(), dir); err != nil {
+		t.Errorf("CleanStaleCoreWorktree on repo with no core.worktree: unexpected error: %v", err)
+	}
+}
+
+// TestCreateWithOptions_DoesNotSetCoreWorktree verifies that creating a
+// worktree does not write core.worktree to the main repo's .git/config.
+// Per-worktree values belong in .git/worktrees/<name>/config.worktree, which
+// `git worktree add` manages on its own.
+func TestCreateWithOptions_DoesNotSetCoreWorktree(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	mgr := NewManager()
+	if _, err := mgr.CreateWithOptions(context.Background(), anvilDir, "no-cw-test", CreateOptions{}); err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
+	cmd.Dir = anvilDir
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Errorf("main repo should not have core.worktree set after worktree creation, got %q",
+			strings.TrimSpace(string(out)))
+	}
+}
+
+// TestCreateWithOptions_SelfHealsStaleCoreWorktree verifies that
+// CreateWithOptions clears a pre-existing stale core.worktree before
+// proceeding. This guards against state left by older Forge versions or
+// manual git invocations.
+func TestCreateWithOptions_SelfHealsStaleCoreWorktree(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	// Seed a stale core.worktree pointing at a non-existent path.
+	stale := filepath.Join(t.TempDir(), "ghost-worker")
+	runGit(t, anvilDir, "config", "core.worktree", stale)
+
+	mgr := NewManager()
+	if _, err := mgr.CreateWithOptions(context.Background(), anvilDir, "self-heal-test", CreateOptions{}); err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
+	cmd.Dir = anvilDir
+	if err := cmd.Run(); err == nil {
+		t.Error("CreateWithOptions should have unset stale core.worktree on the main repo")
+	}
+}
+
+// TestRemove_UnsetsStaleCoreWorktree verifies that Manager.Remove clears any
+// stale core.worktree setting on the main repo. This is the regression test
+// for the originally reported bug: after a worker was cleaned up, a leftover
+// core.worktree caused `git status --porcelain` against the main repo to
+// fail with exit 128, breaking `go build` for any subsequent worker.
+func TestRemove_UnsetsStaleCoreWorktree(t *testing.T) {
+	_, anvilDir := initBareRemoteCloneWithInitialCommit(t)
+
+	mgr := NewManager()
+	ctx := context.Background()
+	wt, err := mgr.CreateWithOptions(ctx, anvilDir, "remove-cw-test", CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateWithOptions: %v", err)
+	}
+
+	// Simulate the stale state described in the bug report: core.worktree
+	// pointing at the worker that's about to be removed.
+	runGit(t, anvilDir, "config", "core.worktree", wt.Path)
+
+	if err := mgr.Remove(ctx, anvilDir, wt); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	// After remove, core.worktree must be unset (the path it pointed to no
+	// longer exists, so the self-heal triggers).
+	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
+	cmd.Dir = anvilDir
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Errorf("Remove should clear stale core.worktree, got %q", strings.TrimSpace(string(out)))
+	}
+
+	// Regression assertion from the bug report: `git status --porcelain`
+	// against the main repo must succeed (exit 0) after a worker round-trip.
+	cmd = exec.Command("git", "status", "--porcelain")
+	cmd.Dir = anvilDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Errorf("git status --porcelain on main repo failed after worker remove: %v\n%s", err, out)
+	}
+}
+
 // gitOutput runs a git command and returns trimmed stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -34,6 +34,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
@@ -100,6 +101,7 @@ func TestCurrentBranch_OnFeatureBranch(t *testing.T) {
 	// Create and switch to a feature branch.
 	cmd := exec.Command("git", "checkout", "-b", "forge/test-bead")
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git checkout -b: %v\n%s", err, out)
 	}
@@ -138,6 +140,7 @@ func TestAssertOnMainBranch_OnFeatureBranch(t *testing.T) {
 	// Simulate environment corruption: checkout a feature branch.
 	cmd := exec.Command("git", "checkout", "-b", "forge/Forge-x1bs")
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git checkout -b: %v\n%s", err, out)
 	}
@@ -185,6 +188,7 @@ func TestVerifyAndRecoverMain_OnFeatureBranch(t *testing.T) {
 	// Simulate environment corruption: checkout a feature branch.
 	cmd := exec.Command("git", "checkout", "-b", "forge/Forge-x1bs")
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git checkout -b: %v\n%s", err, out)
 	}
@@ -691,6 +695,7 @@ func TestGitEnv_ConfinesGitFromOutsideWorktree(t *testing.T) {
 	// the anvil's checkout (the dangerous default we're protecting against).
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Dir = anvilDir
+	cmd.Env = envWithoutGitVars()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("baseline git rev-parse: %v\n%s", err, out)
@@ -790,6 +795,7 @@ func TestCleanStaleCoreWorktree_UnsetsMissingPath(t *testing.T) {
 
 	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err == nil {
 		t.Errorf("core.worktree should be unset, but got %q", strings.TrimSpace(string(out)))
 	}
@@ -812,6 +818,7 @@ func TestCleanStaleCoreWorktree_UnsetsEmptyDir(t *testing.T) {
 
 	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	if err := cmd.Run(); err == nil {
 		t.Error("core.worktree should be unset when value points to an empty directory")
 	}
@@ -853,6 +860,57 @@ func TestCleanStaleCoreWorktree_NoOpWhenUnset(t *testing.T) {
 	}
 }
 
+// TestCleanStaleCoreWorktree_RelativePathMissing verifies that a relative
+// core.worktree value that resolves (via gitdir) to a non-existent path is
+// treated as stale and unset.
+func TestCleanStaleCoreWorktree_RelativePathMissing(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir, "main")
+
+	// Set core.worktree to a relative path. Git resolves relative values
+	// relative to the gitdir (<dir>/.git), so "../nonexistent-worker" resolves
+	// to <dir>/nonexistent-worker, which does not exist.
+	runGit(t, dir, "config", "core.worktree", "../nonexistent-worker")
+
+	if err := CleanStaleCoreWorktree(context.Background(), dir); err != nil {
+		t.Fatalf("CleanStaleCoreWorktree: %v", err)
+	}
+
+	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
+	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
+	if err := cmd.Run(); err == nil {
+		t.Error("core.worktree should have been unset for a relative path resolving to a missing directory")
+	}
+}
+
+// TestCleanStaleCoreWorktree_RelativePathValid verifies that a relative
+// core.worktree value that resolves to a non-empty directory is preserved.
+func TestCleanStaleCoreWorktree_RelativePathValid(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir, "main")
+
+	// Create <dir>/valid-wt with content. With gitdir = <dir>/.git, the
+	// relative value "../valid-wt" resolves to <dir>/valid-wt.
+	validWt := filepath.Join(dir, "valid-wt")
+	if err := os.MkdirAll(validWt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(validWt, "marker"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "config", "core.worktree", "../valid-wt")
+
+	if err := CleanStaleCoreWorktree(context.Background(), dir); err != nil {
+		t.Fatalf("CleanStaleCoreWorktree: %v", err)
+	}
+
+	got := gitOutput(t, dir, "config", "--local", "--get", "core.worktree")
+	if got != "../valid-wt" {
+		t.Errorf("core.worktree was modified: got %q, want %q", got, "../valid-wt")
+	}
+}
+
 // TestCreateWithOptions_DoesNotSetCoreWorktree verifies that creating a
 // worktree does not write core.worktree to the main repo's .git/config.
 // Per-worktree values belong in .git/worktrees/<name>/config.worktree, which
@@ -867,6 +925,7 @@ func TestCreateWithOptions_DoesNotSetCoreWorktree(t *testing.T) {
 
 	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
 	cmd.Dir = anvilDir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err == nil {
 		t.Errorf("main repo should not have core.worktree set after worktree creation, got %q",
 			strings.TrimSpace(string(out)))
@@ -891,6 +950,7 @@ func TestCreateWithOptions_SelfHealsStaleCoreWorktree(t *testing.T) {
 
 	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
 	cmd.Dir = anvilDir
+	cmd.Env = envWithoutGitVars()
 	if err := cmd.Run(); err == nil {
 		t.Error("CreateWithOptions should have unset stale core.worktree on the main repo")
 	}
@@ -923,6 +983,7 @@ func TestRemove_UnsetsStaleCoreWorktree(t *testing.T) {
 	// longer exists, so the self-heal triggers).
 	cmd := exec.Command("git", "config", "--local", "--get", "core.worktree")
 	cmd.Dir = anvilDir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err == nil {
 		t.Errorf("Remove should clear stale core.worktree, got %q", strings.TrimSpace(string(out)))
 	}
@@ -931,6 +992,7 @@ func TestRemove_UnsetsStaleCoreWorktree(t *testing.T) {
 	// against the main repo must succeed (exit 0) after a worker round-trip.
 	cmd = exec.Command("git", "status", "--porcelain")
 	cmd.Dir = anvilDir
+	cmd.Env = envWithoutGitVars()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Errorf("git status --porcelain on main repo failed after worker remove: %v\n%s", err, out)
 	}
@@ -941,6 +1003,7 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = envWithoutGitVars()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)


### PR DESCRIPTION
## Changes

- **Stale `core.worktree` self-heal in worktree manager** - Worktree creation and removal now detect and unset a stale `core.worktree` setting on the main repo when it points to a removed-or-empty worker path. The stale value caused `git status --porcelain` to fail with exit 128, which in turn broke Go's VCS stamping during `go build` from any worker. (Forge-d6j5)

## Original Issue (bug): Forge worktree management leaves stale core.worktree in main repo

The main repo at /home/robin/source/Forge had a stale 'core.worktree' setting in .git/config pointing to a no-longer-existing worker path (Forge-s0wk). This breaks 'go build' for any worker because Go's VCS detection cd's to the main repo (via the worktree's .git pointer) and runs 'git status --porcelain', which fails with 'fatal: this operation must be run in a work tree' (exit 128) when core.worktree points to a path that doesn't exist or is empty. Reproduce: env -i PATH="$PATH" HOME="$HOME" go build ./... from a Forge worktree. Fix: ensure internal/worktree/worktree.go does not set core.worktree on the main repo, and/or unset it during worker cleanup. Workaround applied for Forge-4r9o iteration: 'git -C /home/robin/source/Forge config --unset core.worktree'.

---
Bead: Forge-d6j5 | Branch: forge/Forge-d6j5
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)