### PR TITLE
Implement PR data sources (forge, external, recently_merged) (Forge-9ye8)

### DIFF
--- a/changelog.d/Forge-9ye8.md
+++ b/changelog.d/Forge-9ye8.md
@@ -1,0 +1,2 @@
+category: Added
+- **PR data sources for the /prs tab** - Hearth 2.0's `/prs` tab now lists Forge-managed PRs, externally-authored PRs, and PRs merged in the last 7 days. Sections are populated by a new `GET /api/prs/all` endpoint backed by state.db, with a 60-second client-side cache and manual refresh. (Forge-9ye8)

--- a/internal/web/frontend/src/pages/PRsPage.tsx
+++ b/internal/web/frontend/src/pages/PRsPage.tsx
@@ -9,12 +9,7 @@ import {
   PR_SECTION_TITLES,
   type PRSectionKind,
 } from './prsTypes'
-import {
-  PRS_CACHE_TTL_MS,
-  useExternalPRs,
-  useForgePRs,
-  useRecentlyMergedPRs,
-} from './usePRsData'
+import { PRS_CACHE_TTL_MS, usePRsData } from './usePRsData'
 
 const STATUS_POLL_INTERVAL_MS = 10_000
 
@@ -32,18 +27,12 @@ const SECTION_ICON_CLASSES: Record<PRSectionKind, string> = {
 export default function PRsPage() {
   const status = useApiPoll<StatusResponse>('/api/status', STATUS_POLL_INTERVAL_MS)
 
-  const forge = useForgePRs()
-  const external = useExternalPRs()
-  const merged = useRecentlyMergedPRs()
-
-  // All three section hooks share the same underlying fetch, so loading/
-  // error/refresh state is identical across them. Read once for the page
-  // chrome (footer + refresh button).
-  const { loading, error, refresh, fetchedAt } = forge
+  const { forge_prs, external_prs, recently_merged, loading, error, refresh, fetchedAt } =
+    usePRsData()
   const items: Record<PRSectionKind, PRItem[]> = {
-    forge_prs: forge.items,
-    external_prs: external.items,
-    recently_merged: merged.items,
+    forge_prs,
+    external_prs,
+    recently_merged,
   }
 
   return (

--- a/internal/web/frontend/src/pages/PRsPage.tsx
+++ b/internal/web/frontend/src/pages/PRsPage.tsx
@@ -1,4 +1,4 @@
-import { GitPullRequest } from 'lucide-react'
+import { GitPullRequest, RefreshCw } from 'lucide-react'
 import { useApiPoll } from '../hooks/useApiPoll'
 import type { PRItem, StatusResponse } from '../api'
 import AppHeader from '../components/AppHeader'
@@ -9,8 +9,14 @@ import {
   PR_SECTION_TITLES,
   type PRSectionKind,
 } from './prsTypes'
+import {
+  PRS_CACHE_TTL_MS,
+  useExternalPRs,
+  useForgePRs,
+  useRecentlyMergedPRs,
+} from './usePRsData'
 
-const POLL_INTERVAL_MS = 10000
+const STATUS_POLL_INTERVAL_MS = 10_000
 
 const SECTION_ORDER: PRSectionKind[] = ['forge_prs', 'external_prs', 'recently_merged']
 
@@ -20,33 +26,63 @@ const SECTION_ICON_CLASSES: Record<PRSectionKind, string> = {
   recently_merged: 'text-emerald-400',
 }
 
-// PRsPage is the shell for the Hearth 2.0 /prs tab. The data-fetching layer
-// (Forge-9ye8) and per-PR actions (Forge-x7dy) plug into the section bodies
-// below — for now each section renders its empty state so the navigation,
-// layout, and types are in place for the follow-up sub-tasks.
+// PRsPage is the shell for the Hearth 2.0 /prs tab. The data hooks
+// (Forge-9ye8) populate each section from state.db; per-PR action buttons
+// (Forge-x7dy) plug into the row renderer below.
 export default function PRsPage() {
-  const status = useApiPoll<StatusResponse>('/api/status', POLL_INTERVAL_MS)
+  const status = useApiPoll<StatusResponse>('/api/status', STATUS_POLL_INTERVAL_MS)
 
-  // Sub-task Forge-9ye8 will replace these placeholders with a real
-  // useApiPoll<PRsResponse>('/api/prs/all', ...) call.
+  const forge = useForgePRs()
+  const external = useExternalPRs()
+  const merged = useRecentlyMergedPRs()
+
+  // All three section hooks share the same underlying fetch, so loading/
+  // error/refresh state is identical across them. Read once for the page
+  // chrome (footer + refresh button).
+  const { loading, error, refresh, fetchedAt } = forge
   const items: Record<PRSectionKind, PRItem[]> = {
-    forge_prs: [],
-    external_prs: [],
-    recently_merged: [],
+    forge_prs: forge.items,
+    external_prs: external.items,
+    recently_merged: merged.items,
   }
 
   return (
     <div className="mx-auto flex min-h-full max-w-7xl flex-col gap-6 p-4 sm:p-6">
       <AppHeader daemonOnline={status.data?.running} daemonLoading={status.loading} />
 
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-slate-500">
+          {fetchedAt
+            ? `Last updated ${formatRelative(fetchedAt)}`
+            : loading
+              ? 'Loading…'
+              : 'Not yet loaded'}
+        </p>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="inline-flex items-center gap-1.5 rounded-md border border-slate-700 bg-slate-800/60 px-2.5 py-1 text-xs text-slate-300 transition-colors hover:border-slate-600 hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw size={12} aria-hidden className={loading ? 'animate-spin' : undefined} />
+          Refresh
+        </button>
+      </div>
+
       <main className="flex flex-col gap-4">
         {SECTION_ORDER.map((kind) => (
-          <PRSectionContainer key={kind} kind={kind} items={items[kind]} />
+          <PRSectionContainer
+            key={kind}
+            kind={kind}
+            items={items[kind]}
+            loading={loading && items[kind].length === 0}
+            error={error}
+          />
         ))}
       </main>
 
       <footer className="text-center text-xs text-slate-500">
-        Polled every {POLL_INTERVAL_MS / 1000}s · Hearth 2.0
+        Cached for {PRS_CACHE_TTL_MS / 1000}s · Hearth 2.0
       </footer>
     </div>
   )
@@ -80,6 +116,8 @@ function PRSectionContainer({ kind, items, loading, error }: PRSectionContainerP
               <p className="text-sm text-slate-100">{pr.title || '(no title)'}</p>
               <p className="mt-0.5 text-xs text-slate-500">
                 {pr.anvil} · #{pr.number}
+                {pr.branch ? ` · ${pr.branch}` : ''}
+                {pr.bead_id && !pr.bead_id.startsWith('ext-') ? ` · ${pr.bead_id}` : ''}
               </p>
             </li>
           ))}
@@ -87,4 +125,14 @@ function PRSectionContainer({ kind, items, loading, error }: PRSectionContainerP
       )}
     </Pane>
   )
