### PR TITLE
queue: 'clear' command to dismiss needs-attention without redispatching (Forge-b05m)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ forge queue run <id>                  # Manually dispatch a bead
 forge queue stop <id> --anvil <name>  # Kill worker, prevent re-dispatch
 forge queue clarify <id>              # Mark bead as needing clarification
 forge queue unclarify <id>            # Clear clarification flag
-forge queue retry <id>                # Reset dispatch circuit breaker
+forge queue retry <id>                # Reset circuit breaker AND re-dispatch on next poll
+forge queue clear <id>                # Clear needs-attention flags WITHOUT re-dispatching
 forge history                         # Show recent worker history
 forge history events                  # Show event log
 forge ingots list                     # List ingot records (bead lifecycle)

--- a/changelog.d/Forge-b05m.md
+++ b/changelog.d/Forge-b05m.md
@@ -1,0 +1,2 @@
+category: Added
+- **`forge queue clear` command** - Clears the needs-attention flags from a bead's retry row without re-dispatching. Use this when the underlying work is already done (PR merged, bead closed) and you only want the bead to drop out of the needs-attention list. Unlike `retry`, it does not schedule a re-dispatch; unlike `stop`, it does not mark the bead as needing clarification. Idempotent and emits a `retry_cleared` event. (Forge-b05m)

--- a/cmd/forge/queue.go
+++ b/cmd/forge/queue.go
@@ -26,11 +26,14 @@ func init() {
 	queueStopCmd.Flags().StringP("anvil", "a", "", "Anvil name (required)")
 	_ = queueStopCmd.MarkFlagRequired("anvil")
 	queueStopCmd.Flags().StringP("reason", "r", "", "Why the bead is being stopped (optional)")
+	queueClearCmd.Flags().StringP("anvil", "a", "", "Anvil name (required)")
+	_ = queueClearCmd.MarkFlagRequired("anvil")
 	queueCmd.AddCommand(queueRunCmd)
 	queueCmd.AddCommand(queueClarifyCmd)
 	queueCmd.AddCommand(queueUnclarifyCmd)
 	queueCmd.AddCommand(queueRetryCmd)
 	queueCmd.AddCommand(queueStopCmd)
+	queueCmd.AddCommand(queueClearCmd)
 	rootCmd.AddCommand(queueCmd)
 }
 
