### PR TITLE
Hetzner-forge can merge a Hearth 2.0 PR with a stale dist/ bundle (Forge-lmxc)

### DIFF
--- a/changelog.d/Forge-lmxc.md
+++ b/changelog.d/Forge-lmxc.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Temper detects stale embedded frontend bundles** - Add a `verify_clean` mechanism to temper steps that fails when the step modifies committed files under given pathspecs. Auto-detect the Hearth 2.0 layout (`internal/web/frontend` + `internal/web/dist`) and emit install + build steps that rebuild the bundle and verify the committed `dist/` matches a fresh build of `src/`. Prevents merging PRs whose `go:embed`'d bundle is out of sync with frontend source. (Forge-lmxc)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,7 @@ For pipelines that need more than three steps, per-step working directories, or 
 | `timeout` | duration | `5m` | Per-step timeout. Same parsing as elsewhere in Forge config (`5m`, `30s`, `1h`). |
 | `required` | bool | `true` | When `true`, failure fails the whole temper run. When `false`, failure is reported as a warning. |
 | `paths` | `[]string` | `[]` (always run) | Glob patterns (doublestar syntax, e.g. `client/**`, `**/*.go`). When set, the step is skipped if no changed files in the PR diff match any pattern. When empty or omitted, the step always runs. |
+| `verify_clean` | `[]string` | `[]` (no check) | Pathspecs (relative to the worktree, e.g. `web/dist`) that must remain clean after the step runs. When the step succeeds but `git status --porcelain -- <pathspecs>` reports changes, the step is converted to a failure. Use this to enforce that committed build artifacts (e.g. an embedded frontend bundle) match a fresh build of the source. |
 
 **Precedence:** If `temper.steps` is set and non-empty, it takes precedence over `temper.build`/`test`/`lint`. A warning is logged if both are present. If neither `steps` nor the shorthand fields are set, auto-detection applies as usual.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -205,6 +205,13 @@ type TemperStepConfig struct {
 	// changed files in the diff match any pattern. When empty or nil the
 	// step always runs (backward compatible).
 	Paths []string `mapstructure:"paths" yaml:"paths,omitempty"`
+	// VerifyClean is an optional list of pathspecs (relative to the worktree)
+	// that must remain clean after the step runs. When the step succeeds but
+	// `git status --porcelain -- <pathspecs>` reports any changes, the step
+	// is converted to a failure. Use this to enforce that committed build
+	// artifacts (e.g. an embedded frontend bundle) match a fresh build of
+	// the source.
+	VerifyClean []string `mapstructure:"verify_clean" yaml:"verify_clean,omitempty"`
 }
 
 // IsEmpty returns true if no custom commands are configured.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1067,3 +1067,26 @@ func TestTemperStepConfig_YAMLRoundTrip(t *testing.T) {
 	require.NotNil(t, roundTripped.Steps[2].Required)
 	assert.False(t, *roundTripped.Steps[2].Required)
 }