+}
+
+function formatRelative(timestamp: number): string {
+  const secs = Math.max(0, Math.round((Date.now() - timestamp) / 1000))
+  if (secs < 5) return 'just now'
+  if (secs < 60) return `${secs}s ago`
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.round(mins / 60)
+  return `${hours}h ago`
 }

--- a/internal/web/frontend/src/pages/usePRsData.ts
+++ b/internal/web/frontend/src/pages/usePRsData.ts
@@ -1,18 +1,16 @@
 // usePRsData and the per-section convenience hooks (useForgePRs,
 // useExternalPRs, useRecentlyMergedPRs) back the /prs tab. They share a
-// module-level cache so all three sections of the page issue at most one
-// fetch per polling window — even when rendered as separate hooks.
+// module-level cache so multiple subscribers issue at most one fetch per
+// polling window — the cache is daemon-scoped (a different daemon would
+// be on a different origin), which prevents cross-repo bleed.
 //
-// The cache contract (per Forge-9ye8):
-//   - 60-second TTL: stale entries trigger a background refetch on the next
-//     hook mount or visibility-change.
+// Cache contract (per Forge-9ye8):
+//   - 60-second TTL: stale entries trigger a background refetch on the
+//     next hook mount or visibility-change.
 //   - manual invalidation: refresh() clears the timestamp and forces a
-//     refetch immediately.
-//   - cache key includes repo identity: the underlying API path is
-//     daemon-scoped (a different daemon would be on a different origin), so
-//     cross-repo bleed is prevented by the browser's origin model. We carry
-//     the path as the cache key explicitly so future split endpoints (e.g.
-//     per-anvil routes) can extend this without rewriting the consumers.
+//     refetch immediately, even if the entry is fresh.
+//   - loading reflects an in-flight request, not "data is null". On a
+//     manual refresh, prior data stays visible while loading is true.
 
 import { useCallback, useEffect, useState } from 'react'
 import { ApiError, apiGet, type PRItem, type PRsResponse } from '../api'
