### PR TITLE
Forge: orphan-recovery loops on a closed bead with an open PR (Forge-oinq)

### DIFF
--- a/changelog.d/Forge-oinq.md
+++ b/changelog.d/Forge-oinq.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Orphan-recovery loop on closed bead with open PR** - When `gh pr create` returns "already exists", Forge now looks up the existing PR via `ListOpenPRs` and registers it in `state.db`. Previously the duplicate handler cleared retry state but skipped PR registration, so `HasOpenPRForBead` returned false on the next orphan-recovery sweep and the bead was reset to open and re-dispatched in a loop with Smith repeatedly declaring NO_CHANGES_NEEDED. (Forge-oinq)

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -786,6 +786,9 @@ func (f *fakeVCSProvider) CheckStatusLight(context.Context, string, int) (*vcs.P
 func (f *fakeVCSProvider) ListOpenPRs(context.Context, string) ([]vcs.OpenPR, error) {
 	return nil, nil
 }
+func (f *fakeVCSProvider) GetPRByHeadBranch(_ context.Context, _ string, _ string) (*vcs.OpenPR, error) {
+	return nil, nil
+}
 func (f *fakeVCSProvider) GetRepoOwnerAndName(context.Context, string) (string, string, error) {
 	return "owner", "repo", nil
 }

--- a/internal/burnish/burnish_test.go
+++ b/internal/burnish/burnish_test.go
@@ -63,6 +63,9 @@ func (f *fakeVCS) CheckStatusLight(_ context.Context, _ string, _ int) (*vcs.PRS
 	return nil, nil
 }
 func (f *fakeVCS) ListOpenPRs(_ context.Context, _ string) ([]vcs.OpenPR, error) { return nil, nil }
+func (f *fakeVCS) GetPRByHeadBranch(_ context.Context, _ string, _ string) (*vcs.OpenPR, error) {
+	return nil, nil
+}
 func (f *fakeVCS) GetRepoOwnerAndName(_ context.Context, _ string) (string, string, error) {
 	return "owner", "repo", nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -489,24 +489,20 @@ func (d *Daemon) ingotRecordPR(beadID, anvil string, prNumber int, prURL string)
 // step, HasOpenPRForBead returns false on the next orphan-recovery sweep and
 // the bead is reset to open and re-dispatched, producing a redispatch loop
 // that burns Smith tokens to declare "no changes needed" each iteration.
+// baseBranch is the PR's target branch (bead.EpicBranch or the repo default);
+// storing it prevents rebase/merge actions from defaulting to main for Crucible
+// child beads that target a feature branch.
 // Returns the PR number on success (0 if the PR could not be located or
 // registration failed).
-func (d *Daemon) registerExistingPRByBranch(ctx context.Context, anvilName, anvilPath, beadID, branch string) int {
+func (d *Daemon) registerExistingPRByBranch(ctx context.Context, anvilName, anvilPath, beadID, branch, baseBranch string) int {
 	if branch == "" {
 		return 0
 	}
-	prs, err := d.vcsForAnvil(anvilName).ListOpenPRs(ctx, anvilPath)
+	match, err := d.vcsForAnvil(anvilName).GetPRByHeadBranch(ctx, anvilPath, branch)
 	if err != nil {
-		d.logger.Warn("could not list open PRs to register existing PR after ErrPRAlreadyExists",
+		d.logger.Warn("could not look up open PR by branch to register after ErrPRAlreadyExists",
 			"anvil", anvilName, "branch", branch, "bead", beadID, "error", err)
 		return 0
-	}
-	var match *vcs.OpenPR
-	for i := range prs {
-		if prs[i].Branch == branch {
-			match = &prs[i]
-			break
-		}
 	}
 	if match == nil {
 		d.logger.Warn("ErrPRAlreadyExists but no open PR found by branch — orphan recovery may re-dispatch this bead",
@@ -518,13 +514,14 @@ func (d *Daemon) registerExistingPRByBranch(ctx context.Context, anvilName, anvi
 		return match.Number
 	}
 	dbPR := &state.PR{
-		Number:    match.Number,
-		Anvil:     anvilName,
-		BeadID:    beadID,
-		Branch:    match.Branch,
-		Status:    state.PROpen,
-		CreatedAt: time.Now(),
-		Title:     match.Title,
+		Number:     match.Number,
+		Anvil:      anvilName,
+		BeadID:     beadID,
+		Branch:     match.Branch,
+		BaseBranch: baseBranch,
+		Status:     state.PROpen,
+		CreatedAt:  time.Now(),
+		Title:      match.Title,
 	}
 	if err := d.db.InsertPR(dbPR); err != nil {
 		d.logger.Warn("failed to insert existing PR record after ErrPRAlreadyExists",
@@ -2553,7 +2550,7 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 			// Register the existing PR in state.db so HasOpenPRForBead returns
 			// true on the next orphan-recovery sweep. Without this, the bead
 			// is reset to open and re-dispatched in a loop.
-			d.registerExistingPRByBranch(ctx, bead.Anvil, anvilPath, bead.ID, outcome.Branch)
+			d.registerExistingPRByBranch(ctx, bead.Anvil, anvilPath, bead.ID, outcome.Branch, bead.EpicBranch)
 			// Update worker state so it doesn't hang in WorkerMonitoring
 			// with no PR record for bellows to track.
 			if dbErr := d.db.UpdateWorkerStatus(workerID, state.WorkerDone); dbErr != nil {
@@ -2720,7 +2717,7 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 				// returns true on the next orphan-recovery sweep. Without
 				// this, the bead is reset to open and re-dispatched, with
 				// Smith repeatedly declaring NO_CHANGES_NEEDED in a loop.
-				d.registerExistingPRByBranch(prCtx, bead.Anvil, anvilPath, bead.ID, branch)
+				d.registerExistingPRByBranch(prCtx, bead.Anvil, anvilPath, bead.ID, branch, bead.EpicBranch)
 				if clearErr := d.db.ClearRetry(bead.ID, bead.Anvil); clearErr != nil {
 					d.logger.Error("failed to clear retry record after ErrPRAlreadyExists", "bead", bead.ID, "error", clearErr)
 				}
@@ -2774,6 +2771,27 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 	}
 }
 
+// cleanGitEnv returns a copy of os.Environ with git worktree env vars removed
+// so that git commands in the daemon use directory-based repository discovery
+// (via cmd.Dir) rather than inheriting overrides from an outer git worktree
+// (e.g. GIT_DIR / GIT_WORK_TREE set in a Forge worker subprocess).
+func cleanGitEnv() []string {
+	skip := map[string]bool{
+		"GIT_DIR":                 true,
+		"GIT_WORK_TREE":           true,
+		"GIT_CEILING_DIRECTORIES": true,
+	}
+	base := os.Environ()
+	out := make([]string, 0, len(base))
+	for _, e := range base {
+		k, _, _ := strings.Cut(e, "=")
+		if !skip[k] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // forgeBranchAheadOfMain checks whether the origin remote has a forge branch
 // for the given bead that contains commits not yet merged into the base branch.
 // When epicBranch is set (crucible child beads), it is used as the base instead
@@ -2784,9 +2802,12 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 func (d *Daemon) forgeBranchAheadOfMain(ctx context.Context, anvilPath, beadID, epicBranch string) (string, bool) {
 	branchName := worktree.BranchName(beadID)
 
+	gitEnv := cleanGitEnv()
+
 	// ls-remote is a lightweight ref-only query — no object transfer.
 	lsCmd := executil.HideWindow(exec.CommandContext(ctx, "git", "ls-remote", "--heads", "origin", "--", branchName))
 	lsCmd.Dir = anvilPath
+	lsCmd.Env = gitEnv
 	lsOut, err := lsCmd.Output()
 	if err != nil {
 		// Treat ls-remote failures as inconclusive and fail closed to avoid
@@ -2821,6 +2842,7 @@ func (d *Daemon) forgeBranchAheadOfMain(ctx context.Context, anvilPath, beadID, 
 		epicRef := "origin/" + epicBranch
 		verifyCmd := executil.HideWindow(exec.CommandContext(ctx, "git", "rev-parse", "--verify", epicRef))
 		verifyCmd.Dir = anvilPath
+		verifyCmd.Env = gitEnv
 		if verifyCmd.Run() == nil {
 			baseRef = epicRef
 		}
@@ -2830,6 +2852,7 @@ func (d *Daemon) forgeBranchAheadOfMain(ctx context.Context, anvilPath, beadID, 
 		if explicit := os.Getenv("FORGE_BASE_REF"); explicit != "" {
 			verifyCmd := executil.HideWindow(exec.CommandContext(ctx, "git", "rev-parse", "--verify", explicit))
 			verifyCmd.Dir = anvilPath
+			verifyCmd.Env = gitEnv
 			if verifyCmd.Run() == nil {
 				baseRef = explicit
 			}
@@ -2840,6 +2863,7 @@ func (d *Daemon) forgeBranchAheadOfMain(ctx context.Context, anvilPath, beadID, 
 		for _, candidate := range []string{"origin/main", "origin/master"} {
 			verifyCmd := executil.HideWindow(exec.CommandContext(ctx, "git", "rev-parse", "--verify", candidate))
 			verifyCmd.Dir = anvilPath
+			verifyCmd.Env = gitEnv
 			if verifyCmd.Run() == nil {
 				baseRef = candidate
 				break
@@ -2855,6 +2879,7 @@ func (d *Daemon) forgeBranchAheadOfMain(ctx context.Context, anvilPath, beadID, 
 	logCmd := executil.HideWindow(exec.CommandContext(ctx, "git", "log", "--oneline",
 		"origin/"+branchName, "--not", baseRef))
 	logCmd.Dir = anvilPath
+	logCmd.Env = gitEnv
 	logOut, err := logCmd.Output()
 	if err != nil {
 		// git log failed after confirming the branch exists — fail closed.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -483,6 +483,64 @@ func (d *Daemon) ingotRecordPR(beadID, anvil string, prNumber int, prURL string)
 	}
 }
 
+// registerExistingPRByBranch handles the ErrPRAlreadyExists case from CreatePR
+// by looking up the open PR matching the given branch via the VCS provider and
+// registering it in state.db when it is not already tracked. Without this
+// step, HasOpenPRForBead returns false on the next orphan-recovery sweep and
+// the bead is reset to open and re-dispatched, producing a redispatch loop
+// that burns Smith tokens to declare "no changes needed" each iteration.
+// Returns the PR number on success (0 if the PR could not be located or
+// registration failed).
+func (d *Daemon) registerExistingPRByBranch(ctx context.Context, anvilName, anvilPath, beadID, branch string) int {
+	if branch == "" {
+		return 0
+	}
+	prs, err := d.vcsForAnvil(anvilName).ListOpenPRs(ctx, anvilPath)
+	if err != nil {
+		d.logger.Warn("could not list open PRs to register existing PR after ErrPRAlreadyExists",
+			"anvil", anvilName, "branch", branch, "bead", beadID, "error", err)
+		return 0
+	}
+	var match *vcs.OpenPR
+	for i := range prs {
+		if prs[i].Branch == branch {
+			match = &prs[i]
+			break
+		}
+	}
+	if match == nil {
+		d.logger.Warn("ErrPRAlreadyExists but no open PR found by branch — orphan recovery may re-dispatch this bead",
+			"anvil", anvilName, "branch", branch, "bead", beadID)
+		return 0
+	}
+	if existing, _ := d.db.GetPRByNumber(anvilName, match.Number); existing != nil {
+		// Already tracked — nothing to do, HasOpenPRForBead will return true.
+		return match.Number
+	}
+	dbPR := &state.PR{
+		Number:    match.Number,
+		Anvil:     anvilName,
+		BeadID:    beadID,
+		Branch:    match.Branch,
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+		Title:     match.Title,
+	}
+	if err := d.db.InsertPR(dbPR); err != nil {
+		d.logger.Warn("failed to insert existing PR record after ErrPRAlreadyExists",
+			"anvil", anvilName, "pr", match.Number, "bead", beadID, "error", err)
+		return 0
+	}
+	d.logger.Info("registered existing PR for already-exists branch",
+		"bead", beadID, "anvil", anvilName, "pr", match.Number, "branch", branch)
+	if logErr := d.db.LogEvent(state.EventPRCreated,
+		fmt.Sprintf("Registered existing PR #%d for branch %s (recovered from ErrPRAlreadyExists)", match.Number, branch),
+		beadID, anvilName); logErr != nil {
+		d.logger.Warn("failed to log PR registration event", "bead", beadID, "error", logErr)
+	}
+	return match.Number
+}
+
 // buildVCSProviders creates a VCS provider for each configured anvil based on
 // its platform setting. Anvils without a platform default to GitHub.
 // The state DB is passed to the GitHub provider so it can record PR metadata.
@@ -2492,6 +2550,10 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 			if logErr := d.db.LogEvent(state.EventPRAlreadyExists, fmt.Sprintf("PR already exists for branch %s (duplicate run)", outcome.Branch), bead.ID, bead.Anvil); logErr != nil {
 				d.logger.Error("failed to log duplicate PR event", "bead", bead.ID, "error", logErr)
 			}
+			// Register the existing PR in state.db so HasOpenPRForBead returns
+			// true on the next orphan-recovery sweep. Without this, the bead
+			// is reset to open and re-dispatched in a loop.
+			d.registerExistingPRByBranch(ctx, bead.Anvil, anvilPath, bead.ID, outcome.Branch)
 			// Update worker state so it doesn't hang in WorkerMonitoring
 			// with no PR record for bellows to track.
 			if dbErr := d.db.UpdateWorkerStatus(workerID, state.WorkerDone); dbErr != nil {
@@ -2654,6 +2716,11 @@ func (d *Daemon) applyNoChangesNeededOutcome(ctx context.Context, bead poller.Be
 				_ = d.db.LogEvent(state.EventPRAlreadyExists,
 					fmt.Sprintf("PR already exists for orphaned branch %s (prior run)", branch),
 					bead.ID, bead.Anvil)
+				// Register the existing PR in state.db so HasOpenPRForBead
+				// returns true on the next orphan-recovery sweep. Without
+				// this, the bead is reset to open and re-dispatched, with
+				// Smith repeatedly declaring NO_CHANGES_NEEDED in a loop.
+				d.registerExistingPRByBranch(prCtx, bead.Anvil, anvilPath, bead.ID, branch)
 				if clearErr := d.db.ClearRetry(bead.ID, bead.Anvil); clearErr != nil {
 					d.logger.Error("failed to clear retry record after ErrPRAlreadyExists", "bead", bead.ID, "error", clearErr)
 				}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2276,10 +2276,9 @@ type mockVCSProvider struct {
 	// when the caller will dereference the return value.
 	createPRResult *vcs.PR
 	createPRErr    error
-	// listOpenPRsResult controls what ListOpenPRs returns. Used by tests that
-	// exercise the ErrPRAlreadyExists recovery path which looks up the
-	// existing PR by branch.
-	listOpenPRsResult []vcs.OpenPR
+	// openPRs controls what ListOpenPRs and GetPRByHeadBranch return. Used by
+	// tests that exercise the ErrPRAlreadyExists recovery path.
+	openPRs []vcs.OpenPR
 }
 
 func (m *mockVCSProvider) MergePR(_ context.Context, _ string, _ int, _ string) error {
@@ -2296,7 +2295,15 @@ func (m *mockVCSProvider) CheckStatusLight(_ context.Context, _ string, _ int) (
 	return nil, nil
 }
 func (m *mockVCSProvider) ListOpenPRs(_ context.Context, _ string) ([]vcs.OpenPR, error) {
-	return m.listOpenPRsResult, nil
+	return m.openPRs, nil
+}
+func (m *mockVCSProvider) GetPRByHeadBranch(_ context.Context, _ string, branch string) (*vcs.OpenPR, error) {
+	for i := range m.openPRs {
+		if m.openPRs[i].Branch == branch {
+			return &m.openPRs[i], nil
+		}
+	}
+	return nil, nil
 }
 func (m *mockVCSProvider) GetRepoOwnerAndName(_ context.Context, _ string) (string, string, error) {
 	return "", "", nil
@@ -2552,6 +2559,7 @@ func TestApplyNoChangesNeededOutcome(t *testing.T) {
 			t.Helper()
 			cmd := exec.Command("git", args...)
 			cmd.Dir = orphanAnvilPath
+			cmd.Env = cleanGitTestEnv()
 			out, runErr := cmd.CombinedOutput()
 			require.NoError(t, runErr, "git %v: %s", args, out)
 		}
@@ -2614,6 +2622,7 @@ func TestApplyNoChangesNeededOutcome(t *testing.T) {
 			t.Helper()
 			cmd := exec.Command("git", args...)
 			cmd.Dir = orphanAnvilPath
+			cmd.Env = cleanGitTestEnv()
 			out, runErr := cmd.CombinedOutput()
 			require.NoError(t, runErr, "git %v: %s", args, out)
 		}
@@ -2664,6 +2673,7 @@ func TestApplyNoChangesNeededOutcome(t *testing.T) {
 			t.Helper()
 			cmd := exec.Command("git", args...)
 			cmd.Dir = orphanAnvilPath
+			cmd.Env = cleanGitTestEnv()
 			out, runErr := cmd.CombinedOutput()
 			require.NoError(t, runErr, "git %v: %s", args, out)
 		}
@@ -2674,11 +2684,11 @@ func TestApplyNoChangesNeededOutcome(t *testing.T) {
 		gitLocal("push", "origin", branchName)
 		gitLocal("checkout", "main")
 
-		// Mock VCS: CreatePR fails with ErrPRAlreadyExists, ListOpenPRs returns
-		// the matching open PR so registerExistingPRByBranch can find it.
+		// Mock VCS: CreatePR fails with ErrPRAlreadyExists, GetPRByHeadBranch
+		// returns the matching open PR so registerExistingPRByBranch can find it.
 		mockVCS := &mockVCSProvider{
 			createPRErr: fmt.Errorf("gh pr create: %w: already exists", vcs.ErrPRAlreadyExists),
-			listOpenPRsResult: []vcs.OpenPR{
+			openPRs: []vcs.OpenPR{
 				{Number: 255, Title: "Existing PR", Branch: branchName},
 			},
 		}
@@ -3091,6 +3101,21 @@ func TestReconcileMergedBeads(t *testing.T) {
 	assert.Equal(t, "REC-1", lines[0], "bd close should have been called with REC-1")
 }
 
+// cleanGitTestEnv returns os.Environ with git worktree vars stripped. Used by
+// test git commands so they operate on the test repo (via cmd.Dir) rather than
+// the outer Forge worker process's repo (set via GIT_DIR / GIT_WORK_TREE).
+func cleanGitTestEnv() []string {
+	skip := map[string]bool{"GIT_DIR": true, "GIT_WORK_TREE": true, "GIT_INDEX_FILE": true, "GIT_CEILING_DIRECTORIES": true}
+	var out []string
+	for _, e := range os.Environ() {
+		k, _, _ := strings.Cut(e, "=")
+		if !skip[k] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // initTestGitRepo sets up a bare "remote" repo and a local clone that serves
 // as the anvilPath for forgeBranchAheadOfMain tests. It returns the local path.
 func initTestGitRepo(t *testing.T) (anvilPath string) {
@@ -3106,6 +3131,9 @@ func initTestGitRepo(t *testing.T) (anvilPath string) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
+		// Strip git worktree env vars so setup commands run against the test
+		// repo rather than inheriting the outer Forge worker process's context.
+		cmd.Env = cleanGitTestEnv()
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
 	}
@@ -3157,6 +3185,7 @@ func TestForgeBranchAheadOfMain(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = anvilPath
+		cmd.Env = cleanGitTestEnv()
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2276,6 +2276,10 @@ type mockVCSProvider struct {
 	// when the caller will dereference the return value.
 	createPRResult *vcs.PR
 	createPRErr    error
+	// listOpenPRsResult controls what ListOpenPRs returns. Used by tests that
+	// exercise the ErrPRAlreadyExists recovery path which looks up the
+	// existing PR by branch.
+	listOpenPRsResult []vcs.OpenPR
 }
 
 func (m *mockVCSProvider) MergePR(_ context.Context, _ string, _ int, _ string) error {
@@ -2292,7 +2296,7 @@ func (m *mockVCSProvider) CheckStatusLight(_ context.Context, _ string, _ int) (
 	return nil, nil
 }
 func (m *mockVCSProvider) ListOpenPRs(_ context.Context, _ string) ([]vcs.OpenPR, error) {
-	return nil, nil
+	return m.listOpenPRsResult, nil
 }
 func (m *mockVCSProvider) GetRepoOwnerAndName(_ context.Context, _ string) (string, string, error) {
 	return "", "", nil
@@ -2640,6 +2644,75 @@ func TestApplyNoChangesNeededOutcome(t *testing.T) {
 		require.NotNil(t, r, "retry record should exist after PR creation failure")
 		assert.True(t, r.NeedsHuman, "bead should be needs_human when auto PR creation fails")
 		assert.Contains(t, r.LastError, "GitHub timeout")
+	})
+
+	// Regression for Forge-oinq: when CreatePR returns ErrPRAlreadyExists on
+	// the orphan-branch path, the existing PR must be registered in state.db
+	// so HasOpenPRForBead returns true on the next orphan-recovery sweep.
+	// Without this, the bead is reset to open and re-dispatched in a loop,
+	// with Smith burning tokens to declare NO_CHANGES_NEEDED each iteration.
+	t.Run("orphaned branch: ErrPRAlreadyExists registers existing PR", func(t *testing.T) {
+		const beadID = "NCN-ORPHAN-DUP"
+		orphanAnvilPath := initTestGitRepo(t)
+
+		orphanDB, err := state.Open(filepath.Join(orphanAnvilPath, "state-orphan-dup.db"))
+		require.NoError(t, err)
+		defer orphanDB.Close()
+
+		branchName := worktree.BranchName(beadID)
+		gitLocal := func(args ...string) {
+			t.Helper()
+			cmd := exec.Command("git", args...)
+			cmd.Dir = orphanAnvilPath
+			out, runErr := cmd.CombinedOutput()
+			require.NoError(t, runErr, "git %v: %s", args, out)
+		}
+		gitLocal("checkout", "-b", branchName)
+		require.NoError(t, os.WriteFile(filepath.Join(orphanAnvilPath, "orphan-dup.txt"), []byte("work\n"), 0o644))
+		gitLocal("add", "orphan-dup.txt")
+		gitLocal("commit", "-m", "orphaned work")
+		gitLocal("push", "origin", branchName)
+		gitLocal("checkout", "main")
+
+		// Mock VCS: CreatePR fails with ErrPRAlreadyExists, ListOpenPRs returns
+		// the matching open PR so registerExistingPRByBranch can find it.
+		mockVCS := &mockVCSProvider{
+			createPRErr: fmt.Errorf("gh pr create: %w: already exists", vcs.ErrPRAlreadyExists),
+			listOpenPRsResult: []vcs.OpenPR{
+				{Number: 255, Title: "Existing PR", Branch: branchName},
+			},
+		}
+		d := &Daemon{
+			db:           orphanDB,
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			worktreeMgr:  worktree.NewManager(),
+			vcsProviders: map[string]vcs.Provider{anvil: mockVCS},
+		}
+		d.cfg.Store(&config.Config{})
+
+		bead := poller.Bead{ID: beadID, Anvil: anvil, Title: "Test bead"}
+		d.applyNoChangesNeededOutcome(context.Background(), bead, orphanAnvilPath, "already done")
+
+		// Retry record must be cleared — bead should not be marked needs_human
+		// because the PR exists; the work is represented and bellows will
+		// eventually merge/close it.
+		r, err := orphanDB.GetRetry(beadID, anvil)
+		require.NoError(t, err)
+		assert.Nil(t, r, "retry record should be cleared when PR already exists")
+
+		// PR must be registered in state.db so HasOpenPRForBead returns true,
+		// breaking the orphan-recovery → re-dispatch loop.
+		hasPR, err := orphanDB.HasOpenPRForBead(beadID, anvil)
+		require.NoError(t, err)
+		assert.True(t, hasPR, "existing PR must be registered to break orphan-recovery loop")
+
+		// PR record fields should match the mocked open PR.
+		dbPR, err := orphanDB.GetPRByNumber(anvil, 255)
+		require.NoError(t, err)
+		require.NotNil(t, dbPR, "PR #255 must be inserted into state.db")
+		assert.Equal(t, beadID, dbPR.BeadID)
+		assert.Equal(t, branchName, dbPR.Branch)
+		assert.Equal(t, state.PROpen, dbPR.Status)
 	})
 }
 

--- a/internal/quench/quench_test.go
+++ b/internal/quench/quench_test.go
@@ -282,6 +282,9 @@ func (f *fakeVCS) CheckStatusLight(_ context.Context, _ string, _ int) (*vcs.PRS
 func (f *fakeVCS) ListOpenPRs(_ context.Context, _ string) ([]vcs.OpenPR, error) {
 	return nil, nil
 }
+func (f *fakeVCS) GetPRByHeadBranch(_ context.Context, _ string, _ string) (*vcs.OpenPR, error) {
+	return nil, nil
+}
 func (f *fakeVCS) GetRepoOwnerAndName(_ context.Context, _ string) (string, string, error) {
 	return "owner", "repo", nil
 }

--- a/internal/vcs/gitea.go
+++ b/internal/vcs/gitea.go
@@ -273,6 +273,23 @@ func (g *GiteaProvider) ListOpenPRs(ctx context.Context, worktreePath string) ([
 	return out, nil
 }
 
+// GetPRByHeadBranch returns the open PR whose head branch matches the given
+// branch name, or nil if no matching PR is found. Gitea's REST API does not
+// support head-branch filtering, so this uses the paginated ListOpenPRs and
+// scans for the matching branch.
+func (g *GiteaProvider) GetPRByHeadBranch(ctx context.Context, worktreePath, branch string) (*OpenPR, error) {
+	prs, err := g.ListOpenPRs(ctx, worktreePath)
+	if err != nil {
+		return nil, err
+	}
+	for i := range prs {
+		if prs[i].Branch == branch {
+			return &prs[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // GetRepoOwnerAndName extracts the owner and repository name from the git remote.
 func (g *GiteaProvider) GetRepoOwnerAndName(ctx context.Context, worktreePath string) (owner, repo string, err error) {
 	cmd := executil.HideWindow(exec.CommandContext(ctx, "git", "remote", "get-url", "origin"))

--- a/internal/vcs/github/github.go
+++ b/internal/vcs/github/github.go
@@ -284,6 +284,39 @@ func (p *Provider) ListOpenPRs(ctx context.Context, worktreePath string) ([]vcs.
 	return out, nil
 }
 
+// GetPRByHeadBranch returns the open PR whose head branch matches the given
+// branch name, or nil if no matching PR is found. Uses --head filtering so
+// only the matching PR is returned regardless of how many open PRs exist.
+func (p *Provider) GetPRByHeadBranch(ctx context.Context, worktreePath, branch string) (*vcs.OpenPR, error) {
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch,
+		"--state", "open",
+		"--json", "number,title,headRefName,body",
+		"--limit", "1",
+	))
+	cmd.Dir = worktreePath
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh pr list --head failed: %w\nstderr: %s", err, stderr.String())
+	}
+	var raw []struct {
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		HeadRefName string `json:"headRefName"`
+		Body        string `json:"body"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		return nil, fmt.Errorf("parsing pr list: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	r := raw[0]
+	return &vcs.OpenPR{Number: r.Number, Title: r.Title, Branch: r.HeadRefName, Body: r.Body}, nil
+}
+
 // GetRepoOwnerAndName extracts the owner and repository name from git remote origin.
 func (p *Provider) GetRepoOwnerAndName(ctx context.Context, worktreePath string) (owner, repo string, err error) {
 	cmd := executil.HideWindow(exec.CommandContext(ctx, "git", "remote", "get-url", "origin"))

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -284,6 +284,40 @@ func (g *GitLabProvider) ListOpenPRs(ctx context.Context, worktreePath string) (
 	return out, nil
 }
 
+// GetPRByHeadBranch returns the open MR whose source branch matches the given
+// branch name, or nil if no matching MR is found.
+func (g *GitLabProvider) GetPRByHeadBranch(ctx context.Context, worktreePath, branch string) (*OpenPR, error) {
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "glab", "mr", "list",
+		"--source-branch", branch,
+		"--state", "opened",
+		"--output", "json",
+	))
+	cmd.Dir = worktreePath
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("glab mr list --source-branch failed: %w\nstderr: %s", err, stderr.String())
+	}
+
+	var raw []struct {
+		IID          int    `json:"iid"`
+		Title        string `json:"title"`
+		SourceBranch string `json:"source_branch"`
+		Description  string `json:"description"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		return nil, fmt.Errorf("parsing mr list: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	r := raw[0]
+	return &OpenPR{Number: r.IID, Title: r.Title, Branch: r.SourceBranch, Body: r.Description}, nil
+}
+
 // GetRepoOwnerAndName extracts the namespace (group/subgroup) and project name from the git remote.
 func (g *GitLabProvider) GetRepoOwnerAndName(ctx context.Context, worktreePath string) (owner, repo string, err error) {
 	cmd := executil.HideWindow(exec.CommandContext(ctx, "git", "remote", "get-url", "origin"))

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -472,6 +472,11 @@ type Provider interface {
 	// ListOpenPRs returns all open PRs in the repository.
 	ListOpenPRs(ctx context.Context, worktreePath string) ([]OpenPR, error)
 
+	// GetPRByHeadBranch returns the open PR whose head branch matches the
+	// given branch name, or nil if none exists. Prefer this over ListOpenPRs
+	// when looking up a specific branch to avoid the 100-PR scan limit.
+	GetPRByHeadBranch(ctx context.Context, worktreePath, branch string) (*OpenPR, error)
+
 	// GetRepoOwnerAndName extracts the owner and repository name from the
 	// git remote. The semantics of "owner" vary by platform (org, group,
 	// project namespace, etc.).


### PR DESCRIPTION
## Changes

- **Orphan-recovery loop on closed bead with open PR** - When `gh pr create` returns "already exists", Forge now looks up the existing PR via `ListOpenPRs` and registers it in `state.db`. Previously the duplicate handler cleared retry state but skipped PR registration, so `HasOpenPRForBead` returned false on the next orphan-recovery sweep and the bead was reset to open and re-dispatched in a loop with Smith repeatedly declaring NO_CHANGES_NEEDED. (Forge-oinq)

## Original Issue (bug): Forge: orphan-recovery loops on a closed bead with an open PR

When a bead is closed externally (via 'bd close' from a teammate's machine) while forge has it tracked as in_progress in its in-memory or state.db tracking, forge's orphan-recovery loop keeps resetting the bead's status back to open and re-dispatching it — even though the corresponding PR is already open and the work is done. This was hit during the skybert cutover (2026-05-08) on Heimdall-tgmp and required a pod restart + tag removal to break the loop. The redispatch dance also produces noisy 'no changes needed' smith iterations that cost tokens.

---
Bead: Forge-oinq | Branch: forge/Forge-oinq
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)