+
+func TestTemperStepConfig_VerifyCleanRoundTrip(t *testing.T) {
+	original := &TemperCommandsConfig{
+		Steps: []TemperStepConfig{
+			{
+				Name:        "build-frontend",
+				Command:     "npm",
+				Args:        []string{"run", "build"},
+				Dir:         "web",
+				VerifyClean: []string{"web/dist", "web/static/build"},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "verify_clean", "verify_clean must be in marshalled YAML")
+
+	var roundTripped TemperCommandsConfig
+	require.NoError(t, yaml.Unmarshal(data, &roundTripped))
+	require.Len(t, roundTripped.Steps, 1)
+	assert.Equal(t, []string{"web/dist", "web/static/build"}, roundTripped.Steps[0].VerifyClean)
+}

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -78,6 +78,15 @@ type Step struct {
 	// Paths is a list of glob patterns (doublestar syntax). When non-empty,
 	// the step is skipped if no changed files match any pattern.
 	Paths []string
+	// VerifyClean is a list of pathspecs (relative to the worktree) that must
+	// remain clean — meaning unchanged versus HEAD with no untracked files —
+	// after the step completes. When the step itself passes but produces
+	// changes under any of these paths, the step is converted to a failure
+	// with a message explaining that the committed artifacts are stale. Use
+	// this for steps that rebuild committed build output (e.g. an embedded
+	// frontend bundle): if running `npm run build` mutates the committed
+	// dist/ directory, the bundle Smith committed does not match the source.
+	VerifyClean []string
 }
 
 // Config holds per-anvil verification configuration.
@@ -214,13 +223,14 @@ func ConfigFromSteps(steps []config.TemperStepConfig) *Config {
 			optional = true
 		}
 		out[i] = Step{
-			Name:     strings.TrimSpace(s.Name),
-			Command:  strings.TrimSpace(s.Command),
-			Args:     s.Args,
-			Dir:      strings.TrimSpace(s.Dir),
-			Timeout:  timeout,
-			Optional: optional,
-			Paths:    s.Paths,
+			Name:        strings.TrimSpace(s.Name),
+			Command:     strings.TrimSpace(s.Command),
+			Args:        s.Args,
+			Dir:         strings.TrimSpace(s.Dir),
+			Timeout:     timeout,
+			Optional:    optional,
+			Paths:       s.Paths,
+			VerifyClean: s.VerifyClean,
 		}
 	}
 	return &Config{Steps: out}
@@ -269,6 +279,29 @@ func matchesChangedFiles(patterns, changedFiles []string) bool {
 		}
 	}
 	return false