@@ -22,7 +20,6 @@ export const PRS_API_PATH = '/api/prs/all'
 export const PRS_CACHE_TTL_MS = 60_000
 
 interface CacheEntry {
-  key: string
   data: PRsResponse | null
   fetchedAt: number
   error: string | null
@@ -35,7 +32,6 @@ const emptyResponse: PRsResponse = {
 }
 
 let cache: CacheEntry = {
-  key: PRS_API_PATH,
   data: null,
   fetchedAt: 0,
   error: null,
@@ -56,10 +52,10 @@ function isStale(): boolean {
 async function performFetch(onUnauthorized: () => void): Promise<void> {
   if (inflight) return inflight
   inflight = (async () => {
+    notify()
     try {
       const data = await apiGet<PRsResponse>(PRS_API_PATH)
       cache = {
-        key: PRS_API_PATH,
         data,
         fetchedAt: Date.now(),
         error: null,
@@ -71,7 +67,6 @@ async function performFetch(onUnauthorized: () => void): Promise<void> {
       }
       const message = err instanceof Error ? err.message : 'request failed'
       cache = {
-        key: PRS_API_PATH,
         data: cache.data,
         fetchedAt: Date.now(),
         error: message,
@@ -82,14 +77,6 @@ async function performFetch(onUnauthorized: () => void): Promise<void> {
     }
   })()
   return inflight
-}
-
-// __resetPRsCacheForTests is exposed so unit tests can simulate a fresh
-// session. Production code should never need it.
-export function __resetPRsCacheForTests() {
-  cache = { key: PRS_API_PATH, data: null, fetchedAt: 0, error: null }
-  inflight = null
-  subscribers.clear()
 }
 
 export interface PRsDataState {
@@ -152,7 +139,7 @@ export function usePRsData(): PRsDataState {
     forge_prs: data.forge_prs,
     external_prs: data.external_prs,
     recently_merged: data.recently_merged,
-    loading: cache.data === null && cache.error === null,
+    loading: inflight !== null,
     error: cache.error,
     fetchedAt: cache.fetchedAt > 0 ? cache.fetchedAt : null,
     refresh,
@@ -168,8 +155,7 @@ interface SectionResult {
 }
 
 // useForgePRs reads forge-managed open PRs from state.db via the shared
-// /api/prs/all backend. Sub-task 1 of Forge-ooiz consumes this hook to
-// render the "Forge PRs" section.
+// /api/prs/all backend.
 export function useForgePRs(): SectionResult {
   const s = usePRsData()
   return {

--- a/internal/web/frontend/src/pages/usePRsData.ts
+++ b/internal/web/frontend/src/pages/usePRsData.ts
@@ -1,0 +1,210 @@
+// usePRsData and the per-section convenience hooks (useForgePRs,
+// useExternalPRs, useRecentlyMergedPRs) back the /prs tab. They share a
+// module-level cache so all three sections of the page issue at most one
+// fetch per polling window — even when rendered as separate hooks.
+//
+// The cache contract (per Forge-9ye8):
+//   - 60-second TTL: stale entries trigger a background refetch on the next
+//     hook mount or visibility-change.
+//   - manual invalidation: refresh() clears the timestamp and forces a
+//     refetch immediately.
+//   - cache key includes repo identity: the underlying API path is
+//     daemon-scoped (a different daemon would be on a different origin), so
+//     cross-repo bleed is prevented by the browser's origin model. We carry
+//     the path as the cache key explicitly so future split endpoints (e.g.
+//     per-anvil routes) can extend this without rewriting the consumers.
+
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, apiGet, type PRItem, type PRsResponse } from '../api'
+import { useAuth } from '../auth'
+
+export const PRS_API_PATH = '/api/prs/all'
+export const PRS_CACHE_TTL_MS = 60_000
+
+interface CacheEntry {
+  key: string
+  data: PRsResponse | null
+  fetchedAt: number
+  error: string | null
+}
+
+const emptyResponse: PRsResponse = {
+  forge_prs: [],
+  external_prs: [],
+  recently_merged: [],
+}
+
+let cache: CacheEntry = {
+  key: PRS_API_PATH,
+  data: null,
+  fetchedAt: 0,
+  error: null,
+}
+
+let inflight: Promise<void> | null = null
+const subscribers = new Set<() => void>()
+
+function notify() {
+  for (const fn of subscribers) fn()
+}
+
+function isStale(): boolean {
+  if (cache.fetchedAt === 0) return true
+  return Date.now() - cache.fetchedAt >= PRS_CACHE_TTL_MS
+}
+
+async function performFetch(onUnauthorized: () => void): Promise<void> {
+  if (inflight) return inflight
+  inflight = (async () => {
+    try {
+      const data = await apiGet<PRsResponse>(PRS_API_PATH)
+      cache = {
+        key: PRS_API_PATH,
+        data,
+        fetchedAt: Date.now(),
+        error: null,
+      }
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        onUnauthorized()
+        return
+      }
+      const message = err instanceof Error ? err.message : 'request failed'
+      cache = {
+        key: PRS_API_PATH,
+        data: cache.data,
+        fetchedAt: Date.now(),
+        error: message,
+      }
+    } finally {
+      inflight = null
+      notify()
+    }
+  })()
+  return inflight
+}
+
+// __resetPRsCacheForTests is exposed so unit tests can simulate a fresh
+// session. Production code should never need it.
+export function __resetPRsCacheForTests() {
+  cache = { key: PRS_API_PATH, data: null, fetchedAt: 0, error: null }
+  inflight = null
+  subscribers.clear()
+}
+
+export interface PRsDataState {
+  forge_prs: PRItem[]
+  external_prs: PRItem[]
+  recently_merged: PRItem[]
+  loading: boolean
+  error: string | null
+  fetchedAt: number | null
+  refresh: () => void
+}
+
+// usePRsData returns all three PR sections plus loading/error state and a
+// refresh function that bypasses the in-memory cache. Render this once at
+// the top of a page and pass slices down, or use the per-section convenience
+// hooks below.
+export function usePRsData(): PRsDataState {
+  const { logout } = useAuth()
+  const [, setTick] = useState(0)
+
+  const onUnauthorized = useCallback(() => {
+    void logout()
+  }, [logout])
+
+  useEffect(() => {
+    const sub = () => setTick((n) => n + 1)
+    subscribers.add(sub)
+
+    if (isStale()) {
+      void performFetch(onUnauthorized)
+    }
+
+    const timer = window.setInterval(() => {
+      if (document.visibilityState === 'visible' && isStale()) {
+        void performFetch(onUnauthorized)
+      }
+    }, PRS_CACHE_TTL_MS)
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible' && isStale()) {
+        void performFetch(onUnauthorized)
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      subscribers.delete(sub)
+      window.clearInterval(timer)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [onUnauthorized])
+
+  const refresh = useCallback(() => {
+    cache = { ...cache, fetchedAt: 0, error: null }
+    void performFetch(onUnauthorized)
+  }, [onUnauthorized])
+
+  const data = cache.data ?? emptyResponse
+  return {
+    forge_prs: data.forge_prs,
+    external_prs: data.external_prs,
+    recently_merged: data.recently_merged,
+    loading: cache.data === null && cache.error === null,
+    error: cache.error,
+    fetchedAt: cache.fetchedAt > 0 ? cache.fetchedAt : null,
+    refresh,
+  }
+}
+
+interface SectionResult {
+  items: PRItem[]
+  loading: boolean
+  error: string | null
+  fetchedAt: number | null
+  refresh: () => void
+}
+
+// useForgePRs reads forge-managed open PRs from state.db via the shared
+// /api/prs/all backend. Sub-task 1 of Forge-ooiz consumes this hook to
+// render the "Forge PRs" section.
+export function useForgePRs(): SectionResult {
+  const s = usePRsData()
+  return {
+    items: s.forge_prs,
+    loading: s.loading,
+    error: s.error,
+    fetchedAt: s.fetchedAt,
+    refresh: s.refresh,
+  }
+}
+
+// useExternalPRs reads externally-authored open PRs from the same backend.
+// The daemon's reconcileOpenPRs goroutine periodically shells out to
+// `gh pr list` so this view stays current; the 60-second client cache
+// throttles re-renders without losing freshness on visibility changes.
+export function useExternalPRs(): SectionResult {
+  const s = usePRsData()
+  return {
+    items: s.external_prs,
+    loading: s.loading,
+    error: s.error,
+    fetchedAt: s.fetchedAt,
+    refresh: s.refresh,
+  }
+}
+
+// useRecentlyMergedPRs returns PRs (forge or external) merged within the
+// last 7 days, sorted newest-first.
+export function useRecentlyMergedPRs(): SectionResult {
+  const s = usePRsData()
+  return {
+    items: s.recently_merged,
+    loading: s.loading,
+    error: s.error,
+    fetchedAt: s.fetchedAt,
+    refresh: s.refresh,
+  }
+}

--- a/internal/web/frontend/src/pages/usePRsData.ts
+++ b/internal/web/frontend/src/pages/usePRsData.ts
@@ -1,8 +1,9 @@
-// usePRsData and the per-section convenience hooks (useForgePRs,
-// useExternalPRs, useRecentlyMergedPRs) back the /prs tab. They share a
-// module-level cache so multiple subscribers issue at most one fetch per
-// polling window — the cache is daemon-scoped (a different daemon would
-// be on a different origin), which prevents cross-repo bleed.
+// usePRsData backs the /prs tab. It uses a module-level cache so multiple
+// subscribers issue at most one fetch per polling window — the cache is
+// daemon-scoped (a different daemon would be on a different origin), which
+// prevents cross-repo bleed. Callers that need only one section should
+// destructure the return value rather than wrapping this hook, to avoid
+// duplicate interval and visibilitychange listener registrations.
 //
 // Cache contract (per Forge-9ye8):
 //   - 60-second TTL: stale entries trigger a background refetch on the
@@ -146,51 +147,3 @@ export function usePRsData(): PRsDataState {
   }
 }
 
-interface SectionResult {
-  items: PRItem[]
-  loading: boolean
-  error: string | null
-  fetchedAt: number | null
-  refresh: () => void
-}
-
-// useForgePRs reads forge-managed open PRs from state.db via the shared
-// /api/prs/all backend.
-export function useForgePRs(): SectionResult {
-  const s = usePRsData()
-  return {
-    items: s.forge_prs,
-    loading: s.loading,
-    error: s.error,
-    fetchedAt: s.fetchedAt,
-    refresh: s.refresh,
-  }
-}
-
-// useExternalPRs reads externally-authored open PRs from the same backend.
-// The daemon's reconcileOpenPRs goroutine periodically shells out to
-// `gh pr list` so this view stays current; the 60-second client cache
-// throttles re-renders without losing freshness on visibility changes.
-export function useExternalPRs(): SectionResult {
-  const s = usePRsData()
-  return {
-    items: s.external_prs,
-    loading: s.loading,
-    error: s.error,
-    fetchedAt: s.fetchedAt,
-    refresh: s.refresh,
-  }
-}
-
-// useRecentlyMergedPRs returns PRs (forge or external) merged within the
-// last 7 days, sorted newest-first.
-export function useRecentlyMergedPRs(): SectionResult {
-  const s = usePRsData()
-  return {
-    items: s.recently_merged,
-    loading: s.loading,
-    error: s.error,
-    fetchedAt: s.fetchedAt,
-    refresh: s.refresh,
-  }
-}

--- a/internal/web/prs.go
+++ b/internal/web/prs.go
@@ -83,7 +83,7 @@ func (s *Server) handlePRs(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	merged, err := recentlyMergedPRs(s.db, recentlyMergedWindow)
+	merged, err := s.recentlyMergedPRs(recentlyMergedWindow)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to load merged PRs: "+err.Error())
 		return
@@ -140,8 +140,8 @@ func mapPRToJSON(pr state.PR) prItemJSON {
 // timestamp falls within the given window. The state package only exposes a
 // helper that excludes ext-* IDs, so we query directly here to give the /prs
 // tab a complete view. Results are sorted newest-first.
-func recentlyMergedPRs(db *state.DB, window time.Duration) ([]prItemJSON, error) {
-	conn := db.Conn()
+func (s *Server) recentlyMergedPRs(window time.Duration) ([]prItemJSON, error) {
+	conn := s.db.Conn()
 	if conn == nil {
 		return []prItemJSON{}, nil
 	}
@@ -173,6 +173,7 @@ func recentlyMergedPRs(db *state.DB, window time.Duration) ([]prItemJSON, error)
 		if err := rows.Scan(&id, &number, &anvil, &beadID, &branch, &base, &status, &createdAt,
 			&lastChecked, &ciFix, &reviewFix, &rebase, &ciPassing, &conflicting,
 			&approved, &title, &bellowsManaged); err != nil {
+			s.logger.Warn("recently merged PR row scan failed", "error", err)
 			continue
 		}
 		isExt := strings.HasPrefix(beadID, "ext-")

--- a/internal/web/prs.go
+++ b/internal/web/prs.go
@@ -1,0 +1,236 @@
+package web
+
+import (
+	"database/sql"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// recentlyMergedWindow is how far back the /prs tab's "Recently merged"
+// section looks. PRs whose last_checked timestamp falls within this window
+// after a merge transition are returned.
+const recentlyMergedWindow = 7 * 24 * time.Hour
+
+// prItemJSON is the wire shape for one PR row in /api/prs/all. The fields
+// align with the frontend's PRItem type so callers can use the response
+// without re-mapping.
+type prItemJSON struct {
+	ID              int    `json:"id,omitempty"`
+	Number          int    `json:"number"`
+	Anvil           string `json:"anvil"`
+	Branch          string `json:"branch,omitempty"`
+	BaseBranch      string `json:"base_branch,omitempty"`
+	Title           string `json:"title,omitempty"`
+	Status          string `json:"status"`
+	IsExternal      bool   `json:"is_external"`
+	IsConflicting   bool   `json:"is_conflicting,omitempty"`
+	CIPassing       bool   `json:"ci_passing,omitempty"`
+	ReviewsApproved bool   `json:"reviews_approved,omitempty"`
+	BellowsAssigned bool   `json:"bellows_assigned,omitempty"`
+	CIFixCount      int    `json:"ci_fix_count,omitempty"`
+	ReviewFixCount  int    `json:"review_fix_count,omitempty"`
+	RebaseCount     int    `json:"rebase_count,omitempty"`
+	BeadID          string `json:"bead_id,omitempty"`
+	CreatedAt       string `json:"created_at,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
+	MergedAt        string `json:"merged_at,omitempty"`
+}
+
+// prsResponse is the JSON body returned by GET /api/prs/all. The keys
+// match the frontend PRsResponse / PRSectionKind so the SPA can index the
+// payload directly.
+type prsResponse struct {
+	ForgePRs       []prItemJSON `json:"forge_prs"`
+	ExternalPRs    []prItemJSON `json:"external_prs"`
+	RecentlyMerged []prItemJSON `json:"recently_merged"`
+}
+
+// handlePRs returns the three PR sections shown on the /prs tab:
+//   - forge_prs:       open PRs created by THIS Forge instance and currently
+//     under bellows lifecycle management.
+//   - external_prs:    open PRs that Forge did not create or no longer manages
+//     (other contributors, sibling Forge instances, untracked PRs reconciled
+//     into state.db with synthetic ext-* IDs).
+//   - recently_merged: any PR (forge or external) merged within the last
+//     recentlyMergedWindow.
+//
+// All three are read from state.db. The daemon's reconcileOpenPRs goroutine
+// keeps the table in sync with `gh pr list` so this read-side handler stays
+// fast (single SQL roundtrip) without shelling out per request. Manual
+// refresh is handled by the existing reconcile_prs IPC command.
+func (s *Server) handlePRs(w http.ResponseWriter, _ *http.Request) {
+	openPRs, err := s.db.OpenPRs()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load open PRs: "+err.Error())
+		return
+	}
+
+	resp := prsResponse{
+		ForgePRs:       []prItemJSON{},
+		ExternalPRs:    []prItemJSON{},
+		RecentlyMerged: []prItemJSON{},
+	}
+	for _, pr := range openPRs {
+		item := mapPRToJSON(pr)
+		if isForgeManagedPR(pr) {
+			resp.ForgePRs = append(resp.ForgePRs, item)
+		} else {
+			resp.ExternalPRs = append(resp.ExternalPRs, item)
+		}
+	}
+
+	merged, err := recentlyMergedPRs(s.db, recentlyMergedWindow)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load merged PRs: "+err.Error())
+		return
+	}
+	resp.RecentlyMerged = merged
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// isForgeManagedPR reports whether the given PR is one Forge created and is
+// still actively orchestrating. Synthetic ext-* IDs and PRs whose
+// bellows_managed flag has been cleared (e.g. PRs adopted from a sibling
+// Forge instance) belong in the External section.
+func isForgeManagedPR(pr state.PR) bool {
+	if pr.IsExternal() {
+		return false
+	}
+	return pr.BellowsManaged
+}
+
+// mapPRToJSON converts a state.PR to the wire shape consumed by the SPA.
+func mapPRToJSON(pr state.PR) prItemJSON {
+	item := prItemJSON{
+		ID:              pr.ID,
+		Number:          pr.Number,
+		Anvil:           pr.Anvil,
+		Branch:          pr.Branch,
+		BaseBranch:      pr.BaseBranch,
+		Title:           pr.Title,
+		Status:          string(pr.Status),
+		IsExternal:      pr.IsExternal(),
+		IsConflicting:   pr.IsConflicting,
+		CIPassing:       pr.CIPassing,
+		ReviewsApproved: pr.HasApproval,
+		BellowsAssigned: pr.BellowsManaged,
+		CIFixCount:      pr.CIFixCount,
+		ReviewFixCount:  pr.ReviewFixCount,
+		RebaseCount:     pr.RebaseCount,
+		BeadID:          pr.BeadID,
+	}
+	if !pr.CreatedAt.IsZero() {
+		item.CreatedAt = pr.CreatedAt.Format(time.RFC3339)
+	}
+	if pr.LastChecked != nil {
+		item.UpdatedAt = pr.LastChecked.Format(time.RFC3339)
+		if pr.Status == state.PRMerged {
+			item.MergedAt = pr.LastChecked.Format(time.RFC3339)
+		}
+	}
+	return item
+}
+
+// recentlyMergedPRs returns merged PRs (forge + external) whose last_checked
+// timestamp falls within the given window. The state package only exposes a
+// helper that excludes ext-* IDs, so we query directly here to give the /prs
+// tab a complete view. Results are sorted newest-first.
+func recentlyMergedPRs(db *state.DB, window time.Duration) ([]prItemJSON, error) {
+	conn := db.Conn()
+	if conn == nil {
+		return []prItemJSON{}, nil
+	}
+	// Match the canonical state.dbTimeLayout (fixed-width nanos with offset)
+	// so lexicographic comparison against last_checked stays correct.
+	cutoff := time.Now().Add(-window).UTC().Format("2006-01-02T15:04:05.000000000Z07:00")
+	rows, err := conn.Query(`SELECT id, number, anvil, bead_id, branch, COALESCE(base_branch,''),
+		status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count,
+		ci_passing, is_conflicting, has_approval, COALESCE(title,''), bellows_managed
+		FROM prs
+		WHERE status = 'merged' AND last_checked IS NOT NULL AND last_checked >= ?
+		ORDER BY last_checked DESC, id DESC
+		LIMIT 200`, cutoff)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []prItemJSON{}
+	for rows.Next() {
+		var (
+			id, number                                       int
+			anvil, beadID, branch, base, status, title       string
+			createdAt                                        string
+			lastChecked                                      sql.NullString
+			ciFix, reviewFix, rebase                         int
+			ciPassing, conflicting, approved, bellowsManaged int
+		)
+		if err := rows.Scan(&id, &number, &anvil, &beadID, &branch, &base, &status, &createdAt,
+			&lastChecked, &ciFix, &reviewFix, &rebase, &ciPassing, &conflicting,
+			&approved, &title, &bellowsManaged); err != nil {
+			continue
+		}
+		isExt := strings.HasPrefix(beadID, "ext-")
+		item := prItemJSON{
+			ID:              id,
+			Number:          number,
+			Anvil:           anvil,
+			Branch:          branch,
+			BaseBranch:      base,
+			Title:           title,
+			Status:          status,
+			IsExternal:      isExt,
+			IsConflicting:   conflicting != 0,
+			CIPassing:       ciPassing != 0,
+			ReviewsApproved: approved != 0,
+			BellowsAssigned: bellowsManaged != 0,
+			CIFixCount:      ciFix,
+			ReviewFixCount:  reviewFix,
+			RebaseCount:     rebase,
+			BeadID:          beadID,
+			CreatedAt:       createdAt,
+		}
+		if lastChecked.Valid {
+			item.UpdatedAt = lastChecked.String
+			item.MergedAt = lastChecked.String
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Defensive: SQL ORDER BY on the stored timestamp string already yields
+	// the right order, but stay tolerant of any rows whose last_checked
+	// value cannot be compared lexically by re-sorting on the parsed time.
+	sort.SliceStable(out, func(i, j int) bool {
+		ti := parseAnyTime(out[i].MergedAt)
+		tj := parseAnyTime(out[j].MergedAt)
+		return ti.After(tj)
+	})
+	return out, nil
+}
+
+// parseAnyTime parses a timestamp using the layouts the state package
+// produces (canonical fixed-width with nanos, then RFC3339Nano / RFC3339).
+// Returns the zero time when none of them parse.
+func parseAnyTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse("2006-01-02T15:04:05.000000000Z07:00", s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	return time.Time{}
+}

--- a/internal/web/prs.go
+++ b/internal/web/prs.go
@@ -58,10 +58,11 @@ type prsResponse struct {
 //   - recently_merged: any PR (forge or external) merged within the last
 //     recentlyMergedWindow.
 //
-// All three are read from state.db. The daemon's reconcileOpenPRs goroutine
-// keeps the table in sync with `gh pr list` so this read-side handler stays
-// fast (single SQL roundtrip) without shelling out per request. Manual
-// refresh is handled by the existing reconcile_prs IPC command.
+// All three are read from state.db via two queries (OpenPRs for open PRs,
+// recentlyMergedPRs for the merged window). The daemon's reconcileOpenPRs
+// goroutine keeps the table in sync with `gh pr list` so this handler never
+// shells out per request. The frontend refresh button re-fetches this
+// endpoint directly; it does not trigger the reconcile_prs IPC command.
 func (s *Server) handlePRs(w http.ResponseWriter, _ *http.Request) {
 	openPRs, err := s.db.OpenPRs()
 	if err != nil {
@@ -125,12 +126,12 @@ func mapPRToJSON(pr state.PR) prItemJSON {
 		BeadID:          pr.BeadID,
 	}
 	if !pr.CreatedAt.IsZero() {
-		item.CreatedAt = pr.CreatedAt.Format(time.RFC3339)
+		item.CreatedAt = pr.CreatedAt.UTC().Format(time.RFC3339Nano)
 	}
 	if pr.LastChecked != nil {
-		item.UpdatedAt = pr.LastChecked.Format(time.RFC3339)
+		item.UpdatedAt = pr.LastChecked.UTC().Format(time.RFC3339Nano)
 		if pr.Status == state.PRMerged {
-			item.MergedAt = pr.LastChecked.Format(time.RFC3339)
+			item.MergedAt = pr.LastChecked.UTC().Format(time.RFC3339Nano)
 		}
 	}
 	return item
@@ -147,7 +148,9 @@ func (s *Server) recentlyMergedPRs(window time.Duration) ([]prItemJSON, error) {
 	}
 	// Match the canonical state.dbTimeLayout (fixed-width nanos with offset)
 	// so lexicographic comparison against last_checked stays correct.
-	cutoff := time.Now().Add(-window).UTC().Format("2006-01-02T15:04:05.000000000Z07:00")
+	// Do NOT force UTC here — UpdatePRStatus writes time.Now() in the local
+	// timezone, so the cutoff must use the same offset to keep comparisons valid.
+	cutoff := time.Now().Add(-window).Format("2006-01-02T15:04:05.000000000Z07:00")
 	rows, err := conn.Query(`SELECT id, number, anvil, bead_id, branch, COALESCE(base_branch,''),
 		status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count,
 		ci_passing, is_conflicting, has_approval, COALESCE(title,''), bellows_managed
@@ -194,11 +197,15 @@ func (s *Server) recentlyMergedPRs(window time.Duration) ([]prItemJSON, error) {
 			ReviewFixCount:  reviewFix,
 			RebaseCount:     rebase,
 			BeadID:          beadID,
-			CreatedAt:       createdAt,
+		}
+		if t := parseAnyTime(createdAt); !t.IsZero() {
+			item.CreatedAt = t.UTC().Format(time.RFC3339Nano)
 		}
 		if lastChecked.Valid {
-			item.UpdatedAt = lastChecked.String
-			item.MergedAt = lastChecked.String
+			if t := parseAnyTime(lastChecked.String); !t.IsZero() {
+				item.UpdatedAt = t.UTC().Format(time.RFC3339Nano)
+				item.MergedAt = t.UTC().Format(time.RFC3339Nano)
+			}
 		}
 		out = append(out, item)
 	}

--- a/internal/web/prs_test.go
+++ b/internal/web/prs_test.go
@@ -157,6 +157,10 @@ func TestPRsAll_RecentlyMerged_RespectsWindow(t *testing.T) {
 	rec := httptest.NewRecorder()
 	srv.routes().ServeHTTP(rec, req)
 
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
 	var resp prsResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("parse: %v", err)

--- a/internal/web/prs_test.go
+++ b/internal/web/prs_test.go
@@ -1,0 +1,167 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Forge/internal/state"
+)
+
+func TestPRsAll_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, httptest.NewRequest("GET", "/api/prs/all", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d", rec.Code)
+	}
+}
+
+func TestPRsAll_EmptyResponseShape(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/prs/all", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// All three sections must be present and serialise as [] (not null) so
+	// the SPA can rely on indexing without null checks.
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, field := range []string{"forge_prs", "external_prs", "recently_merged"} {
+		raw, ok := body[field]
+		if !ok {
+			t.Errorf("field %q missing from response", field)
+			continue
+		}
+		if string(raw) == "null" {
+			t.Errorf("field %q is null; want []", field)
+		}
+	}
+}
+
+func TestPRsAll_SectionAssignment(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+
+	// Insert one forge-managed PR, one external PR, and one recently-merged PR.
+	now := time.Now().UTC()
+	forgePR := &state.PR{
+		Number:    1, Anvil: "anvil-a", BeadID: "Forge-aaaa",
+		Branch: "feature/x", Status: state.PROpen, Title: "Forge change",
+		CreatedAt: now,
+	}
+	if err := srv.db.InsertPR(forgePR); err != nil {
+		t.Fatalf("insert forge PR: %v", err)
+	}
+	// InsertPR sets bellows_managed=1 by default for forge PRs.
+
+	externalPR := &state.PR{
+		Number:    2, Anvil: "anvil-a", BeadID: "ext-2",
+		Branch: "patch", Status: state.PROpen, Title: "External patch",
+		CreatedAt: now,
+	}
+	if err := srv.db.InsertPR(externalPR); err != nil {
+		t.Fatalf("insert external PR: %v", err)
+	}
+	if err := srv.db.UpdatePRBellowsManaged(externalPR.ID, false); err != nil {
+		t.Fatalf("clear bellows on external: %v", err)
+	}
+
+	mergedPR := &state.PR{
+		Number:    3, Anvil: "anvil-a", BeadID: "Forge-bbbb",
+		Branch: "feature/y", Status: state.PROpen, Title: "Old change",
+		CreatedAt: now.Add(-2 * 24 * time.Hour),
+	}
+	if err := srv.db.InsertPR(mergedPR); err != nil {
+		t.Fatalf("insert merged PR: %v", err)
+	}
+	if err := srv.db.UpdatePRStatus(mergedPR.ID, state.PRMerged); err != nil {
+		t.Fatalf("mark merged: %v", err)
+	}
+
+	cookie := loginAndGetCookie(t, srv)
+	req := httptest.NewRequest("GET", "/api/prs/all", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp prsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Forge PR (open, bellows-managed, non-ext bead) goes to forge_prs.
+	if len(resp.ForgePRs) != 1 {
+		t.Fatalf("forge_prs: want 1, got %d (%+v)", len(resp.ForgePRs), resp.ForgePRs)
+	}
+	if got := resp.ForgePRs[0]; got.Number != 1 || got.IsExternal {
+		t.Errorf("forge_prs[0] unexpected: %+v", got)
+	}
+
+	// External PR (ext-* bead, not bellows-managed) goes to external_prs.
+	if len(resp.ExternalPRs) != 1 {
+		t.Fatalf("external_prs: want 1, got %d (%+v)", len(resp.ExternalPRs), resp.ExternalPRs)
+	}
+	if got := resp.ExternalPRs[0]; got.Number != 2 || !got.IsExternal {
+		t.Errorf("external_prs[0] unexpected: %+v", got)
+	}
+
+	// Merged PR within the 7-day window goes to recently_merged.
+	if len(resp.RecentlyMerged) != 1 {
+		t.Fatalf("recently_merged: want 1, got %d (%+v)", len(resp.RecentlyMerged), resp.RecentlyMerged)
+	}
+	if got := resp.RecentlyMerged[0]; got.Number != 3 || got.Status != string(state.PRMerged) {
+		t.Errorf("recently_merged[0] unexpected: %+v", got)
+	}
+}
+
+func TestPRsAll_RecentlyMerged_RespectsWindow(t *testing.T) {
+	// A PR last_checked >7 days ago must be excluded from recently_merged.
+	srv := newServerWithDefaults(t, nil)
+
+	pr := &state.PR{
+		Number:    99, Anvil: "anvil-a", BeadID: "Forge-cccc",
+		Branch: "old", Status: state.PROpen, Title: "Stale merged",
+		CreatedAt: time.Now().UTC().Add(-30 * 24 * time.Hour),
+	}
+	if err := srv.db.InsertPR(pr); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := srv.db.UpdatePRStatus(pr.ID, state.PRMerged); err != nil {
+		t.Fatalf("mark merged: %v", err)
+	}
+	// Backdate last_checked so the merge falls outside the 7-day window.
+	if _, err := srv.db.Conn().Exec(
+		`UPDATE prs SET last_checked = ? WHERE id = ?`,
+		time.Now().UTC().Add(-30*24*time.Hour).Format("2006-01-02T15:04:05.000000000Z07:00"),
+		pr.ID,
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	cookie := loginAndGetCookie(t, srv)
+	req := httptest.NewRequest("GET", "/api/prs/all", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	var resp prsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp.RecentlyMerged) != 0 {
+		t.Errorf("expected stale PR to be excluded, got %+v", resp.RecentlyMerged)
+	}
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -56,6 +56,7 @@ func (s *Server) routes() http.Handler {
 		r.Get("/ingots/{bead_id}", s.handleIngot)
 		r.Get("/history/workers", s.handleHistoryWorkers)
 		r.Get("/costs", s.handleCosts)
+		r.Get("/prs/all", s.handlePRs)
 		r.Get("/bead/{bead_id}", s.handleBeadDetail)
 
 		// Destructive admin actions (Hearth 2.0).


### PR DESCRIPTION
## Changes

- **PR data sources for the /prs tab** - Hearth 2.0's `/prs` tab now lists Forge-managed PRs, externally-authored PRs, and PRs merged in the last 7 days. Sections are populated by a new `GET /api/prs/all` endpoint backed by state.db, with a 60-second client-side cache and manual refresh. (Forge-9ye8)

## Original Issue (task): Implement PR data sources (forge, external, recently_merged)

Add data hooks: useForgePRs() reads from state.db (reuse existing daemon state query used by Hytte's PRModal); useExternalPRs() shells out to `gh pr list` filtered to other contributors, with a 60-second in-memory cache (timestamp + invalidation on manual refresh); useRecentlyMergedPRs() fetches merged PRs from the same backend. Place in web/src/components/hearth/usePRsData.ts. Sub-task 1 consumes these hooks to render section contents. Ensure cache key includes repo identity to avoid cross-repo bleed.

---
Bead: Forge-9ye8 | Branch: forge/Forge-9ye8
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)