@@ -184,7 +187,7 @@ var queueClarifyCmd = &cobra.Command{
 
 var queueRetryCmd = &cobra.Command{
 	Use:     "retry <id>",
-	Short:   "Reset dispatch circuit breaker for a bead (clears needs_human from dispatch failures)",
+	Short:   "Reset the circuit breaker and re-dispatch the bead on the next poll",
 	Args:    cobra.ExactArgs(1),
 	Example: "  forge queue retry BD-42 --anvil heimdall",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -324,6 +327,60 @@ The bead will not be dispatched again until you run 'forge queue unclarify'.`,
 		}
 
 		fmt.Printf("Bead %s stopped — use 'forge queue unclarify --anvil %s %s' to resume\n", beadID, anvil, beadID)
+		return nil
+	},
+}
+
+var queueClearCmd = &cobra.Command{
+	Use:   "clear <id>",
+	Short: "Clear the needs-attention flags without re-dispatching",
+	Long: `Clear the needs-attention flags from a bead's retry state without
+triggering a re-dispatch. Use this when the underlying work is already done
+(e.g. PR merged, bead closed) and you only want the bead to stop showing up
+in the needs-attention list.
+
+Unlike 'forge queue retry', this does NOT schedule the bead for the next
+poll. Unlike 'forge queue stop', this does NOT mark the bead as needing
+clarification. Idempotent — safe to run on an already-clean bead.`,
+	Args:    cobra.ExactArgs(1),
+	Example: "  forge queue clear BD-42 --anvil heimdall",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		beadID := args[0]
+		anvil, _ := cmd.Flags().GetString("anvil")
+
+		client, err := ipc.NewClient()
+		if err != nil {
+			return fmt.Errorf("connecting to daemon: %w (is 'forge up' running?)", err)
+		}
+		defer client.Close()
+
+		payload, _ := json.Marshal(ipc.ClearBeadPayload{
+			BeadID: beadID,
+			Anvil:  anvil,
+		})
+
+		resp, err := client.Send(ipc.Command{
+			Type:    "clear_bead",
+			Payload: payload,
+		})
+		if err != nil {
+			return fmt.Errorf("sending command: %w", err)
+		}
+
+		if resp.Type == "error" {
+			var msg map[string]string
+			var errMsg string
+			if err := json.Unmarshal(resp.Payload, &msg); err == nil && msg["message"] != "" {
+				errMsg = msg["message"]
+			} else if len(resp.Payload) > 0 {
+				errMsg = string(resp.Payload)
+			} else {
+				errMsg = "unknown error from daemon"
+			}
+			return fmt.Errorf("daemon error: %s", errMsg)
+		}
+
+		fmt.Printf("Needs-attention flags cleared for bead %s (no re-dispatch)\n", beadID)
 		return nil
 	},
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,10 +171,29 @@ forge queue unclarify BD-42 --anvil my-api
 
 ### `forge queue retry <id>`
 
-Reset the dispatch circuit breaker for a bead so it can be retried.
+Reset the circuit breaker and re-dispatch the bead on the next poll. Use this
+when the previous attempt failed for a transient reason and you want Forge to
+try again.
 
 ```bash
 forge queue retry BD-42 --anvil my-api
+```
+
+| Flag | Description |
+|------|-------------|
+| `-a, --anvil` | Anvil name (required) |
+
+### `forge queue clear <id>`
+
+Clear the needs-attention flags from a bead without triggering a re-dispatch.
+Use this when the underlying work is already done (PR merged, bead closed) and
+you only want the bead to stop showing up in the needs-attention list. Unlike
+`retry`, it does not schedule the bead for the next poll. Unlike `stop`, it
+does not mark the bead as needing clarification. Idempotent — safe to run on
+an already-clean bead.
+
+```bash
+forge queue clear BD-42 --anvil my-api
 ```
 
 | Flag | Description |

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3730,6 +3730,30 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		resp, _ := ipc.NewQueuedResponse(reqID, "retrying bead")
 		return resp
 
+	case "clear_bead":
+		var cp ipc.ClearBeadPayload
+		if err := json.Unmarshal(cmd.Payload, &cp); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": "invalid clear_bead payload"})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if cp.BeadID == "" || cp.Anvil == "" {
+			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if cp.Anvil != "" {
+			if canonical, _, ok := d.resolveAnvilConfig(cp.Anvil); ok {
+				cp.Anvil = canonical
+			}
+		}
+		if err := d.db.ClearNeedsAttention(cp.BeadID, cp.Anvil); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to clear needs-attention flags: %v", err)})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		_ = d.db.LogEvent(state.EventRetryCleared, fmt.Sprintf("Needs-attention flags cleared for bead %s (manual)", cp.BeadID), cp.BeadID, cp.Anvil)
+		d.logger.Info("needs-attention flags cleared", "bead", cp.BeadID, "anvil", cp.Anvil)
+		data, _ := json.Marshal(map[string]string{"message": "needs-attention flags cleared"})
+		return ipc.Response{Type: "ok", Payload: data}
+
 	case "dismiss_bead":
 		var dp ipc.DismissBeadPayload
 		if err := json.Unmarshal(cmd.Payload, &dp); err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1132,6 +1132,88 @@ func TestHandleIPC_DismissBead(t *testing.T) {
 	})
 }
 
+func TestHandleIPC_ClearBead(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "state.db")
+	db, err := state.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:            db,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		worktreeMgr:   worktree.NewManager(),
+		promptBuilder: prompt.NewBuilder(),
+	}
+	d.cfg.Store(&config.Config{})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		resp := d.handleIPC(ipc.Command{Type: "clear_bead", Payload: []byte("invalid")})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "invalid clear_bead payload")
+	})
+
+	t.Run("missing fields", func(t *testing.T) {
+		payload, _ := json.Marshal(ipc.ClearBeadPayload{BeadID: "X"})
+		resp := d.handleIPC(ipc.Command{Type: "clear_bead", Payload: payload})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "bead_id and anvil are required")
+	})
+
+	t.Run("success clears flags but preserves row", func(t *testing.T) {
+		require.NoError(t, db.UpsertRetry(&state.RetryRecord{
+			BeadID:              "BD-CLEAR",
+			Anvil:               "anvil-1",
+			NeedsHuman:          true,
+			DispatchFailures:    3,
+			RecoveryFailures:    1,
+			ClarificationNeeded: true,
+			RetryCount:          5,
+			LastError:           "boom",
+		}))
+
+		payload, _ := json.Marshal(ipc.ClearBeadPayload{BeadID: "BD-CLEAR", Anvil: "anvil-1"})
+		resp := d.handleIPC(ipc.Command{Type: "clear_bead", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+
+		r, err := db.GetRetry("BD-CLEAR", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.False(t, r.NeedsHuman)
+		assert.Equal(t, 0, r.DispatchFailures)
+		assert.Equal(t, 0, r.RecoveryFailures)
+		assert.Empty(t, r.LastError)
+		// Untouched fields.
+		assert.True(t, r.ClarificationNeeded)
+		assert.Equal(t, 5, r.RetryCount)
+
+		// retry_cleared event should be logged.
+		events, err := db.RecentEvents(50)
+		require.NoError(t, err)
+		var found bool
+		for _, e := range events {
+			if e.Type == state.EventRetryCleared && e.BeadID == "BD-CLEAR" && e.Anvil == "anvil-1" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected retry_cleared event for BD-CLEAR")
+	})
+
+	t.Run("idempotent on missing row", func(t *testing.T) {
+		payload, _ := json.Marshal(ipc.ClearBeadPayload{BeadID: "BD-NONE", Anvil: "anvil-1"})
+		resp := d.handleIPC(ipc.Command{Type: "clear_bead", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+	})
+}
+
 func TestResolveGoRaceDetection(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-race-*")
 	require.NoError(t, err)

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -127,6 +127,15 @@ type RetryBeadPayload struct {
 	PRID   int    `json:"pr_id,omitempty"`
 }
 
+// ClearBeadPayload is the payload for a "clear_bead" command.
+// Clears the needs-attention flags from a bead's retry row without triggering
+// a re-dispatch. Idempotent — succeeds even when the row is already clean or
+// missing.
+type ClearBeadPayload struct {
+	BeadID string `json:"bead_id"`
+	Anvil  string `json:"anvil"`
+}
+
 // DismissBeadPayload is the payload for a "dismiss_bead" command.
 // Removes the bead from the Needs Attention list. When PRID > 0, the dismiss
 // targets an exhausted PR (setting status to closed) rather than the retries table.

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1376,6 +1376,7 @@ const (
 	EventClarificationNeeded  EventType = "clarification_needed"
 	EventClarificationCleared EventType = "clarification_cleared"
 	EventRetryReset           EventType = "retry_reset"
+	EventRetryCleared         EventType = "retry_cleared"
 	EventBeadDismissed        EventType = "bead_dismissed"
 	EventSchematicStarted     EventType = "schematic_started"
 	EventSchematicDone        EventType = "schematic_done"
@@ -2202,6 +2203,27 @@ func (db *DB) ResetRetry(beadID, anvil string) error {
 		return fmt.Errorf("no retry record found for bead %q on anvil %q", beadID, anvil)
 	}
 	return nil
+}
+
+// ClearNeedsAttention zeroes the needs-attention flags on a bead's retry row
+// without scheduling a re-dispatch. Unlike ResetRetry it leaves
+// clarification_needed, retry_count, and next_retry untouched, and unlike
+// DismissRetry it preserves the row. It is idempotent: running it on an
+// already-clean row (or a bead with no retry row at all) is a no-op success.
+func (db *DB) ClearNeedsAttention(beadID, anvil string) error {
+	now := time.Now().Format(dbTimeLayout)
+	_, err := db.conn.Exec(
+		`UPDATE retries
+		 SET needs_human = 0,
+		     dispatch_failures = 0,
+		     recovery_failures = 0,
+		     first_recovery_failure_at = NULL,
+		     last_error = '',
+		     updated_at = ?
+		 WHERE bead_id = ? AND anvil = ?`,
+		now, beadID, anvil,
+	)
+	return err
 }
 
 // DismissRetry removes the retry record entirely, clearing the bead from the

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -553,6 +553,238 @@ func TestDB_DismissRetry(t *testing.T) {
 	}
 }
 
+func TestDB_ClearNeedsAttention_ZeroesColumns(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	past := time.Now().Add(-1 * time.Hour)
+	firstFailure := time.Now().Add(-30 * time.Minute)
+	if err := db.UpsertRetry(&RetryRecord{
+		BeadID:               "BD-1",
+		Anvil:                "anvil-1",
+		RetryCount:           4,
+		NextRetry:            &past,
+		NeedsHuman:           true,
+		ClarificationNeeded:  true,
+		DispatchFailures:     3,
+		RecoveryFailures:     2,
+		FirstRecoveryFailure: &firstFailure,
+		LastError:            "boom",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pre, err := db.GetRetry("BD-1", "anvil-1")
+	if err != nil || pre == nil {
+		t.Fatalf("seed record missing: %v", err)
+	}
+	preUpdatedAt := pre.UpdatedAt
+	time.Sleep(5 * time.Millisecond)
+
+	if err := db.ClearNeedsAttention("BD-1", "anvil-1"); err != nil {
+		t.Fatalf("ClearNeedsAttention returned error: %v", err)
+	}
+
+	r, err := db.GetRetry("BD-1", "anvil-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r == nil {
+		t.Fatal("expected record to still exist after clear")
+	}
+	if r.NeedsHuman {
+		t.Error("expected NeedsHuman=false after clear")
+	}
+	if r.DispatchFailures != 0 {
+		t.Errorf("expected DispatchFailures=0 after clear, got %d", r.DispatchFailures)
+	}
+	if r.RecoveryFailures != 0 {
+		t.Errorf("expected RecoveryFailures=0 after clear, got %d", r.RecoveryFailures)
+	}
+	if r.FirstRecoveryFailure != nil {
+		t.Errorf("expected FirstRecoveryFailure=nil after clear, got %v", r.FirstRecoveryFailure)
+	}
+	if r.LastError != "" {
+		t.Errorf("expected LastError empty after clear, got %q", r.LastError)
+	}
+	// Fields the bead spec says must NOT be touched.
+	if !r.ClarificationNeeded {
+		t.Error("expected ClarificationNeeded to be preserved (true) after clear")
+	}
+	if r.RetryCount != 4 {
+		t.Errorf("expected RetryCount preserved (=4) after clear, got %d", r.RetryCount)
+	}
+	if r.NextRetry == nil {
+		t.Error("expected NextRetry preserved (non-nil) after clear")
+	}
+	if !r.UpdatedAt.After(preUpdatedAt) {
+		t.Errorf("expected UpdatedAt to advance, before=%v after=%v", preUpdatedAt, r.UpdatedAt)
+	}
+}
+
+func TestDB_ClearNeedsAttention_Idempotent(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// No-op success when no row exists at all.
+	if err := db.ClearNeedsAttention("BD-NONE", "anvil-1"); err != nil {
+		t.Fatalf("ClearNeedsAttention on missing row should be no-op success, got: %v", err)
+	}
+
+	// Seed a clean row, clear twice, both should succeed without error.
+	if err := db.UpsertRetry(&RetryRecord{
+		BeadID: "BD-CLEAN",
+		Anvil:  "anvil-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ClearNeedsAttention("BD-CLEAN", "anvil-1"); err != nil {
+		t.Fatalf("first clear failed: %v", err)
+	}
+	if err := db.ClearNeedsAttention("BD-CLEAN", "anvil-1"); err != nil {
+		t.Fatalf("second clear failed: %v", err)
+	}
+
+	r, err := db.GetRetry("BD-CLEAN", "anvil-1")
+	if err != nil || r == nil {
+		t.Fatalf("expected row to still exist, err=%v", err)
+	}
+	if r.NeedsHuman || r.DispatchFailures != 0 || r.RecoveryFailures != 0 || r.LastError != "" {
+		t.Errorf("expected fully clean row after two clears, got %+v", r)
+	}
+}
+
+func TestDB_ClearNeedsAttention_OtherRowsUntouched(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := db.UpsertRetry(&RetryRecord{
+		BeadID:           "BD-TARGET",
+		Anvil:            "anvil-1",
+		NeedsHuman:       true,
+		DispatchFailures: 2,
+		LastError:        "target",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertRetry(&RetryRecord{
+		BeadID:           "BD-SIBLING",
+		Anvil:            "anvil-1",
+		NeedsHuman:       true,
+		DispatchFailures: 5,
+		LastError:        "untouched",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Cross-anvil row with the same bead ID — must also stay untouched.
+	if err := db.UpsertRetry(&RetryRecord{
+		BeadID:           "BD-TARGET",
+		Anvil:            "anvil-2",
+		NeedsHuman:       true,
+		DispatchFailures: 7,
+		LastError:        "other-anvil",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.ClearNeedsAttention("BD-TARGET", "anvil-1"); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	target, err := db.GetRetry("BD-TARGET", "anvil-1")
+	if err != nil || target == nil {
+		t.Fatalf("target row missing: %v", err)
+	}
+	if target.NeedsHuman || target.DispatchFailures != 0 || target.LastError != "" {
+		t.Errorf("target row not cleared: %+v", target)
+	}
+
+	sibling, err := db.GetRetry("BD-SIBLING", "anvil-1")
+	if err != nil || sibling == nil {
+		t.Fatalf("sibling row missing: %v", err)
+	}
+	if !sibling.NeedsHuman || sibling.DispatchFailures != 5 || sibling.LastError != "untouched" {
+		t.Errorf("sibling row was modified: %+v", sibling)
+	}
+
+	otherAnvil, err := db.GetRetry("BD-TARGET", "anvil-2")
+	if err != nil || otherAnvil == nil {
+		t.Fatalf("cross-anvil row missing: %v", err)
+	}
+	if !otherAnvil.NeedsHuman || otherAnvil.DispatchFailures != 7 || otherAnvil.LastError != "other-anvil" {
+		t.Errorf("cross-anvil row was modified: %+v", otherAnvil)
+	}
+}
+
+func TestDB_ClearNeedsAttention_DoesNotScheduleRetry(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Seed a row with no scheduled retry; after clear, NextRetry must
+	// remain unset and the bead must drop out of the needs-human set.
+	if err := db.UpsertRetry(&RetryRecord{
+		BeadID:           "BD-NOENQ",
+		Anvil:            "anvil-1",
+		NeedsHuman:       true,
+		DispatchFailures: 3,
+		LastError:        "boom",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.ClearNeedsAttention("BD-NOENQ", "anvil-1"); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+
+	r, err := db.GetRetry("BD-NOENQ", "anvil-1")
+	if err != nil || r == nil {
+		t.Fatalf("expected row to exist, err=%v", err)
+	}
+	if r.NextRetry != nil {
+		t.Errorf("ClearNeedsAttention must not schedule a retry; got NextRetry=%v", r.NextRetry)
+	}
+
+	needsHuman, err := db.NeedsHumanBeadIDSet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := needsHuman["BD-NOENQ\x00anvil-1"]; ok {
+		t.Error("expected BD-NOENQ to no longer be in needs-human set after clear")
+	}
+}
+
 func TestDB_LastWorkerLogPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
 	if err != nil {


### PR DESCRIPTION
## Changes

- **`forge queue clear` command** - Clears the needs-attention flags from a bead's retry row without re-dispatching. Use this when the underlying work is already done (PR merged, bead closed) and you only want the bead to drop out of the needs-attention list. Unlike `retry`, it does not schedule a re-dispatch; unlike `stop`, it does not mark the bead as needing clarification. Idempotent and emits a `retry_cleared` event. (Forge-b05m)

## Original Issue (feature): queue: 'clear' command to dismiss needs-attention without redispatching

`forge queue retry` is the only way to clear `needs_human` from a stuck bead today, but its full behaviour is "reset circuit breaker AND mark for next-poll dispatch". This is a footgun for the common operator workflow:

> The bead is already done (PR merged, work shipped) — I just want it to stop showing up in needs-attention.

The current options force the operator to either:
1. `forge queue retry` and immediately `forge queue stop` (race against the next 30-second poll cycle).
2. UPDATE the retries table directly via sqlite3.
3. `bd close` the bead first, then retry (still races against poll, since `bd close` propagation lags Forge's local state).

Today's incident: Forge-zyi1 was bd-closed and then `forge queue retry`-ed to clear needs-attention. Forge's poll fired ~20s later, before `bd close` was visible to the daemon's snapshot, dispatched the bead again, started schematic + opus-4-7 smith iter 1 (~$0.10 already burned by the time it was caught), required `forge queue stop` to halt.

## Add: `forge queue clear`

Behaviour:
- Clears `needs_human`, `dispatch_failures`, `recovery_failures`, `last_error` for the named bead.
- Does NOT trigger or schedule a dispatch.
- Does NOT set `clarification_needed=1` (so the bead is not blocked from being legitimately picked up by `bd ready` if it is genuinely re-opened later).
- Idempotent — running on a row that is already clean is a no-op success.
- Same flag set as `retry` (`-a/--anvil` required for disambiguation).

Pseudocode:

    UPDATE retries
       SET needs_human = 0,
           dispatch_failures = 0,
           recovery_failures = 0,
           first_recovery_failure_at = NULL,
           last_error = '',
           updated_at = ?
     WHERE bead_id = ? AND anvil = ?;

Emit a `retry_cleared` event so the history log distinguishes this from a retry-triggered redispatch.

## Help text and docs

- Update `forge queue --help` ordering: `clear` near `retry` and `stop`, with one-liners that contrast them clearly:
    - `retry` — Reset the circuit breaker and re-dispatch the bead on the next poll.
    - `stop` — Fully stop a bead: kill worker, prevent re-dispatch, release to open.
    - `clear` — Clear the needs-attention flags without re-dispatching.
- Mention `clear` in the README/CLAUDE.md operator docs section about unsticking beads.

## Tests

- Unit test: `clear` zeros all the right columns and does not enqueue.
- Unit test: idempotency — second invocation succeeds with no-op.
- Unit test: an unrelated bead's row is not touched.
- Integration test (or note): after `clear`, the next poll does NOT pick up the bead unless `bd ready` legitimately surfaces it.

## Acceptance

- `make build`, `make test` pass.
- `forge queue clear <id> -a <anvil>` works as specified.
- README and `forge queue --help` updated to distinguish the three commands.
- Changelog fragment in changelog.d/ (category: Added).

## Reference

- Existing `retry` command for the closest pattern.
- `internal/store/retries.go` (or equivalent — search for `UPDATE retries`) for the write path.
- Today's Forge-zyi1 sequence in `~/.forge/state.db` events table illustrates the footgun (`retry_reset` followed by an unwanted `bead_claimed`).


---
Bead: Forge-b05m | Branch: forge/Forge-b05m
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)