### PR TITLE
Hearth 2.0: dashboard crashes when /api/crucibles returns null instead of [] (Forge-76hw)

### DIFF
--- a/changelog.d/Forge-76hw.md
+++ b/changelog.d/Forge-76hw.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Hearth 2.0 dashboard crash on empty crucibles** - The `/api/crucibles` endpoint now serialises an empty list as `[]` instead of `null`, and the dashboard's stat-card readout null-guards `crucibles.length` so a fresh deploy with no active crucibles renders correctly. (Forge-76hw)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3069,7 +3069,11 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		return ipc.Response{Type: "status", Payload: data}
 
 	case "crucibles":
-		var items []ipc.CrucibleStatusItem
+		// Initialise as an empty (non-nil) slice so an environment with no
+		// active crucibles serialises as `{"crucibles":[]}` rather than
+		// `{"crucibles":null}` — the Hearth 2.0 SPA dereferences this field
+		// directly and a null value crashes the dashboard.
+		items := []ipc.CrucibleStatusItem{}
 		d.crucibleStatuses.Range(func(key, value any) bool {
 			s := value.(crucible.Status)
 			items = append(items, ipc.CrucibleStatusItem{

--- a/internal/web/frontend/src/pages/DashboardPage.tsx
+++ b/internal/web/frontend/src/pages/DashboardPage.tsx
@@ -32,8 +32,8 @@ export default function DashboardPage() {
     [workers.data],
   )
 
-  const queueCount = queue.data?.items.length ?? 0
-  const crucibleCount = crucibles.data?.crucibles.length ?? 0
+  const queueCount = queue.data?.items?.length ?? 0
+  const crucibleCount = crucibles.data?.crucibles?.length ?? 0
   const daemonHealthy = status.data?.running
 
   return (


### PR DESCRIPTION
## Changes

- **Hearth 2.0 dashboard crash on empty crucibles** - The `/api/crucibles` endpoint now serialises an empty list as `[]` instead of `null`, and the dashboard's stat-card readout null-guards `crucibles.length` so a fresh deploy with no active crucibles renders correctly. (Forge-76hw)

## Original Issue (bug): Hearth 2.0: dashboard crashes when /api/crucibles returns null instead of []

On a fresh skybert deploy with no active crucibles, /api/crucibles serializes the empty Go slice as JSON null ('{"crucibles":null}') instead of an empty array. The Hearth 2.0 frontend's DashboardPage then dereferences this with the pattern 'r.data?.crucibles.length ?? 0' — the optional chain only short-circuits at .data, not at .crucibles, so when data is present but crucibles is null, .length on null throws TypeError and React unmounts the entire app. Result: blank page on every route (/, /login, /ingots, etc.) with one console error: 'Uncaught TypeError: Cannot read properties of null (reading length)'. Verified live on https://forge.skytest.fhi.no after rev 10 rollout (image ghcr.io/robin831/forge:19aef7d7f3ed).

---
Bead: Forge-76hw | Branch: forge/Forge-76hw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)