### PR TITLE
Add /prs tab scaffolding and AppHeader integration (Forge-6321)

### DIFF
--- a/changelog.d/Forge-6321.md
+++ b/changelog.d/Forge-6321.md
@@ -1,0 +1,2 @@
+category: Added
+- **Hearth 2.0 PRs tab scaffolding** - Added a new `/prs` route to the Hearth dashboard and a "PRs" link in the AppHeader, with three section containers (Forge PRs, External PRs, Recently merged) and shared `PRItem`/`PRSection` types ready for the data and action sub-tasks to plug into. (Forge-6321)

--- a/internal/web/frontend/src/App.tsx
+++ b/internal/web/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import DashboardPage from './pages/DashboardPage'
 import IngotsPage from './pages/IngotsPage'
 import CruciblesPage from './pages/CruciblesPage'
 import HistoryPage from './pages/HistoryPage'
+import PRsPage from './pages/PRsPage'
 import CostsPage from './pages/CostsPage'
 import BeadDetailPage from './pages/BeadDetailPage'
 
@@ -61,6 +62,14 @@ export default function App() {
         element={
           <ProtectedRoute>
             <HistoryPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/prs"
+        element={
+          <ProtectedRoute>
+            <PRsPage />
           </ProtectedRoute>
         }
       />

--- a/internal/web/frontend/src/api.ts
+++ b/internal/web/frontend/src/api.ts
@@ -242,6 +242,41 @@ export interface BeadDetailResponse {
   prs: BeadDetailPR[]
 }
 
+export interface PRItem {
+  id?: number
+  number: number
+  anvil: string
+  repo?: string
+  branch?: string
+  base_branch?: string
+  title?: string
+  url?: string
+  author?: string
+  status: string
+  is_external: boolean
+  is_conflicting?: boolean
+  ci_passing?: boolean
+  ci_failing?: boolean
+  reviews_approved?: boolean
+  bellows_assigned?: boolean
+  ci_fix_count?: number
+  review_fix_count?: number
+  rebase_count?: number
+  bead_id?: string
+  created_at?: string
+  updated_at?: string
+  merged_at?: string
+  closed_at?: string
+}
+
+// PRsResponse is the shape served by GET /api/prs/all. Keys align with
+// PRSectionKind so callers can index directly without a mapping layer.
+export interface PRsResponse {
+  forge_prs: PRItem[]
+  external_prs: PRItem[]
+  recently_merged: PRItem[]
+}
+
 export class ApiError extends Error {
   status: number
   constructor(status: number, message: string) {

--- a/internal/web/frontend/src/components/AppHeader.tsx
+++ b/internal/web/frontend/src/components/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { Activity, Coins, FlaskConical, Hammer, History, LayoutDashboard, LogOut, Package } from 'lucide-react'
+import { Activity, Coins, FlaskConical, GitPullRequest, Hammer, History, LayoutDashboard, LogOut, Package } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 import { useAuth } from '../auth'
 
@@ -14,6 +14,7 @@ const navItems: NavItem[] = [
   { to: '/ingots', label: 'Ingots', icon: Package },
   { to: '/crucibles', label: 'Crucibles', icon: FlaskConical },
   { to: '/history', label: 'History', icon: History },
+  { to: '/prs', label: 'PRs', icon: GitPullRequest },
   { to: '/costs', label: 'Costs', icon: Coins },
 ]
 

--- a/internal/web/frontend/src/pages/PRsPage.tsx
+++ b/internal/web/frontend/src/pages/PRsPage.tsx
@@ -1,0 +1,91 @@
+import { GitPullRequest } from 'lucide-react'
+import { useApiPoll } from '../hooks/useApiPoll'
+import type { StatusResponse } from '../api'
+import AppHeader from '../components/AppHeader'
+import Pane, { EmptyState } from '../components/Pane'
+import {
+  PR_SECTION_DESCRIPTIONS,
+  PR_SECTION_EMPTY_MESSAGES,
+  PR_SECTION_TITLES,
+  type PRItem,
+  type PRSectionKind,
+} from './prsTypes'
+
+const POLL_INTERVAL_MS = 10000
+
+const SECTION_ORDER: PRSectionKind[] = ['forge_prs', 'external_prs', 'recently_merged']
+
+const SECTION_ICON_CLASSES: Record<PRSectionKind, string> = {
+  forge_prs: 'text-amber-400',
+  external_prs: 'text-sky-400',
+  recently_merged: 'text-emerald-400',
+}
+
+// PRsPage is the shell for the Hearth 2.0 /prs tab. The data-fetching layer
+// (Forge-9ye8) and per-PR actions (Forge-x7dy) plug into the section bodies
+// below — for now each section renders its empty state so the navigation,
+// layout, and types are in place for the follow-up sub-tasks.
+export default function PRsPage() {
+  const status = useApiPoll<StatusResponse>('/api/status', POLL_INTERVAL_MS)
+
+  // Sub-task Forge-9ye8 will replace these placeholders with a real
+  // useApiPoll<PRsResponse>('/api/prs/all', ...) call.
+  const items: Record<PRSectionKind, PRItem[]> = {
+    forge_prs: [],
+    external_prs: [],
+    recently_merged: [],
+  }
+
+  return (
+    <div className="mx-auto flex min-h-full max-w-7xl flex-col gap-6 p-4 sm:p-6">
+      <AppHeader daemonOnline={status.data?.running} daemonLoading={status.loading} />
+
+      <main className="flex flex-col gap-4">
+        {SECTION_ORDER.map((kind) => (
+          <PRSectionContainer key={kind} kind={kind} items={items[kind]} />
+        ))}
+      </main>
+
+      <footer className="text-center text-xs text-slate-500">
+        Polled every {POLL_INTERVAL_MS / 1000}s · Hearth 2.0
+      </footer>
+    </div>
+  )
+}
+
+interface PRSectionContainerProps {
+  kind: PRSectionKind
+  items: PRItem[]
+  loading?: boolean
+  error?: string | null
+}
+
+function PRSectionContainer({ kind, items, loading, error }: PRSectionContainerProps) {
+  return (
+    <Pane
+      title={PR_SECTION_TITLES[kind]}
+      icon={<GitPullRequest size={16} className={SECTION_ICON_CLASSES[kind]} aria-hidden />}
+      count={items.length}
+      loading={loading}
+      error={error ?? null}
+    >
+      <div className="px-4 pt-3 text-xs text-slate-400">
+        {PR_SECTION_DESCRIPTIONS[kind]}
+      </div>
+      {items.length === 0 ? (
+        <EmptyState message={PR_SECTION_EMPTY_MESSAGES[kind]} />
+      ) : (
+        <ul className="divide-y divide-slate-800" data-testid={`prs-${kind}`}>
+          {items.map((pr) => (
+            <li key={pr.id ?? `${pr.repo ?? pr.anvil}#${pr.number}`} className="px-4 py-3">
+              <p className="text-sm text-slate-100">{pr.title}</p>
+              <p className="mt-0.5 text-xs text-slate-500">
+                {pr.anvil} · #{pr.number}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Pane>
+  )
+}

--- a/internal/web/frontend/src/pages/PRsPage.tsx
+++ b/internal/web/frontend/src/pages/PRsPage.tsx
@@ -1,13 +1,12 @@
 import { GitPullRequest } from 'lucide-react'
 import { useApiPoll } from '../hooks/useApiPoll'
-import type { StatusResponse } from '../api'
+import type { PRItem, StatusResponse } from '../api'
 import AppHeader from '../components/AppHeader'
 import Pane, { EmptyState } from '../components/Pane'
 import {
   PR_SECTION_DESCRIPTIONS,
   PR_SECTION_EMPTY_MESSAGES,
   PR_SECTION_TITLES,
-  type PRItem,
   type PRSectionKind,
 } from './prsTypes'
 
@@ -78,7 +77,7 @@ function PRSectionContainer({ kind, items, loading, error }: PRSectionContainerP
         <ul className="divide-y divide-slate-800" data-testid={`prs-${kind}`}>
           {items.map((pr) => (
             <li key={pr.id ?? `${pr.repo ?? pr.anvil}#${pr.number}`} className="px-4 py-3">
-              <p className="text-sm text-slate-100">{pr.title}</p>
+              <p className="text-sm text-slate-100">{pr.title || '(no title)'}</p>
               <p className="mt-0.5 text-xs text-slate-500">
                 {pr.anvil} · #{pr.number}
               </p>

--- a/internal/web/frontend/src/pages/prsTypes.ts
+++ b/internal/web/frontend/src/pages/prsTypes.ts
@@ -1,0 +1,70 @@
+// Shared types for the /prs tab. Kept colocated with PRsPage.tsx so the
+// data-fetching and action sub-tasks (Forge-9ye8, Forge-x7dy) can extend a
+// single source of truth without introducing a top-level API change.
+
+export type PRSectionKind = 'forge_prs' | 'external_prs' | 'recently_merged'
+
+// PRItem is a flat representation that covers all three sections. Forge-created
+// PRs come from state.db (id present), external PRs come from `gh pr list`
+// (repo present, is_external=true), recently-merged PRs may originate from
+// either source.
+export interface PRItem {
+  id?: number
+  number: number
+  anvil: string
+  repo?: string
+  branch?: string
+  base_branch?: string
+  title: string
+  url?: string
+  author?: string
+  status: string
+  is_external: boolean
+  is_conflicting?: boolean
+  ci_passing?: boolean
+  ci_failing?: boolean
+  reviews_approved?: boolean
+  bellows_assigned?: boolean
+  ci_fix_count?: number
+  review_fix_count?: number
+  rebase_count?: number
+  bead_id?: string
+  created_at?: string
+  updated_at?: string
+  merged_at?: string
+  closed_at?: string
+}
+
+export interface PRSection {
+  kind: PRSectionKind
+  title: string
+  description?: string
+  items: PRItem[]
+}
+
+// PRsResponse is the shape served by GET /api/prs/all (implemented in
+// Forge-9ye8). Defined here so the page can be typed against it before the
+// endpoint exists.
+export interface PRsResponse {
+  forge: PRItem[]
+  external: PRItem[]
+  recently_merged: PRItem[]
+}
+
+export const PR_SECTION_TITLES: Record<PRSectionKind, string> = {
+  forge_prs: 'Forge PRs',
+  external_prs: 'External PRs',
+  recently_merged: 'Recently merged',
+}
+
+export const PR_SECTION_DESCRIPTIONS: Record<PRSectionKind, string> = {
+  forge_prs: 'Open PRs created by Forge — track CI, review, and merge state.',
+  external_prs: 'Open PRs from other contributors across registered anvils.',
+  recently_merged: 'PRs merged in the last 7 days.',
+}
+
+export const PR_SECTION_EMPTY_MESSAGES: Record<PRSectionKind, string> = {
+  forge_prs: 'No open Forge PRs.',
+  external_prs: 'No open external PRs.',
+  recently_merged: 'No PRs merged recently.',
+}

--- a/internal/web/frontend/src/pages/prsTypes.ts
+++ b/internal/web/frontend/src/pages/prsTypes.ts
@@ -1,54 +1,15 @@
-// Shared types for the /prs tab. Kept colocated with PRsPage.tsx so the
-// data-fetching and action sub-tasks (Forge-9ye8, Forge-x7dy) can extend a
-// single source of truth without introducing a top-level API change.
+// View-specific types and copy constants for the /prs tab.
+// API-shaped types (PRItem, PRsResponse) live in src/api.ts.
+
+import type { PRItem } from '../api'
 
 export type PRSectionKind = 'forge_prs' | 'external_prs' | 'recently_merged'
-
-// PRItem is a flat representation that covers all three sections. Forge-created
-// PRs come from state.db (id present), external PRs come from `gh pr list`
-// (repo present, is_external=true), recently-merged PRs may originate from
-// either source.
-export interface PRItem {
-  id?: number
-  number: number
-  anvil: string
-  repo?: string
-  branch?: string
-  base_branch?: string
-  title: string
-  url?: string
-  author?: string
-  status: string
-  is_external: boolean
-  is_conflicting?: boolean
-  ci_passing?: boolean
-  ci_failing?: boolean
-  reviews_approved?: boolean
-  bellows_assigned?: boolean
-  ci_fix_count?: number
-  review_fix_count?: number
-  rebase_count?: number
-  bead_id?: string
-  created_at?: string
-  updated_at?: string
-  merged_at?: string
-  closed_at?: string
-}
 
 export interface PRSection {
   kind: PRSectionKind
   title: string
   description?: string
   items: PRItem[]
-}
-
-// PRsResponse is the shape served by GET /api/prs/all (implemented in
-// Forge-9ye8). Defined here so the page can be typed against it before the
-// endpoint exists.
-export interface PRsResponse {
-  forge: PRItem[]
-  external: PRItem[]
-  recently_merged: PRItem[]
 }
 
 export const PR_SECTION_TITLES: Record<PRSectionKind, string> = {


### PR DESCRIPTION
## Changes

- **Hearth 2.0 PRs tab scaffolding** - Added a new `/prs` route to the Hearth dashboard and a "PRs" link in the AppHeader, with three section containers (Forge PRs, External PRs, Recently merged) and shared `PRItem`/`PRSection` types ready for the data and action sub-tasks to plug into. (Forge-6321)

## Original Issue (task): Add /prs tab scaffolding and AppHeader integration

Create web/src/components/hearth/PRsTab.tsx as a new tab component (not a modal), structured after web/src/components/mezzanine/PRModal.tsx but adapted to tab layout. Wire into AppHeader's tab registry/router so /prs route renders it. Define the three section containers (forge_prs, external_prs, recently_merged) with empty states and section headers. Establish shared types (PRItem, PRSection) in a colocated types file. This sub-task lays the UI shell that the data-fetching and action sub-tasks plug into.

---
Bead: Forge-6321 | Branch: forge/Forge-6321
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)