+}
+
+// verifyCleanCheck runs `git status --porcelain` against the given pathspecs
+// in the worktree and returns its trimmed output. Empty output means no
+// modifications, additions, or untracked files exist under those paths.
+//
+// A 30s timeout guards against a stuck git invocation. The check is best-effort
+// — callers log and continue when err is non-nil so a transient git failure
+// does not break the pipeline.
+func verifyCleanCheck(ctx context.Context, worktreePath string, pathspecs []string) (string, error) {
+	if len(pathspecs) == 0 {
+		return "", nil
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	args := []string{"-C", worktreePath, "status", "--porcelain", "--"}
+	args = append(args, pathspecs...)
+	out, err := executil.HideWindow(exec.CommandContext(checkCtx, "git", args...)).Output()
+	if err != nil {
+		return "", fmt.Errorf("git status --porcelain: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // ChangedFilesFromGit returns the list of changed file paths (relative to the
@@ -339,6 +372,34 @@ func Run(ctx context.Context, worktreePath string, cfg Config, db *state.DB, bea
 		}
 
 		stepResult := runStep(ctx, worktreePath, step)
+
+		// VerifyClean: if the step succeeded but mutated tracked or untracked
+		// files under one of the VerifyClean pathspecs, the committed artifact
+		// is out of sync with current source — convert the step to a failure
+		// so the pipeline loops back to Smith with actionable feedback.
+		if stepResult.Passed && len(step.VerifyClean) > 0 {
+			dirty, err := verifyCleanCheck(ctx, worktreePath, step.VerifyClean)
+			if err != nil {
+				log.Printf("[temper] VerifyClean check for step %q failed: %v — treating as clean", step.Name, err)
+			} else if dirty != "" {
+				stepResult.Passed = false
+				stepResult.ExitCode = -1
+				msg := fmt.Sprintf(
+					"Step %q ran successfully but modified committed files under %v.\n"+
+						"This means the committed build output is stale relative to the current source.\n"+
+						"Run the same step locally and commit the regenerated artifacts so the\n"+
+						"committed bundle matches a fresh build of the source.\n\n"+
+						"git status --porcelain output:\n%s",
+					step.Name, step.VerifyClean, dirty,
+				)
+				if stepResult.Output == "" {
+					stepResult.Output = msg
+				} else {
+					stepResult.Output = stepResult.Output + "\n\n" + msg
+				}
+			}
+		}
+
 		result.Steps = append(result.Steps, stepResult)
 
 		if !stepResult.Passed && !step.Optional {
@@ -529,6 +590,17 @@ func detectSteps(worktreePath string, opts *DetectOptions, goRace bool) []Step {
 		})
 	}
 
+	// Embedded frontend bundle pattern: detect projects that ship a frontend
+	// inside a Go binary via go:embed. The Hearth 2.0 layout puts source at
+	// internal/web/frontend and the committed build output at internal/web/dist.
+	// When a Smith touches frontend src without rebuilding dist, the embedded
+	// bundle in the deployed binary diverges from source — Forge-lmxc was
+	// caused by exactly that. Append steps that rebuild and verify the bundle
+	// when frontend files are present in the diff.
+	for _, eb := range detectEmbeddedBundles(worktreePath) {
+		steps = append(steps, eb.Steps()...)
+	}
+
 	// Fallback: just check if it builds
 	if len(steps) == 0 {
 		steps = append(steps, Step{
@@ -594,6 +666,84 @@ func buildSummary(r *Result) string {
 // nodeSubdirs is the list of common subdirectories where a Node.js project
 // might live in hybrid repositories (e.g., Go at root, Node in web/).
 var nodeSubdirs = []string{"web", "frontend", "client", "app", "ui"}
+
+// embeddedBundle describes a frontend-source/built-output pair embedded into a
+// Go binary via go:embed. The auto-detector emits temper steps that reinstall
+// dependencies, rebuild the bundle, and verify the committed output matches a
+// fresh build of the source.
+type embeddedBundle struct {
+	// Name is a short identifier used as a step-name prefix (e.g. "hearth").
+	Name string
+	// FrontendDir is the relative path to the frontend source directory
+	// (containing package.json) within the worktree.
+	FrontendDir string
+	// DistDir is the relative path to the committed build output directory
+	// within the worktree. This is what gets verified after `npm run build`.
+	DistDir string
+}
+
+// embeddedBundleLayouts lists the known embedded-frontend layouts. Currently
+// the only entry is Forge's own Hearth 2.0 web UI; new entries can be added
+// for other anvils that ship an embedded bundle.
+var embeddedBundleLayouts = []embeddedBundle{
+	{Name: "hearth", FrontendDir: "internal/web/frontend", DistDir: "internal/web/dist"},
+}
+
+// detectEmbeddedBundles returns the embedded-bundle layouts present in the
+// worktree. A layout matches when its FrontendDir contains a package.json and
+// its DistDir contains an index.html (the marker file produced by Vite).
+func detectEmbeddedBundles(worktreePath string) []embeddedBundle {
+	var found []embeddedBundle
+	for _, eb := range embeddedBundleLayouts {
+		if !fileExists(filepath.Join(worktreePath, eb.FrontendDir), "package.json") {
+			continue
+		}
+		if !fileExists(filepath.Join(worktreePath, eb.DistDir), "index.html") {
+			continue
+		}
+		found = append(found, eb)
+	}
+	return found
+}
+
+// Steps returns the temper steps for an embedded-bundle layout: install deps,
+// rebuild the bundle, and verify the committed dist matches a fresh build.
+// The Paths filter ensures the steps only run when files in the frontend
+// source or build config actually changed in the diff.
+func (eb embeddedBundle) Steps() []Step {
+	paths := []string{
+		eb.FrontendDir + "/src/**",
+		eb.FrontendDir + "/package.json",
+		eb.FrontendDir + "/package-lock.json",
+		eb.FrontendDir + "/index.html",
+		eb.FrontendDir + "/vite.config.ts",
+		eb.FrontendDir + "/vite.config.js",
+		eb.FrontendDir + "/tsconfig.json",
+		eb.FrontendDir + "/tsconfig.app.json",
+		eb.FrontendDir + "/tsconfig.node.json",
+	}
+	return []Step{
+		{
+			Name:    eb.Name + "-frontend-install",
+			Command: "npm",
+			Args:    []string{"install", "--no-audit", "--no-fund"},
+			Dir:     eb.FrontendDir,
+			Timeout: 5 * time.Minute,
+			Paths:   paths,
+		},
+		{
+			Name:    eb.Name + "-frontend-build",
+			Command: "npm",
+			Args:    []string{"run", "build"},
+			Dir:     eb.FrontendDir,
+			Timeout: 5 * time.Minute,
+			Paths:   paths,
+			// The committed dist/ must match a fresh build. If `npm run build`
+			// modifies any file under DistDir, Smith committed a stale bundle.
+			VerifyClean: []string{eb.DistDir},
+		},
+	}
+}
 
 // detectNodeDirs returns the relative directories containing a package.json.
 // An empty string entry means the root directory.

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -285,9 +285,9 @@ func matchesChangedFiles(patterns, changedFiles []string) bool {
 // in the worktree and returns its trimmed output. Empty output means no
 // modifications, additions, or untracked files exist under those paths.
 //
-// A 30s timeout guards against a stuck git invocation. The check is best-effort
-// — callers log and continue when err is non-nil so a transient git failure
-// does not break the pipeline.
+// A 30s timeout guards against a stuck git invocation. GIT_DIR and
+// GIT_WORK_TREE are stripped from the environment so the -C flag reliably
+// targets the correct repo even when Forge itself runs inside a git worktree.
 func verifyCleanCheck(ctx context.Context, worktreePath string, pathspecs []string) (string, error) {
 	if len(pathspecs) == 0 {
 		return "", nil
@@ -297,11 +297,25 @@ func verifyCleanCheck(ctx context.Context, worktreePath string, pathspecs []stri
 
 	args := []string{"-C", worktreePath, "status", "--porcelain", "--"}
 	args = append(args, pathspecs...)
-	out, err := executil.HideWindow(exec.CommandContext(checkCtx, "git", args...)).Output()
-	if err != nil {
-		return "", fmt.Errorf("git status --porcelain: %w", err)
+	cmd := executil.HideWindow(exec.CommandContext(checkCtx, "git", args...))
+	// Strip git repo-override env vars so -C always targets worktreePath rather
+	// than any ambient GIT_DIR set by a parent process (e.g. a git worktree shell).
+	var filteredEnv []string
+	for _, e := range os.Environ() {
+		key, _, _ := strings.Cut(e, "=")
+		if key == "GIT_DIR" || key == "GIT_WORK_TREE" || key == "GIT_INDEX_FILE" {
+			continue
+		}
+		filteredEnv = append(filteredEnv, e)
 	}
-	return strings.TrimSpace(string(out)), nil
+	cmd.Env = filteredEnv
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git status --porcelain: %w\n%s", err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 // ChangedFilesFromGit returns the list of changed file paths (relative to the
@@ -380,7 +394,10 @@ func Run(ctx context.Context, worktreePath string, cfg Config, db *state.DB, bea
 		if stepResult.Passed && len(step.VerifyClean) > 0 {
 			dirty, err := verifyCleanCheck(ctx, worktreePath, step.VerifyClean)
 			if err != nil {
-				log.Printf("[temper] VerifyClean check for step %q failed: %v — treating as clean", step.Name, err)
+				log.Printf("[temper] VerifyClean check for step %q failed: %v", step.Name, err)
+				stepResult.Passed = false
+				stepResult.ExitCode = -1
+				stepResult.Output = fmt.Sprintf("VerifyClean check could not be performed for step %q: %v\nCannot confirm that committed artifacts are up to date — treating as failure.", step.Name, err)
 			} else if dirty != "" {
 				stepResult.Passed = false
 				stepResult.ExitCode = -1

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -3,7 +3,9 @@ package temper
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -295,6 +297,200 @@ func TestConfigFromCommands_SingleWordCommand(t *testing.T) {
 	require.NotNil(t, cfg)
 	assert.Equal(t, "pytest", cfg.Steps[0].Command)
 	assert.Empty(t, cfg.Steps[0].Args)
+}
+
+func TestConfigFromSteps_PassesVerifyCleanThrough(t *testing.T) {
+	cfg := ConfigFromSteps([]config.TemperStepConfig{
+		{
+			Name:        "build",
+			Command:     "npm",
+			Args:        []string{"run", "build"},
+			VerifyClean: []string{"web/dist", "web/static"},
+		},
+	})
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 1)
+	assert.Equal(t, []string{"web/dist", "web/static"}, cfg.Steps[0].VerifyClean,
+		"VerifyClean should be carried from TemperStepConfig into the temper Step")
+}
+
+func TestDetectEmbeddedBundles_DetectsHearthLayout(t *testing.T) {
+	dir := t.TempDir()
+	// Hearth 2.0 layout: frontend source + committed dist with index.html.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "web", "frontend"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "web", "frontend", "package.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "web", "dist"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "web", "dist", "index.html"), []byte("<html></html>"), 0o644))
+
+	bundles := detectEmbeddedBundles(dir)
+	require.Len(t, bundles, 1)
+	assert.Equal(t, "hearth", bundles[0].Name)
+	assert.Equal(t, "internal/web/frontend", bundles[0].FrontendDir)
+	assert.Equal(t, "internal/web/dist", bundles[0].DistDir)
+}
+
+func TestDetectEmbeddedBundles_RequiresBothPaths(t *testing.T) {
+	// Only frontend exists, no dist — should not match.
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "web", "frontend"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "web", "frontend", "package.json"), []byte("{}"), 0o644))
+
+	assert.Empty(t, detectEmbeddedBundles(dir),
+		"detection requires both a frontend package.json and a dist/index.html")
+
+	// Only dist exists, no frontend — also should not match.
+	dir2 := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir2, "internal", "web", "dist"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir2, "internal", "web", "dist", "index.html"), []byte(""), 0o644))
+
+	assert.Empty(t, detectEmbeddedBundles(dir2))
+}
+
+func TestEmbeddedBundle_Steps_Shape(t *testing.T) {
+	eb := embeddedBundle{Name: "hearth", FrontendDir: "internal/web/frontend", DistDir: "internal/web/dist"}
+	steps := eb.Steps()
+	require.Len(t, steps, 2, "expected install + build steps")
+
+	assert.Equal(t, "hearth-frontend-install", steps[0].Name)
+	assert.Equal(t, "npm", steps[0].Command)
+	assert.Equal(t, []string{"install", "--no-audit", "--no-fund"}, steps[0].Args)
+	assert.Equal(t, "internal/web/frontend", steps[0].Dir)
+	assert.Empty(t, steps[0].VerifyClean, "install step does not verify clean (it may touch package-lock or node_modules)")
+
+	assert.Equal(t, "hearth-frontend-build", steps[1].Name)
+	assert.Equal(t, "npm", steps[1].Command)
+	assert.Equal(t, []string{"run", "build"}, steps[1].Args)
+	assert.Equal(t, "internal/web/frontend", steps[1].Dir)
+	assert.Equal(t, []string{"internal/web/dist"}, steps[1].VerifyClean,
+		"build step must verify dist remains clean — that's the whole point of the check")
+
+	// Both steps should share the same Paths filter so they only run when
+	// frontend src or build config actually changed.
+	assert.Equal(t, steps[0].Paths, steps[1].Paths)
+	assert.NotEmpty(t, steps[0].Paths)
+	assert.Contains(t, steps[0].Paths, "internal/web/frontend/src/**")
+}
+
+func TestDetectSteps_IncludesEmbeddedBundleForHearthLayout(t *testing.T) {
+	dir := t.TempDir()
+	// Go at root + Hearth 2.0 frontend pattern.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "web", "frontend"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "web", "frontend", "package.json"), []byte("{}"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "internal", "web", "dist"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "internal", "web", "dist", "index.html"), []byte("<html></html>"), 0o644))
+
+	opts := &DetectOptions{DisableGolangciLint: true}
+	steps := detectSteps(dir, opts, false)
+	names := stepNames(steps)
+
+	assert.Contains(t, names, "hearth-frontend-install")
+	assert.Contains(t, names, "hearth-frontend-build")
+}
+
+// gitAvailable returns true when a `git` binary is on PATH so tests that
+// shell out to git can be skipped on minimal CI images.
+func gitAvailable() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// initGitRepo bootstraps a minimal git repo in dir with one initial commit so
+// `git status --porcelain` and `git diff` have a HEAD to compare against.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "--initial-branch=main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"add", "-A"},
+		{"-c", "commit.gpgsign=false", "commit", "-m", "init", "--allow-empty"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		// Strip GIT_* env vars so the parent test environment doesn't leak.
+		var env []string
+		for _, e := range os.Environ() {
+			if strings.HasPrefix(e, "GIT_") {
+				continue
+			}
+			env = append(env, e)
+		}
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func TestRun_VerifyClean_FailsWhenStepDirtiesArtifact(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available on PATH")
+	}
+	dir := t.TempDir()
+	// Commit a "dist" file so git tracks it.
+	distDir := filepath.Join(dir, "dist")
+	require.NoError(t, os.MkdirAll(distDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(distDir, "bundle.js"), []byte("v1"), 0o644))
+	initGitRepo(t, dir)
+
+	// Step "rebuild" simulates a build that overwrites the committed dist
+	// output with different bytes — exactly the stale-bundle scenario.
+	cmdName := "sh"
+	args := []string{"-c", "echo v2 > dist/bundle.js"}
+	if runtime.GOOS == "windows" {
+		t.Skip("uses sh; skip on Windows")
+	}
+
+	cfg := Config{Steps: []Step{{
+		Name:        "rebuild",
+		Command:     cmdName,
+		Args:        args,
+		Timeout:     30 * time.Second,
+		VerifyClean: []string{"dist"},
+	}}}
+
+	res := Run(context.Background(), dir, cfg, nil, "Forge-test", "test")
+	require.NotNil(t, res)
+	assert.False(t, res.Passed, "VerifyClean should convert success to failure when dist diverges")
+	assert.Equal(t, "rebuild", res.FailedStep)
+	assert.Contains(t, res.Steps[0].Output, "stale relative to the current source")
+}
+
+func TestRun_VerifyClean_PassesWhenStepLeavesArtifactClean(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available on PATH")
+	}
+	dir := t.TempDir()
+	distDir := filepath.Join(dir, "dist")
+	require.NoError(t, os.MkdirAll(distDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(distDir, "bundle.js"), []byte("v1"), 0o644))
+	initGitRepo(t, dir)
+
+	// "rebuild" is a no-op (true) — it leaves the worktree exactly as
+	// committed, which is the same shape as a successful idempotent rebuild.
+	cmdName := "true"
+	if runtime.GOOS == "windows" {
+		// Windows lacks `true`; use cmd's noop equivalent.
+		cmdName = "cmd"
+	}
+	args := []string(nil)
+	if runtime.GOOS == "windows" {
+		args = []string{"/c", "exit", "0"}
+	}
+
+	cfg := Config{Steps: []Step{{
+		Name:        "rebuild",
+		Command:     cmdName,
+		Args:        args,
+		Timeout:     30 * time.Second,
+		VerifyClean: []string{"dist"},
+	}}}
+
+	res := Run(context.Background(), dir, cfg, nil, "Forge-test", "test")
+	require.NotNil(t, res)
+	assert.True(t, res.Passed, "step should pass when committed artifacts match a fresh build")
+	assert.Empty(t, res.FailedStep)
 }
 
 func TestConfigFromCommands_Timeouts(t *testing.T) {


### PR DESCRIPTION
## Changes

- **Temper detects stale embedded frontend bundles** - Add a `verify_clean` mechanism to temper steps that fails when the step modifies committed files under given pathspecs. Auto-detect the Hearth 2.0 layout (`internal/web/frontend` + `internal/web/dist`) and emit install + build steps that rebuild the bundle and verify the committed `dist/` matches a fresh build of `src/`. Prevents merging PRs whose `go:embed`'d bundle is out of sync with frontend source. (Forge-lmxc)

## Original Issue (bug): Hetzner-forge can merge a Hearth 2.0 PR with a stale dist/ bundle

Hearth 2.0's frontend bundle at internal/web/dist/ is embedded via go:embed. When a smith-driven PR modifies frontend source (internal/web/frontend/src/), it must also re-run 'npm run build' so the committed dist/ matches the source. Forge-cnj8 (#577) shipped backend csrfCheck middleware AND a frontend apiPost wrapper, but the committed dist/ was built BEFORE the apiPost change — so the deployed bundle did NOT send X-Forge-Action. Every admin action returned 403. Hot-fixed manually in commit 44f09cfa. The deeper issue: nothing in temper enforces that committed dist matches a fresh build of current src.

---
Bead: Forge-lmxc | Branch: forge/Forge-lmxc
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)