### PR TITLE
Hearth 2.0: Beads-Forge page — UI skeleton, conversation persistence, draft input (Forge-qcqv)

### DIFF
--- a/changelog.d/Forge-qcqv.md
+++ b/changelog.d/Forge-qcqv.md
@@ -1,0 +1,2 @@
+category: Added
+- **Beads-Forge page foundation** - Hearth 2.0 gains a new `/forge` route with a session sidebar, chat-style conversation view, and a free-text "new session" draft input. Sessions and messages are persisted in `state.db` via the new `forge_sessions` and `forge_session_messages` tables, and managed through the `/api/forge/sessions` REST endpoints. This is a foundation-only delivery — claude integration and bead emission arrive in follow-on beads. (Forge-qcqv)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -383,6 +383,35 @@ CREATE TABLE IF NOT EXISTS web_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_web_sessions_expires ON web_sessions(expires_at);
+
+-- forge_sessions backs the "Beads-Forge" page in Hearth 2.0: each row is one
+-- conversation that designs a bead through dialogue. Foundation schema only —
+-- the AI integration and grilling stage live in follow-on beads, so for now
+-- a session is just a titled container for an ordered list of messages.
+CREATE TABLE IF NOT EXISTS forge_sessions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT NOT NULL DEFAULT '',
+    status      TEXT NOT NULL DEFAULT 'draft',
+    anvil       TEXT NOT NULL DEFAULT '',
+    created_by  TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_forge_sessions_updated_at ON forge_sessions(updated_at);
+CREATE INDEX IF NOT EXISTS idx_forge_sessions_created_by ON forge_sessions(created_by);
+
+CREATE TABLE IF NOT EXISTS forge_session_messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  INTEGER NOT NULL,
+    role        TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES forge_sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_forge_session_messages_session_id
+    ON forge_session_messages(session_id, id);
 `
 
 // dbTimeLayout is the canonical, fixed-width layout used for timestamps

--- a/internal/state/forge_sessions.go
+++ b/internal/state/forge_sessions.go
@@ -253,6 +253,57 @@ func (db *DB) ListForgeSessionMessages(sessionID int64) ([]ForgeSessionMessage, 
 	return out, rows.Err()
 }
 
+// ForgeSessionWithCount pairs a session with its pre-computed message count.
+// Returned by ListForgeSessionsWithCounts to avoid a separate COUNT per row.
+type ForgeSessionWithCount struct {
+	ForgeSession
+	MessageCount int
+}
+
+// ListForgeSessionsWithCounts returns sessions with their message counts using
+// a single LEFT JOIN query, eliminating the N+1 pattern of a per-row COUNT.
+// When createdBy is non-empty, rows owned by that user plus unattributed rows
+// (created_by="") are returned, consistent with forgeSessionVisibleTo.
+func (db *DB) ListForgeSessionsWithCounts(createdBy string, limit int) ([]ForgeSessionWithCount, error) {
+	if limit < 1 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	q := `SELECT s.id, s.title, s.status, s.anvil, s.created_by, s.created_at, s.updated_at,
+	             COUNT(m.id) AS message_count
+	      FROM forge_sessions s
+	      LEFT JOIN forge_session_messages m ON m.session_id = s.id`
+	args := []any{}
+	if createdBy != "" {
+		q += ` WHERE (s.created_by = ? OR s.created_by = '')`
+		args = append(args, createdBy)
+	}
+	q += ` GROUP BY s.id ORDER BY s.updated_at DESC, s.id DESC LIMIT ?`
+	args = append(args, limit)
+	rows, err := db.conn.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ForgeSessionWithCount{}
+	for rows.Next() {
+		var sc ForgeSessionWithCount
+		var createdAt, updatedAt string
+		if err := rows.Scan(
+			&sc.ID, &sc.Title, &sc.Status, &sc.Anvil, &sc.CreatedBy,
+			&createdAt, &updatedAt, &sc.MessageCount,
+		); err != nil {
+			return nil, err
+		}
+		sc.CreatedAt = parseTime(createdAt)
+		sc.UpdatedAt = parseTime(updatedAt)
+		out = append(out, sc)
+	}
+	return out, rows.Err()
+}
+
 // CountForgeSessionMessages returns the number of persisted messages for a
 // session. Used by the API to populate the sidebar preview without sending
 // the full message list.

--- a/internal/state/forge_sessions.go
+++ b/internal/state/forge_sessions.go
@@ -1,0 +1,299 @@
+package state
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// ForgeSession is one conversation row that backs the Beads-Forge page in
+// Hearth 2.0. Each session pairs a list of messages (forge_session_messages)
+// with metadata about who started it and what stage it is in.
+//
+// Status values are an open-ended TEXT to avoid an enum migration when later
+// beads add stages (plan_ready, beads_created, etc.). The foundation bead
+// uses only "draft" and "archived".
+type ForgeSession struct {
+	ID        int64
+	Title     string
+	Status    string
+	Anvil     string
+	CreatedBy string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// ForgeSessionMessage is one entry in a forge session conversation. Roles
+// follow the chat-style convention: "user", "assistant", "system". The
+// foundation bead only writes "user" and "system" entries; the AI bead will
+// add "assistant" once claude is wired in.
+type ForgeSessionMessage struct {
+	ID        int64
+	SessionID int64
+	Role      string
+	Content   string
+	CreatedAt time.Time
+}
+
+// Permitted forge session status values. Other beads may add more — the DB
+// stores TEXT so this is an advisory list rather than a strict enum.
+const (
+	ForgeSessionStatusDraft    = "draft"
+	ForgeSessionStatusArchived = "archived"
+)
+
+// Permitted forge session message roles.
+const (
+	ForgeMessageRoleUser      = "user"
+	ForgeMessageRoleAssistant = "assistant"
+	ForgeMessageRoleSystem    = "system"
+)
+
+// CreateForgeSession inserts a new session row, returning the assigned ID
+// and the canonical timestamps. CreatedBy may be empty when the caller is
+// unable to attribute the session to a user.
+func (db *DB) CreateForgeSession(s ForgeSession) (ForgeSession, error) {
+	now := time.Now().UTC()
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = now
+	}
+	if s.UpdatedAt.IsZero() {
+		s.UpdatedAt = now
+	}
+	if s.Status == "" {
+		s.Status = ForgeSessionStatusDraft
+	}
+	res, err := db.conn.Exec(
+		`INSERT INTO forge_sessions (title, status, anvil, created_by, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		s.Title, s.Status, s.Anvil, s.CreatedBy,
+		s.CreatedAt.UTC().Format(dbTimeLayout),
+		s.UpdatedAt.UTC().Format(dbTimeLayout),
+	)
+	if err != nil {
+		return ForgeSession{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return ForgeSession{}, err
+	}
+	s.ID = id
+	return s, nil
+}
+
+// GetForgeSession returns the session with the given ID, or nil if no row
+// exists. Errors other than ErrNoRows are returned to the caller.
+func (db *DB) GetForgeSession(id int64) (*ForgeSession, error) {
+	row := db.conn.QueryRow(
+		`SELECT id, title, status, anvil, created_by, created_at, updated_at
+		 FROM forge_sessions WHERE id = ?`, id,
+	)
+	return scanForgeSessionRow(row)
+}
+
+// ListForgeSessions returns sessions ordered by most-recent activity first.
+// When createdBy is non-empty, only sessions started by that user are
+// returned; this keeps the sidebar scoped to the signed-in user. Limit is
+// clamped to [1, 200].
+func (db *DB) ListForgeSessions(createdBy string, limit int) ([]ForgeSession, error) {
+	if limit < 1 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	q := `SELECT id, title, status, anvil, created_by, created_at, updated_at
+	      FROM forge_sessions`
+	args := []any{}
+	if createdBy != "" {
+		q += ` WHERE created_by = ?`
+		args = append(args, createdBy)
+	}
+	q += ` ORDER BY updated_at DESC, id DESC LIMIT ?`
+	args = append(args, limit)
+	rows, err := db.conn.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ForgeSession{}
+	for rows.Next() {
+		s, err := scanForgeSessionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *s)
+	}
+	return out, rows.Err()
+}
+
+// UpdateForgeSession applies a partial update to the session row. Only the
+// fields whose pointer is non-nil are written, so callers can rename a
+// session without touching its status (or vice versa). The updated_at
+// column is always advanced.
+func (db *DB) UpdateForgeSession(id int64, title, status *string) error {
+	if title == nil && status == nil {
+		// Still bump updated_at so the sidebar reorders even on a no-op
+		// touch (e.g. when a message is appended via TouchForgeSession).
+		_, err := db.conn.Exec(
+			`UPDATE forge_sessions SET updated_at = ? WHERE id = ?`,
+			time.Now().UTC().Format(dbTimeLayout), id,
+		)
+		return err
+	}
+	q := `UPDATE forge_sessions SET updated_at = ?`
+	args := []any{time.Now().UTC().Format(dbTimeLayout)}
+	if title != nil {
+		q += `, title = ?`
+		args = append(args, *title)
+	}
+	if status != nil {
+		q += `, status = ?`
+		args = append(args, *status)
+	}
+	q += ` WHERE id = ?`
+	args = append(args, id)
+	_, err := db.conn.Exec(q, args...)
+	return err
+}
+
+// TouchForgeSession bumps updated_at to now without changing other fields.
+// Called after appending a message so the sidebar reorders correctly.
+func (db *DB) TouchForgeSession(id int64) error {
+	return db.UpdateForgeSession(id, nil, nil)
+}
+
+// DeleteForgeSession removes a session and its messages. Foreign keys are
+// declared with ON DELETE CASCADE in the schema, but SQLite only honours
+// that when foreign_keys = ON, so we delete messages explicitly to be
+// independent of the connection-level pragma.
+func (db *DB) DeleteForgeSession(id int64) error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`DELETE FROM forge_session_messages WHERE session_id = ?`, id); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM forge_sessions WHERE id = ?`, id); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// AppendForgeSessionMessage inserts a new message and bumps the parent
+// session's updated_at in a single transaction. Returns the persisted
+// message with its assigned ID and timestamp.
+func (db *DB) AppendForgeSessionMessage(m ForgeSessionMessage) (ForgeSessionMessage, error) {
+	if m.SessionID == 0 {
+		return ForgeSessionMessage{}, errors.New("forge session message: session_id is required")
+	}
+	if m.Role == "" {
+		return ForgeSessionMessage{}, errors.New("forge session message: role is required")
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now().UTC()
+	}
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return ForgeSessionMessage{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.Exec(
+		`INSERT INTO forge_session_messages (session_id, role, content, created_at)
+		 VALUES (?, ?, ?, ?)`,
+		m.SessionID, m.Role, m.Content,
+		m.CreatedAt.UTC().Format(dbTimeLayout),
+	)
+	if err != nil {
+		return ForgeSessionMessage{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return ForgeSessionMessage{}, err
+	}
+	if _, err := tx.Exec(
+		`UPDATE forge_sessions SET updated_at = ? WHERE id = ?`,
+		m.CreatedAt.UTC().Format(dbTimeLayout), m.SessionID,
+	); err != nil {
+		return ForgeSessionMessage{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ForgeSessionMessage{}, err
+	}
+	m.ID = id
+	return m, nil
+}
+
+// ListForgeSessionMessages returns the messages for a session in insertion
+// order (oldest first), suitable for direct rendering in the chat view.
+func (db *DB) ListForgeSessionMessages(sessionID int64) ([]ForgeSessionMessage, error) {
+	rows, err := db.conn.Query(
+		`SELECT id, session_id, role, content, created_at
+		 FROM forge_session_messages
+		 WHERE session_id = ?
+		 ORDER BY id ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ForgeSessionMessage{}
+	for rows.Next() {
+		var m ForgeSessionMessage
+		var createdAt string
+		if err := rows.Scan(&m.ID, &m.SessionID, &m.Role, &m.Content, &createdAt); err != nil {
+			return nil, err
+		}
+		m.CreatedAt = parseTime(createdAt)
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// CountForgeSessionMessages returns the number of persisted messages for a
+// session. Used by the API to populate the sidebar preview without sending
+// the full message list.
+func (db *DB) CountForgeSessionMessages(sessionID int64) (int, error) {
+	row := db.conn.QueryRow(
+		`SELECT COUNT(*) FROM forge_session_messages WHERE session_id = ?`,
+		sessionID,
+	)
+	var n int
+	if err := row.Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// scanForgeSessionRow scans a single sql.Row into a ForgeSession. Returns
+// (nil, nil) when the row does not exist.
+func scanForgeSessionRow(row *sql.Row) (*ForgeSession, error) {
+	var s ForgeSession
+	var createdAt, updatedAt string
+	err := row.Scan(&s.ID, &s.Title, &s.Status, &s.Anvil, &s.CreatedBy, &createdAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	s.CreatedAt = parseTime(createdAt)
+	s.UpdatedAt = parseTime(updatedAt)
+	return &s, nil
+}
+
+// scanForgeSessionRows scans the next row of a sql.Rows cursor into a
+// ForgeSession. The caller is responsible for advancing the cursor.
+func scanForgeSessionRows(rows *sql.Rows) (*ForgeSession, error) {
+	var s ForgeSession
+	var createdAt, updatedAt string
+	if err := rows.Scan(&s.ID, &s.Title, &s.Status, &s.Anvil, &s.CreatedBy, &createdAt, &updatedAt); err != nil {
+		return nil, err
+	}
+	s.CreatedAt = parseTime(createdAt)
+	s.UpdatedAt = parseTime(updatedAt)
+	return &s, nil
+}

--- a/internal/state/forge_sessions.go
+++ b/internal/state/forge_sessions.go
@@ -25,8 +25,8 @@ type ForgeSession struct {
 
 // ForgeSessionMessage is one entry in a forge session conversation. Roles
 // follow the chat-style convention: "user", "assistant", "system". The
-// foundation bead only writes "user" and "system" entries; the AI bead will
-// add "assistant" once claude is wired in.
+// foundation bead only writes "user" entries through its API; the AI bead
+// will add "assistant" (and any "system" framing) once claude is wired in.
 type ForgeSessionMessage struct {
 	ID        int64
 	SessionID int64

--- a/internal/state/forge_sessions_test.go
+++ b/internal/state/forge_sessions_test.go
@@ -1,0 +1,280 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openTestDB(t *testing.T) *DB {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "forge-state-fs-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestForgeSessions_CreateAndGet(t *testing.T) {
+	db := openTestDB(t)
+
+	s, err := db.CreateForgeSession(ForgeSession{
+		Title:     "Refactor poller",
+		Anvil:     "anvil-1",
+		CreatedBy: "alice",
+	})
+	if err != nil {
+		t.Fatalf("CreateForgeSession: %v", err)
+	}
+	if s.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+	if s.Status != ForgeSessionStatusDraft {
+		t.Errorf("expected default status %q, got %q", ForgeSessionStatusDraft, s.Status)
+	}
+	if s.CreatedAt.IsZero() || s.UpdatedAt.IsZero() {
+		t.Error("expected timestamps to be set")
+	}
+
+	got, err := db.GetForgeSession(s.ID)
+	if err != nil {
+		t.Fatalf("GetForgeSession: %v", err)
+	}
+	if got == nil {
+		t.Fatal("session not found after insert")
+	}
+	if got.Title != "Refactor poller" || got.Anvil != "anvil-1" || got.CreatedBy != "alice" {
+		t.Errorf("unexpected fields: %+v", got)
+	}
+}
+
+func TestForgeSessions_GetMissingReturnsNil(t *testing.T) {
+	db := openTestDB(t)
+	got, err := db.GetForgeSession(9999)
+	if err != nil {
+		t.Fatalf("GetForgeSession: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing session, got %+v", got)
+	}
+}
+
+func TestForgeSessions_ListOrderAndScope(t *testing.T) {
+	db := openTestDB(t)
+
+	// Insert sessions for two different users; the older one should
+	// come last in the list, and the bob session should be filtered
+	// out when we scope to alice.
+	a1, err := db.CreateForgeSession(ForgeSession{Title: "Older alice", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Force a small clock skew so updated_at differs.
+	time.Sleep(2 * time.Millisecond)
+	_, err = db.CreateForgeSession(ForgeSession{Title: "Bob's session", CreatedBy: "bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(2 * time.Millisecond)
+	a2, err := db.CreateForgeSession(ForgeSession{Title: "Newer alice", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := db.ListForgeSessions("", 50)
+	if err != nil {
+		t.Fatalf("ListForgeSessions: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 sessions, got %d", len(all))
+	}
+	if all[0].ID != a2.ID {
+		t.Errorf("expected newest session first, got id=%d", all[0].ID)
+	}
+
+	scoped, err := db.ListForgeSessions("alice", 50)
+	if err != nil {
+		t.Fatalf("ListForgeSessions(alice): %v", err)
+	}
+	if len(scoped) != 2 {
+		t.Fatalf("expected 2 alice sessions, got %d", len(scoped))
+	}
+	if scoped[0].ID != a2.ID || scoped[1].ID != a1.ID {
+		t.Errorf("unexpected order: %d then %d", scoped[0].ID, scoped[1].ID)
+	}
+}
+
+func TestForgeSessions_AppendBumpsUpdatedAt(t *testing.T) {
+	db := openTestDB(t)
+
+	s, err := db.CreateForgeSession(ForgeSession{Title: "Talk", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := s.UpdatedAt
+	// Sleep so the updated_at delta is observable in the dbTimeLayout
+	// resolution (nanoseconds, but on some platforms the system clock
+	// only advances on millisecond ticks).
+	time.Sleep(2 * time.Millisecond)
+
+	m, err := db.AppendForgeSessionMessage(ForgeSessionMessage{
+		SessionID: s.ID,
+		Role:      ForgeMessageRoleUser,
+		Content:   "Hello",
+	})
+	if err != nil {
+		t.Fatalf("AppendForgeSessionMessage: %v", err)
+	}
+	if m.ID == 0 {
+		t.Error("expected non-zero message ID")
+	}
+	if m.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	got, err := db.GetForgeSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.UpdatedAt.After(original) {
+		t.Errorf("expected updated_at to advance after appending; was %v, now %v", original, got.UpdatedAt)
+	}
+}
+
+func TestForgeSessions_ListMessagesInOrder(t *testing.T) {
+	db := openTestDB(t)
+
+	s, err := db.CreateForgeSession(ForgeSession{Title: "Conv", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{"first", "second", "third"} {
+		if _, err := db.AppendForgeSessionMessage(ForgeSessionMessage{
+			SessionID: s.ID,
+			Role:      ForgeMessageRoleUser,
+			Content:   content,
+		}); err != nil {
+			t.Fatalf("append %s: %v", content, err)
+		}
+	}
+
+	msgs, err := db.ListForgeSessionMessages(s.ID)
+	if err != nil {
+		t.Fatalf("ListForgeSessionMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+	for i, want := range []string{"first", "second", "third"} {
+		if msgs[i].Content != want {
+			t.Errorf("msg %d: want %q, got %q", i, want, msgs[i].Content)
+		}
+	}
+
+	count, err := db.CountForgeSessionMessages(s.ID)
+	if err != nil {
+		t.Fatalf("CountForgeSessionMessages: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected count 3, got %d", count)
+	}
+}
+
+func TestForgeSessions_UpdateTitleAndStatus(t *testing.T) {
+	db := openTestDB(t)
+	s, err := db.CreateForgeSession(ForgeSession{Title: "Old", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newTitle := "Renamed"
+	if err := db.UpdateForgeSession(s.ID, &newTitle, nil); err != nil {
+		t.Fatalf("UpdateForgeSession (title): %v", err)
+	}
+	got, err := db.GetForgeSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "Renamed" {
+		t.Errorf("expected title Renamed, got %q", got.Title)
+	}
+	if got.Status != ForgeSessionStatusDraft {
+		t.Errorf("status should remain draft when not updated, got %q", got.Status)
+	}
+
+	archived := ForgeSessionStatusArchived
+	if err := db.UpdateForgeSession(s.ID, nil, &archived); err != nil {
+		t.Fatalf("UpdateForgeSession (status): %v", err)
+	}
+	got, err = db.GetForgeSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != ForgeSessionStatusArchived {
+		t.Errorf("expected archived status, got %q", got.Status)
+	}
+	if got.Title != "Renamed" {
+		t.Errorf("title should remain Renamed when only status updated, got %q", got.Title)
+	}
+}
+
+func TestForgeSessions_DeleteCascades(t *testing.T) {
+	db := openTestDB(t)
+	s, err := db.CreateForgeSession(ForgeSession{Title: "Doomed", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.AppendForgeSessionMessage(ForgeSessionMessage{
+		SessionID: s.ID,
+		Role:      ForgeMessageRoleUser,
+		Content:   "hi",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.DeleteForgeSession(s.ID); err != nil {
+		t.Fatalf("DeleteForgeSession: %v", err)
+	}
+
+	got, err := db.GetForgeSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected session to be deleted, got %+v", got)
+	}
+	count, err := db.CountForgeSessionMessages(s.ID)
+	if err != nil {
+		t.Fatalf("CountForgeSessionMessages: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected messages to be cascade-deleted, got %d", count)
+	}
+}
+
+func TestForgeSessions_AppendValidation(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := db.AppendForgeSessionMessage(ForgeSessionMessage{
+		Role:    ForgeMessageRoleUser,
+		Content: "no session",
+	}); err == nil {
+		t.Error("expected error for missing session_id")
+	}
+	s, err := db.CreateForgeSession(ForgeSession{Title: "S", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.AppendForgeSessionMessage(ForgeSessionMessage{
+		SessionID: s.ID,
+		Content:   "no role",
+	}); err == nil {
+		t.Error("expected error for missing role")
+	}
+}

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -153,9 +153,7 @@ func (s *Server) handleForgeSessionsCreate(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, "initial message exceeds size limit")
 		return
 	}
-	if len(req.Title) > maxForgeTitleLen {
-		req.Title = req.Title[:maxForgeTitleLen]
-	}
+	req.Title = truncateTitle(req.Title)
 	if req.Title == "" && req.InitialMessage != "" {
 		req.Title = autoTitleFromMessage(req.InitialMessage)
 	}
@@ -279,10 +277,7 @@ func (s *Server) handleForgeSessionUpdate(w http.ResponseWriter, r *http.Request
 		}
 	}
 	if req.Title != nil {
-		t := strings.TrimSpace(*req.Title)
-		if len(t) > maxForgeTitleLen {
-			t = t[:maxForgeTitleLen]
-		}
+		t := truncateTitle(*req.Title)
 		req.Title = &t
 	}
 	if req.Status != nil {
@@ -449,10 +444,10 @@ func parseForgeSessionID(w http.ResponseWriter, r *http.Request) (int64, bool) {
 	return id, true
 }
 
-// forgeSessionVisibleTo enforces the per-user scoping rule. A session
-// without a created_by attribution (legacy rows, scripts) is treated as
-// owned by the daemon and only visible to its creator-of-record; the empty
-// string never matches a real session.
+// forgeSessionVisibleTo enforces the per-user scoping rule. Rows with a
+// non-empty created_by are only visible to that user. Legacy rows that
+// pre-date attribution (created_by == "") fall back to being visible to
+// every signed-in user so they remain readable after the schema change.
 func forgeSessionVisibleTo(row *state.ForgeSession, username string) bool {
 	if row == nil {
 		return false
@@ -475,7 +470,23 @@ func isValidForgeSessionStatus(s string) bool {
 	return false
 }
 
-// autoTitleFromMessage takes the first line (or first ~80 chars) of a
+// truncateTitle trims whitespace from the edges of a title and caps it at
+// maxForgeTitleLen runes. Truncation happens on rune boundaries so multi-byte
+// characters (emoji, non-ASCII text) cannot be sliced in half.
+func truncateTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ""
+	}
+	runes := []rune(title)
+	if len(runes) > maxForgeTitleLen {
+		runes = runes[:maxForgeTitleLen]
+		title = string(runes)
+	}
+	return title
+}
+
+// autoTitleFromMessage takes the first line (or first ~80 runes) of a
 // message body and uses it as the session title. Whitespace at the edges
 // and trailing punctuation are trimmed so the sidebar stays tidy.
 func autoTitleFromMessage(msg string) string {

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -97,19 +97,14 @@ func (s *Server) handleForgeSessionsList(w http.ResponseWriter, r *http.Request)
 		}
 		limit = n
 	}
-	rows, err := s.db.ListForgeSessions(sess.Username, limit)
+	rows, err := s.db.ListForgeSessionsWithCounts(sess.Username, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list sessions: "+err.Error())
 		return
 	}
 	out := make([]forgeSessionDTO, 0, len(rows))
 	for _, row := range rows {
-		count, err := s.db.CountForgeSessionMessages(row.ID)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to count messages: "+err.Error())
-			return
-		}
-		out = append(out, toForgeSessionDTO(row, count))
+		out = append(out, toForgeSessionDTO(row.ForgeSession, row.MessageCount))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"sessions": out})
 }
@@ -176,6 +171,8 @@ func (s *Server) handleForgeSessionsCreate(w http.ResponseWriter, r *http.Reques
 			Content:   req.InitialMessage,
 		})
 		if err != nil {
+			// Delete the orphaned session so a retry starts clean.
+			_ = s.db.DeleteForgeSession(row.ID)
 			writeError(w, http.StatusInternalServerError, "failed to append message: "+err.Error())
 			return
 		}
@@ -187,7 +184,11 @@ func (s *Server) handleForgeSessionsCreate(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	count, _ := s.db.CountForgeSessionMessages(row.ID)
+	count, err := s.db.CountForgeSessionMessages(row.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to count messages: "+err.Error())
+		return
+	}
 	resp := map[string]any{"session": toForgeSessionDTO(row, count)}
 	if firstMessage != nil {
 		resp["message"] = *firstMessage
@@ -276,6 +277,10 @@ func (s *Server) handleForgeSessionUpdate(w http.ResponseWriter, r *http.Request
 			return
 		}
 	}
+	if req.Title == nil && req.Status == nil {
+		writeError(w, http.StatusBadRequest, "request must include title or status")
+		return
+	}
 	if req.Title != nil {
 		t := truncateTitle(*req.Title)
 		req.Title = &t
@@ -297,7 +302,11 @@ func (s *Server) handleForgeSessionUpdate(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "failed to reload session")
 		return
 	}
-	count, _ := s.db.CountForgeSessionMessages(id)
+	count, err := s.db.CountForgeSessionMessages(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to count messages: "+err.Error())
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"session": toForgeSessionDTO(*row, count)})
 }
 
@@ -421,7 +430,11 @@ func (s *Server) handleForgeSessionAppend(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "failed to reload session")
 		return
 	}
-	count, _ := s.db.CountForgeSessionMessages(id)
+	count, err := s.db.CountForgeSessionMessages(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to count messages: "+err.Error())
+		return
+	}
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"message": toForgeMessageDTO(m),
 		"session": toForgeSessionDTO(*updated, count),

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -1,0 +1,500 @@
+package web
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/go-chi/chi/v5"
+)
+
+// Beads-Forge HTTP handlers
+//
+// This file backs the /forge route in the Hearth 2.0 SPA. Each row in
+// state.forge_sessions is one chat-style conversation that designs a bead.
+// The foundation bead delivers persistence + draft input only — the AI
+// integration and grilling stage land in follow-on beads, so the message
+// API is intentionally simple: every POST appends one message verbatim.
+
+// maxForgeMessageBytes caps the size of a single message payload. Messages
+// are stored in SQLite TEXT columns, but we want a sensible upper bound so
+// a runaway client cannot spend all of the daemon's memory in one request.
+const maxForgeMessageBytes = 64 * 1024
+
+// maxForgeTitleLen limits the length of session titles. Long titles wreck
+// the sidebar layout and there is no use case for more than a short label.
+const maxForgeTitleLen = 200
+
+// forgeSessionDTO is the JSON shape returned by the listing and CRUD
+// endpoints. Timestamps are rendered as RFC3339 to match the rest of the
+// Hearth 2.0 API surface.
+type forgeSessionDTO struct {
+	ID           int64  `json:"id"`
+	Title        string `json:"title"`
+	Status       string `json:"status"`
+	Anvil        string `json:"anvil,omitempty"`
+	CreatedBy    string `json:"created_by,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+	MessageCount int    `json:"message_count"`
+}
+
+// forgeMessageDTO is the JSON shape for a single message.
+type forgeMessageDTO struct {
+	ID        int64  `json:"id"`
+	SessionID int64  `json:"session_id"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	CreatedAt string `json:"created_at"`
+}
+
+// toForgeSessionDTO converts a state row into the API DTO. The caller is
+// responsible for supplying the message count — most listings already need
+// the count, and computing it inline keeps the helper free of *DB.
+func toForgeSessionDTO(s state.ForgeSession, messageCount int) forgeSessionDTO {
+	return forgeSessionDTO{
+		ID:           s.ID,
+		Title:        s.Title,
+		Status:       s.Status,
+		Anvil:        s.Anvil,
+		CreatedBy:    s.CreatedBy,
+		CreatedAt:    s.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:    s.UpdatedAt.Format(time.RFC3339),
+		MessageCount: messageCount,
+	}
+}
+
+// toForgeMessageDTO converts a state row into the API DTO.
+func toForgeMessageDTO(m state.ForgeSessionMessage) forgeMessageDTO {
+	return forgeMessageDTO{
+		ID:        m.ID,
+		SessionID: m.SessionID,
+		Role:      m.Role,
+		Content:   m.Content,
+		CreatedAt: m.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+// handleForgeSessionsList serves GET /api/forge/sessions. Sessions are
+// scoped to the signed-in user so two operators sharing a daemon don't see
+// each other's drafts.
+func (s *Server) handleForgeSessionsList(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	limit := 50
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		limit = n
+	}
+	rows, err := s.db.ListForgeSessions(sess.Username, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list sessions: "+err.Error())
+		return
+	}
+	out := make([]forgeSessionDTO, 0, len(rows))
+	for _, row := range rows {
+		count, err := s.db.CountForgeSessionMessages(row.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to count messages: "+err.Error())
+			return
+		}
+		out = append(out, toForgeSessionDTO(row, count))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sessions": out})
+}
+
+// createForgeSessionRequest is the body for POST /api/forge/sessions. Both
+// fields are optional: empty title means "untitled" and an empty initial
+// message means "no opening prompt yet".
+type createForgeSessionRequest struct {
+	Title          string `json:"title,omitempty"`
+	Anvil          string `json:"anvil,omitempty"`
+	InitialMessage string `json:"initial_message,omitempty"`
+}
+
+// handleForgeSessionsCreate serves POST /api/forge/sessions. When the body
+// includes an initial_message, it is persisted as the first user message in
+// the same response so the SPA does not need a second round-trip. The auto
+// title is the first ~80 chars of the initial message when no title is
+// supplied; this is the same heuristic Hytte's chat uses.
+func (s *Server) handleForgeSessionsCreate(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxForgeMessageBytes+4096))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req createForgeSessionRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+	}
+	req.Title = strings.TrimSpace(req.Title)
+	req.Anvil = strings.TrimSpace(req.Anvil)
+	req.InitialMessage = strings.TrimSpace(req.InitialMessage)
+	if len(req.InitialMessage) > maxForgeMessageBytes {
+		writeError(w, http.StatusBadRequest, "initial message exceeds size limit")
+		return
+	}
+	if len(req.Title) > maxForgeTitleLen {
+		req.Title = req.Title[:maxForgeTitleLen]
+	}
+	if req.Title == "" && req.InitialMessage != "" {
+		req.Title = autoTitleFromMessage(req.InitialMessage)
+	}
+
+	row, err := s.db.CreateForgeSession(state.ForgeSession{
+		Title:     req.Title,
+		Anvil:     req.Anvil,
+		CreatedBy: sess.Username,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create session: "+err.Error())
+		return
+	}
+
+	var firstMessage *forgeMessageDTO
+	if req.InitialMessage != "" {
+		m, err := s.db.AppendForgeSessionMessage(state.ForgeSessionMessage{
+			SessionID: row.ID,
+			Role:      state.ForgeMessageRoleUser,
+			Content:   req.InitialMessage,
+		})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to append message: "+err.Error())
+			return
+		}
+		dto := toForgeMessageDTO(m)
+		firstMessage = &dto
+		// Reload the session so updated_at reflects the message append.
+		if reloaded, err := s.db.GetForgeSession(row.ID); err == nil && reloaded != nil {
+			row = *reloaded
+		}
+	}
+
+	count, _ := s.db.CountForgeSessionMessages(row.ID)
+	resp := map[string]any{"session": toForgeSessionDTO(row, count)}
+	if firstMessage != nil {
+		resp["message"] = *firstMessage
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+// handleForgeSessionGet serves GET /api/forge/sessions/{id}. The response
+// bundles the session metadata and the full message list so the chat view
+// only needs one round-trip when navigating from the sidebar.
+func (s *Server) handleForgeSessionGet(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id, ok := parseForgeSessionID(w, r)
+	if !ok {
+		return
+	}
+	row, err := s.db.GetForgeSession(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load session: "+err.Error())
+		return
+	}
+	if row == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if !forgeSessionVisibleTo(row, sess.Username) {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	msgs, err := s.db.ListForgeSessionMessages(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load messages: "+err.Error())
+		return
+	}
+	out := make([]forgeMessageDTO, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, toForgeMessageDTO(m))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"session":  toForgeSessionDTO(*row, len(msgs)),
+		"messages": out,
+	})
+}
+
+// updateForgeSessionRequest is the body for PATCH /api/forge/sessions/{id}.
+// Both fields are optional; nil pointer = "leave alone".
+type updateForgeSessionRequest struct {
+	Title  *string `json:"title,omitempty"`
+	Status *string `json:"status,omitempty"`
+}
+
+// handleForgeSessionUpdate serves PATCH /api/forge/sessions/{id}. Used for
+// renaming and archiving sessions from the sidebar.
+func (s *Server) handleForgeSessionUpdate(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id, ok := parseForgeSessionID(w, r)
+	if !ok {
+		return
+	}
+	row, err := s.db.GetForgeSession(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load session: "+err.Error())
+		return
+	}
+	if row == nil || !forgeSessionVisibleTo(row, sess.Username) {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 8*1024))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req updateForgeSessionRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+	}
+	if req.Title != nil {
+		t := strings.TrimSpace(*req.Title)
+		if len(t) > maxForgeTitleLen {
+			t = t[:maxForgeTitleLen]
+		}
+		req.Title = &t
+	}
+	if req.Status != nil {
+		st := strings.TrimSpace(*req.Status)
+		if !isValidForgeSessionStatus(st) {
+			writeError(w, http.StatusBadRequest, "invalid status value")
+			return
+		}
+		req.Status = &st
+	}
+	if err := s.db.UpdateForgeSession(id, req.Title, req.Status); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to update session: "+err.Error())
+		return
+	}
+	row, err = s.db.GetForgeSession(id)
+	if err != nil || row == nil {
+		writeError(w, http.StatusInternalServerError, "failed to reload session")
+		return
+	}
+	count, _ := s.db.CountForgeSessionMessages(id)
+	writeJSON(w, http.StatusOK, map[string]any{"session": toForgeSessionDTO(*row, count)})
+}
+
+// handleForgeSessionDelete serves DELETE /api/forge/sessions/{id}. The
+// delete is permanent; the foundation bead does not implement an
+// archive-instead-of-delete flow because the next bead can flip status to
+// "archived" via PATCH if soft delete becomes desirable.
+func (s *Server) handleForgeSessionDelete(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id, ok := parseForgeSessionID(w, r)
+	if !ok {
+		return
+	}
+	row, err := s.db.GetForgeSession(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load session: "+err.Error())
+		return
+	}
+	if row == nil || !forgeSessionVisibleTo(row, sess.Username) {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if err := s.db.DeleteForgeSession(id); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to delete session: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// appendForgeMessageRequest is the body for POST /api/forge/sessions/{id}/messages.
+// The foundation bead only writes user-role messages; later beads will add
+// assistant responses. We accept role explicitly so the API stays
+// open-ended, but reject anything other than "user" until the AI bead lands.
+type appendForgeMessageRequest struct {
+	Content string `json:"content"`
+	Role    string `json:"role,omitempty"`
+}
+
+// handleForgeSessionAppend serves POST /api/forge/sessions/{id}/messages.
+// The foundation bead only persists the user message — claude integration
+// arrives in the next bead.
+func (s *Server) handleForgeSessionAppend(w http.ResponseWriter, r *http.Request) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	id, ok := parseForgeSessionID(w, r)
+	if !ok {
+		return
+	}
+	row, err := s.db.GetForgeSession(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load session: "+err.Error())
+		return
+	}
+	if row == nil || !forgeSessionVisibleTo(row, sess.Username) {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxForgeMessageBytes+4096))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req appendForgeMessageRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+	}
+	req.Content = strings.TrimSpace(req.Content)
+	if req.Content == "" {
+		writeError(w, http.StatusBadRequest, "content is required")
+		return
+	}
+	if len(req.Content) > maxForgeMessageBytes {
+		writeError(w, http.StatusBadRequest, "content exceeds size limit")
+		return
+	}
+	role := strings.TrimSpace(req.Role)
+	if role == "" {
+		role = state.ForgeMessageRoleUser
+	}
+	// Foundation bead constraint: only user-authored messages can be
+	// appended via the public API. Assistant messages will arrive once the
+	// AI bead wires claude into the daemon — at that point the worker
+	// itself, not an HTTP client, will write them.
+	if role != state.ForgeMessageRoleUser {
+		writeError(w, http.StatusBadRequest, "only user role messages may be appended in the foundation API")
+		return
+	}
+
+	// If the session has no title yet, derive one from the first message.
+	titleBefore := row.Title
+
+	m, err := s.db.AppendForgeSessionMessage(state.ForgeSessionMessage{
+		SessionID: id,
+		Role:      role,
+		Content:   req.Content,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to append message: "+err.Error())
+		return
+	}
+
+	if titleBefore == "" {
+		newTitle := autoTitleFromMessage(req.Content)
+		if newTitle != "" {
+			_ = s.db.UpdateForgeSession(id, &newTitle, nil)
+		}
+	}
+
+	updated, err := s.db.GetForgeSession(id)
+	if err != nil || updated == nil {
+		writeError(w, http.StatusInternalServerError, "failed to reload session")
+		return
+	}
+	count, _ := s.db.CountForgeSessionMessages(id)
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"message": toForgeMessageDTO(m),
+		"session": toForgeSessionDTO(*updated, count),
+	})
+}
+
+// parseForgeSessionID extracts the {id} URL parameter and parses it as an
+// int64. Writes an error response and returns ok=false on failure.
+func parseForgeSessionID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := chi.URLParam(r, "id")
+	if raw == "" {
+		writeError(w, http.StatusBadRequest, "id is required")
+		return 0, false
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		writeError(w, http.StatusBadRequest, "invalid session id")
+		return 0, false
+	}
+	return id, true
+}
+
+// forgeSessionVisibleTo enforces the per-user scoping rule. A session
+// without a created_by attribution (legacy rows, scripts) is treated as
+// owned by the daemon and only visible to its creator-of-record; the empty
+// string never matches a real session.
+func forgeSessionVisibleTo(row *state.ForgeSession, username string) bool {
+	if row == nil {
+		return false
+	}
+	if row.CreatedBy == "" {
+		// Backwards compatible: pre-attribution rows are visible to everyone.
+		return true
+	}
+	return row.CreatedBy == username
+}
+
+// isValidForgeSessionStatus returns true for the status values the
+// foundation bead understands. The state layer stores TEXT, so future beads
+// can extend this list without a schema migration.
+func isValidForgeSessionStatus(s string) bool {
+	switch s {
+	case state.ForgeSessionStatusDraft, state.ForgeSessionStatusArchived:
+		return true
+	}
+	return false
+}
+
+// autoTitleFromMessage takes the first line (or first ~80 chars) of a
+// message body and uses it as the session title. Whitespace at the edges
+// and trailing punctuation are trimmed so the sidebar stays tidy.
+func autoTitleFromMessage(msg string) string {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return ""
+	}
+	if idx := strings.IndexAny(msg, "\r\n"); idx >= 0 {
+		msg = msg[:idx]
+	}
+	const maxLen = 80
+	if len(msg) > maxLen {
+		// Trim at a UTF-8 boundary by cutting on rune boundaries.
+		runes := []rune(msg)
+		if len(runes) > maxLen {
+			runes = runes[:maxLen]
+			msg = string(runes) + "…"
+		}
+	}
+	return strings.TrimRight(msg, ".,;: ")
+}
+

--- a/internal/web/forge_sessions_test.go
+++ b/internal/web/forge_sessions_test.go
@@ -158,7 +158,9 @@ func TestForgeSessions_GetReturnsMessages(t *testing.T) {
 		t.Fatalf("get: %d", rec.Code)
 	}
 	var got struct {
-		Session  struct{ MessageCount int } `json:"session"`
+		Session struct {
+			MessageCount int `json:"message_count"`
+		} `json:"session"`
 		Messages []struct {
 			Content string `json:"content"`
 			Role    string `json:"role"`

--- a/internal/web/forge_sessions_test.go
+++ b/internal/web/forge_sessions_test.go
@@ -1,0 +1,325 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// forgeRequest issues an authenticated request with the X-Forge-Action
+// header set so it satisfies the CSRF middleware.
+func forgeRequest(t *testing.T, srv *Server, method, path, body, cookie string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != "" {
+		reader = bytes.NewReader([]byte(body))
+	}
+	var req *http.Request
+	if reader != nil {
+		req = httptest.NewRequest(method, path, reader)
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if method != http.MethodGet && method != http.MethodHead {
+		req.Header.Set("X-Forge-Action", "1")
+	}
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	}
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestForgeSessions_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestForgeSessions_CreateAndList(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	body := `{"title":"Refactor poller","initial_message":"Let's break up the poll loop."}`
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions", body, cookie)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		Session struct {
+			ID           int64  `json:"id"`
+			Title        string `json:"title"`
+			Status       string `json:"status"`
+			MessageCount int    `json:"message_count"`
+		} `json:"session"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if created.Session.ID == 0 {
+		t.Fatal("expected non-zero session id")
+	}
+	if created.Session.Title != "Refactor poller" {
+		t.Errorf("expected title preserved, got %q", created.Session.Title)
+	}
+	if created.Session.Status != "draft" {
+		t.Errorf("expected default status draft, got %q", created.Session.Status)
+	}
+	if created.Session.MessageCount != 1 {
+		t.Errorf("expected message_count=1, got %d", created.Session.MessageCount)
+	}
+	if created.Message.Role != "user" || created.Message.Content == "" {
+		t.Errorf("unexpected first message: %+v", created.Message)
+	}
+
+	// List should include the just-created session.
+	rec = forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions", "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: %d", rec.Code)
+	}
+	var list struct {
+		Sessions []struct {
+			ID           int64  `json:"id"`
+			Title        string `json:"title"`
+			MessageCount int    `json:"message_count"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("parse list: %v", err)
+	}
+	if len(list.Sessions) != 1 || list.Sessions[0].ID != created.Session.ID {
+		t.Fatalf("expected 1 session in list, got %+v", list)
+	}
+	if list.Sessions[0].MessageCount != 1 {
+		t.Errorf("expected message_count=1 in list, got %d", list.Sessions[0].MessageCount)
+	}
+}
+
+func TestForgeSessions_AutoTitleFromInitialMessage(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	body := `{"initial_message":"Refactor the entire poller please."}`
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions", body, cookie)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		Session struct {
+			Title string `json:"title"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(created.Session.Title), "refactor") {
+		t.Errorf("expected auto-title to derive from message, got %q", created.Session.Title)
+	}
+}
+
+func TestForgeSessions_GetReturnsMessages(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions",
+		`{"title":"chat","initial_message":"hello"}`, cookie)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: %d", rec.Code)
+	}
+	var created struct {
+		Session struct{ ID int64 } `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	// Append a second message.
+	rec = forgeRequest(t, srv, http.MethodPost,
+		"/api/forge/sessions/"+itoa(created.Session.ID)+"/messages",
+		`{"content":"second"}`, cookie)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("append: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = forgeRequest(t, srv, http.MethodGet,
+		"/api/forge/sessions/"+itoa(created.Session.ID), "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: %d", rec.Code)
+	}
+	var got struct {
+		Session  struct{ MessageCount int } `json:"session"`
+		Messages []struct {
+			Content string `json:"content"`
+			Role    string `json:"role"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got.Messages))
+	}
+	if got.Messages[0].Content != "hello" || got.Messages[1].Content != "second" {
+		t.Errorf("messages out of order: %+v", got.Messages)
+	}
+	if got.Session.MessageCount != 2 {
+		t.Errorf("expected message_count=2, got %d", got.Session.MessageCount)
+	}
+}
+
+func TestForgeSessions_AppendRejectsAssistantRole(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions",
+		`{"title":"chat"}`, cookie)
+	var created struct {
+		Session struct{ ID int64 } `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	rec = forgeRequest(t, srv, http.MethodPost,
+		"/api/forge/sessions/"+itoa(created.Session.ID)+"/messages",
+		`{"role":"assistant","content":"hi"}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for assistant role, got %d", rec.Code)
+	}
+}
+
+func TestForgeSessions_AppendRejectsEmptyContent(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions", `{"title":"x"}`, cookie)
+	var created struct {
+		Session struct{ ID int64 } `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	rec = forgeRequest(t, srv, http.MethodPost,
+		"/api/forge/sessions/"+itoa(created.Session.ID)+"/messages",
+		`{"content":"   "}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestForgeSessions_RenameAndArchive(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions", `{"title":"orig"}`, cookie)
+	var created struct {
+		Session struct {
+			ID    int64  `json:"id"`
+			Title string `json:"title"`
+		} `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	rec = forgeRequest(t, srv, http.MethodPatch,
+		"/api/forge/sessions/"+itoa(created.Session.ID),
+		`{"title":"renamed"}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rename: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var renamed struct {
+		Session struct {
+			Title  string `json:"title"`
+			Status string `json:"status"`
+		} `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &renamed)
+	if renamed.Session.Title != "renamed" {
+		t.Errorf("expected title=renamed, got %q", renamed.Session.Title)
+	}
+
+	rec = forgeRequest(t, srv, http.MethodPatch,
+		"/api/forge/sessions/"+itoa(created.Session.ID),
+		`{"status":"archived"}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("archive: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var archived struct {
+		Session struct{ Status string } `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &archived)
+	if archived.Session.Status != "archived" {
+		t.Errorf("expected status=archived, got %q", archived.Session.Status)
+	}
+
+	// Invalid status should be rejected.
+	rec = forgeRequest(t, srv, http.MethodPatch,
+		"/api/forge/sessions/"+itoa(created.Session.ID),
+		`{"status":"bogus"}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for bogus status, got %d", rec.Code)
+	}
+}
+
+func TestForgeSessions_Delete(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions",
+		`{"title":"doomed","initial_message":"hi"}`, cookie)
+	var created struct {
+		Session struct{ ID int64 } `json:"session"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	rec = forgeRequest(t, srv, http.MethodDelete,
+		"/api/forge/sessions/"+itoa(created.Session.ID), "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = forgeRequest(t, srv, http.MethodGet,
+		"/api/forge/sessions/"+itoa(created.Session.ID), "", cookie)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 after delete, got %d", rec.Code)
+	}
+}
+
+func TestForgeSessions_CSRFEnforced(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/forge/sessions",
+		bytes.NewReader([]byte(`{"title":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403 without X-Forge-Action header, got %d", rec.Code)
+	}
+}
+
+// itoa converts a positive int64 to its decimal string. We use a tiny
+// helper rather than strconv.Itoa to avoid importing strconv just for the
+// int64→string conversion in test URL building.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}

--- a/internal/web/frontend/src/App.tsx
+++ b/internal/web/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import HistoryPage from './pages/HistoryPage'
 import PRsPage from './pages/PRsPage'
 import CostsPage from './pages/CostsPage'
 import BeadDetailPage from './pages/BeadDetailPage'
+import ForgePage from './pages/ForgePage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { authenticated, loading } = useAuth()
@@ -78,6 +79,14 @@ export default function App() {
         element={
           <ProtectedRoute>
             <CostsPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/forge"
+        element={
+          <ProtectedRoute>
+            <ForgePage />
           </ProtectedRoute>
         }
       />

--- a/internal/web/frontend/src/api.ts
+++ b/internal/web/frontend/src/api.ts
@@ -364,6 +364,114 @@ export const actions = {
     apiPost(`/api/bead/${encodeURIComponent(beadID)}/note`, { anvil, note }),
 }
 
+// ForgeSession is one design conversation persisted on the server. The
+// foundation bead surfaces the metadata used by the sidebar; the message
+// list comes from the per-session GET endpoint.
+export interface ForgeSession {
+  id: number
+  title: string
+  status: string
+  anvil?: string
+  created_by?: string
+  created_at: string
+  updated_at: string
+  message_count: number
+}
+
+// ForgeMessage is one entry in a forge session conversation. The foundation
+// bead only writes "user" messages; later beads will add "assistant" once
+// claude is wired up.
+export interface ForgeMessage {
+  id: number
+  session_id: number
+  role: 'user' | 'assistant' | 'system'
+  content: string
+  created_at: string
+}
+
+export interface ForgeSessionsListResponse {
+  sessions: ForgeSession[]
+}
+
+export interface ForgeSessionDetailResponse {
+  session: ForgeSession
+  messages: ForgeMessage[]
+}
+
+// forgeSessions wraps the /api/forge/sessions endpoints. All mutating calls
+// route through apiPost / apiSend which set the X-Forge-Action header that
+// the daemon's CSRF middleware requires.
+export const forgeSessions = {
+  list: (signal?: AbortSignal) =>
+    apiGet<ForgeSessionsListResponse>('/api/forge/sessions', signal),
+  get: (id: number, signal?: AbortSignal) =>
+    apiGet<ForgeSessionDetailResponse>(
+      `/api/forge/sessions/${id}`,
+      signal,
+    ),
+  create: (input: { title?: string; anvil?: string; initial_message?: string }) =>
+    apiPost<{ session: ForgeSession; message?: ForgeMessage }>(
+      '/api/forge/sessions',
+      input,
+    ),
+  appendMessage: (id: number, content: string) =>
+    apiPost<{ session: ForgeSession; message: ForgeMessage }>(
+      `/api/forge/sessions/${id}/messages`,
+      { content },
+    ),
+  rename: (id: number, title: string) =>
+    apiSend<{ session: ForgeSession }>(
+      'PATCH',
+      `/api/forge/sessions/${id}`,
+      { title },
+    ),
+  setStatus: (id: number, status: string) =>
+    apiSend<{ session: ForgeSession }>(
+      'PATCH',
+      `/api/forge/sessions/${id}`,
+      { status },
+    ),
+  delete: (id: number) =>
+    apiSend<{ status: string }>('DELETE', `/api/forge/sessions/${id}`),
+}
+
+// apiSend is a generic helper for non-POST mutating verbs (PATCH, DELETE,
+// PUT). The CSRF middleware accepts any non-safe method as long as the
+// X-Forge-Action header is present. apiPost remains the friendlier name for
+// the common case.
+export async function apiSend<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const headers: Record<string, string> = { 'X-Forge-Action': '1' }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const res = await fetch(path, {
+    method,
+    credentials: 'include',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  if (res.status === 401) {
+    throw new ApiError(401, 'unauthorized')
+  }
+  const text = await res.text()
+  let parsed: unknown = null
+  if (text) {
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      parsed = null
+    }
+  }
+  if (!res.ok) {
+    const msg =
+      (parsed as { error?: string })?.error ?? `HTTP ${res.status}`
+    throw new ApiError(res.status, msg)
+  }
+  return (parsed ?? {}) as T
+}
+
 // PRActionKind enumerates the per-row actions exposed on the /prs tab. The
 // backend resolves the PR row from state.db using the numeric id, so the
 // frontend only sends the path — no body is required.

--- a/internal/web/frontend/src/components/AppHeader.tsx
+++ b/internal/web/frontend/src/components/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { Activity, Coins, FlaskConical, GitPullRequest, Hammer, History, LayoutDashboard, LogOut, Package } from 'lucide-react'
+import { Activity, Coins, FlaskConical, GitPullRequest, Hammer, History, LayoutDashboard, LogOut, Package, Sparkles } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 import { useAuth } from '../auth'
 
@@ -15,6 +15,7 @@ const navItems: NavItem[] = [
   { to: '/crucibles', label: 'Crucibles', icon: FlaskConical },
   { to: '/history', label: 'History', icon: History },
   { to: '/prs', label: 'PRs', icon: GitPullRequest },
+  { to: '/forge', label: 'Forge', icon: Sparkles },
   { to: '/costs', label: 'Costs', icon: Coins },
 ]
 

--- a/internal/web/frontend/src/pages/ForgePage.tsx
+++ b/internal/web/frontend/src/pages/ForgePage.tsx
@@ -1,0 +1,642 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Archive,
+  ArchiveRestore,
+  ArrowLeft,
+  Hammer,
+  MessageSquarePlus,
+  Pencil,
+  Plus,
+  Send,
+  Trash2,
+} from 'lucide-react'
+import { useApiPoll } from '../hooks/useApiPoll'
+import { useToast } from '../hooks/useToast'
+import {
+  ApiError,
+  forgeSessions,
+  type ForgeMessage,
+  type ForgeSession,
+  type StatusResponse,
+} from '../api'
+import AppHeader from '../components/AppHeader'
+import { relativeTime } from '../lib/format'
+
+const STATUS_POLL_INTERVAL_MS = 10_000
+
+// ForgePage is the Hearth 2.0 "Beads-Forge" page: an iterative, chat-style
+// surface for designing beads through conversation. The foundation bead
+// delivers persistence + draft input only — later beads add the claude
+// integration and the grilling/plan stages.
+export default function ForgePage() {
+  const status = useApiPoll<StatusResponse>('/api/status', STATUS_POLL_INTERVAL_MS)
+  const toast = useToast()
+
+  const [sessions, setSessions] = useState<ForgeSession[]>([])
+  const [activeId, setActiveId] = useState<number | null>(null)
+  const [messages, setMessages] = useState<ForgeMessage[]>([])
+  const [loadingSessions, setLoadingSessions] = useState(true)
+  const [loadingMessages, setLoadingMessages] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [composer, setComposer] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [renamingId, setRenamingId] = useState<number | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLTextAreaElement>(null)
+  const renameInputRef = useRef<HTMLInputElement>(null)
+
+  const handleApiError = useCallback(
+    (err: unknown, fallback: string) => {
+      const msg = err instanceof ApiError ? err.message : fallback
+      toast.push(msg, 'error')
+    },
+    [toast],
+  )
+
+  // Load the session list once on mount and refresh after mutations.
+  const refreshSessions = useCallback(async () => {
+    setLoadingSessions(true)
+    try {
+      const data = await forgeSessions.list()
+      setSessions(data.sessions ?? [])
+    } catch (err) {
+      handleApiError(err, 'Failed to load sessions')
+    } finally {
+      setLoadingSessions(false)
+    }
+  }, [handleApiError])
+
+  useEffect(() => {
+    void refreshSessions()
+  }, [refreshSessions])
+
+  // Load messages when the active session changes.
+  useEffect(() => {
+    if (activeId === null) {
+      setMessages([])
+      return
+    }
+    let cancelled = false
+    setLoadingMessages(true)
+    ;(async () => {
+      try {
+        const data = await forgeSessions.get(activeId)
+        if (cancelled) return
+        setMessages(data.messages ?? [])
+      } catch (err) {
+        if (cancelled) return
+        handleApiError(err, 'Failed to load messages')
+      } finally {
+        if (!cancelled) setLoadingMessages(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [activeId, handleApiError])
+
+  // Auto-scroll to the bottom when new messages arrive.
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  // Focus the rename input when entering rename mode.
+  useEffect(() => {
+    if (renamingId !== null) {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    }
+  }, [renamingId])
+
+  const activeSession = useMemo(
+    () => sessions.find((s) => s.id === activeId) ?? null,
+    [sessions, activeId],
+  )
+
+  const startNewSession = useCallback(async () => {
+    const text = draft.trim()
+    setBusy(true)
+    try {
+      const data = await forgeSessions.create({
+        initial_message: text || undefined,
+      })
+      setSessions((prev) => [data.session, ...prev])
+      setActiveId(data.session.id)
+      setDraft('')
+      if (data.message) {
+        setMessages([data.message])
+      } else {
+        setMessages([])
+      }
+      // Re-fetch the list so the message_count is fresh for sidebar items
+      // we already had in memory.
+      void refreshSessions()
+    } catch (err) {
+      handleApiError(err, 'Failed to start session')
+    } finally {
+      setBusy(false)
+    }
+  }, [draft, handleApiError, refreshSessions])
+
+  const sendMessage = useCallback(async () => {
+    if (activeId === null) return
+    const text = composer.trim()
+    if (!text) return
+    const optimistic: ForgeMessage = {
+      id: -Date.now(),
+      session_id: activeId,
+      role: 'user',
+      content: text,
+      created_at: new Date().toISOString(),
+    }
+    setComposer('')
+    setMessages((prev) => [...prev, optimistic])
+    setBusy(true)
+    try {
+      const data = await forgeSessions.appendMessage(activeId, text)
+      setMessages((prev) => prev.map((m) => (m.id === optimistic.id ? data.message : m)))
+      setSessions((prev) =>
+        prev.map((s) => (s.id === activeId ? data.session : s)),
+      )
+    } catch (err) {
+      // Roll back the optimistic insert and restore the draft.
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id))
+      setComposer(text)
+      handleApiError(err, 'Failed to send message')
+    } finally {
+      setBusy(false)
+      composerRef.current?.focus()
+    }
+  }, [activeId, composer, handleApiError])
+
+  const renameSession = useCallback(
+    async (id: number, title: string) => {
+      const trimmed = title.trim()
+      if (!trimmed) {
+        setRenamingId(null)
+        return
+      }
+      try {
+        const data = await forgeSessions.rename(id, trimmed)
+        setSessions((prev) => prev.map((s) => (s.id === id ? data.session : s)))
+        setRenamingId(null)
+      } catch (err) {
+        handleApiError(err, 'Failed to rename session')
+      }
+    },
+    [handleApiError],
+  )
+
+  const archiveSession = useCallback(
+    async (id: number, archive: boolean) => {
+      try {
+        const data = await forgeSessions.setStatus(id, archive ? 'archived' : 'draft')
+        setSessions((prev) => prev.map((s) => (s.id === id ? data.session : s)))
+        toast.push(archive ? 'Session archived' : 'Session restored', 'success')
+      } catch (err) {
+        handleApiError(err, 'Failed to update session')
+      }
+    },
+    [handleApiError, toast],
+  )
+
+  const deleteSession = useCallback(
+    async (id: number) => {
+      try {
+        await forgeSessions.delete(id)
+        setSessions((prev) => prev.filter((s) => s.id !== id))
+        if (activeId === id) {
+          setActiveId(null)
+          setMessages([])
+        }
+        toast.push('Session deleted', 'success')
+      } catch (err) {
+        handleApiError(err, 'Failed to delete session')
+      }
+    },
+    [activeId, handleApiError, toast],
+  )
+
+  return (
+    <div className="mx-auto flex min-h-full max-w-7xl flex-col gap-4 p-4 sm:p-6">
+      <AppHeader daemonOnline={status.data?.running} daemonLoading={status.loading} />
+
+      <div className="grid min-h-[36rem] grid-cols-1 gap-4 md:grid-cols-[18rem_minmax(0,1fr)]">
+        <SessionSidebar
+          sessions={sessions}
+          loading={loadingSessions}
+          activeId={activeId}
+          renamingId={renamingId}
+          renameValue={renameValue}
+          renameInputRef={renameInputRef}
+          onSelect={setActiveId}
+          onNew={() => {
+            setActiveId(null)
+            setDraft('')
+            composerRef.current?.focus()
+          }}
+          onStartRename={(s) => {
+            setRenamingId(s.id)
+            setRenameValue(s.title || '')
+          }}
+          onCancelRename={() => setRenamingId(null)}
+          onSubmitRename={renameSession}
+          onRenameValueChange={setRenameValue}
+          onArchive={archiveSession}
+          onDelete={deleteSession}
+        />
+
+        <main className="flex min-h-[36rem] flex-col rounded-xl border border-slate-800 bg-slate-900/60">
+          {activeSession ? (
+            <>
+              <header className="flex items-center gap-3 border-b border-slate-800 px-4 py-3">
+                <button
+                  type="button"
+                  onClick={() => setActiveId(null)}
+                  className="rounded-md p-1 text-slate-400 hover:bg-slate-800/60 hover:text-slate-200 md:hidden"
+                  aria-label="Back to sessions"
+                >
+                  <ArrowLeft size={16} />
+                </button>
+                <Hammer size={16} className="text-amber-400" aria-hidden />
+                <div className="min-w-0 flex-1">
+                  <h2 className="truncate text-sm font-semibold text-slate-100">
+                    {activeSession.title || 'Untitled session'}
+                  </h2>
+                  <p className="truncate text-xs text-slate-500">
+                    {activeSession.status} · updated {relativeTime(activeSession.updated_at)}
+                  </p>
+                </div>
+              </header>
+
+              <ConversationView
+                messages={messages}
+                loading={loadingMessages}
+                endRef={messagesEndRef}
+              />
+
+              <Composer
+                value={composer}
+                onChange={setComposer}
+                onSend={sendMessage}
+                disabled={busy}
+                placeholder="Reply… (no AI yet — your message is just persisted for now)"
+                inputRef={composerRef}
+              />
+            </>
+          ) : (
+            <NewSessionView
+              draft={draft}
+              onDraftChange={setDraft}
+              onStart={startNewSession}
+              busy={busy}
+              composerRef={composerRef}
+            />
+          )}
+        </main>
+      </div>
+
+      <footer className="text-center text-xs text-slate-500">
+        Beads-Forge · foundation bead — persistence only, AI integration arrives in the next bead.
+      </footer>
+    </div>
+  )
+}
+
+interface SessionSidebarProps {
+  sessions: ForgeSession[]
+  loading: boolean
+  activeId: number | null
+  renamingId: number | null
+  renameValue: string
+  renameInputRef: React.RefObject<HTMLInputElement | null>
+  onSelect: (id: number) => void
+  onNew: () => void
+  onStartRename: (s: ForgeSession) => void
+  onCancelRename: () => void
+  onSubmitRename: (id: number, title: string) => Promise<void>
+  onRenameValueChange: (v: string) => void
+  onArchive: (id: number, archive: boolean) => Promise<void>
+  onDelete: (id: number) => Promise<void>
+}
+
+function SessionSidebar({
+  sessions,
+  loading,
+  activeId,
+  renamingId,
+  renameValue,
+  renameInputRef,
+  onSelect,
+  onNew,
+  onStartRename,
+  onCancelRename,
+  onSubmitRename,
+  onRenameValueChange,
+  onArchive,
+  onDelete,
+}: SessionSidebarProps) {
+  return (
+    <aside className="flex max-h-[32rem] min-h-[20rem] flex-col rounded-xl border border-slate-800 bg-slate-900/60 md:max-h-none">
+      <header className="flex items-center justify-between gap-2 border-b border-slate-800 px-4 py-3">
+        <h2 className="text-sm font-semibold text-slate-200">Design sessions</h2>
+        <button
+          type="button"
+          onClick={onNew}
+          className="inline-flex items-center gap-1 rounded-md border border-amber-600/40 bg-amber-600/15 px-2 py-1 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-600/25"
+          aria-label="Start a new session"
+        >
+          <Plus size={12} aria-hidden />
+          New
+        </button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <p className="px-4 py-8 text-center text-sm text-slate-500">Loading…</p>
+        ) : sessions.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-slate-500">
+            No sessions yet — start one on the right.
+          </p>
+        ) : (
+          <ul className="divide-y divide-slate-800/60" data-testid="forge-sessions-list">
+            {sessions.map((s) => (
+              <li
+                key={s.id}
+                className={`group flex items-center gap-2 px-3 py-2 transition-colors ${
+                  s.id === activeId ? 'bg-slate-800/60' : 'hover:bg-slate-800/40'
+                }`}
+              >
+                {renamingId === s.id ? (
+                  <form
+                    className="flex flex-1 items-center gap-1"
+                    onSubmit={(e) => {
+                      e.preventDefault()
+                      void onSubmitRename(s.id, renameValue)
+                    }}
+                  >
+                    <input
+                      ref={renameInputRef}
+                      value={renameValue}
+                      onChange={(e) => onRenameValueChange(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') onCancelRename()
+                      }}
+                      className="flex-1 rounded border border-slate-600 bg-slate-800 px-2 py-1 text-xs text-slate-100 focus:border-amber-400 focus:outline-none"
+                      aria-label="Rename session"
+                    />
+                  </form>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onSelect(s.id)}
+                    className="flex min-w-0 flex-1 flex-col items-start text-left"
+                  >
+                    <span
+                      className={`truncate text-sm ${
+                        s.id === activeId ? 'text-slate-100' : 'text-slate-200'
+                      }`}
+                    >
+                      {s.title || 'Untitled session'}
+                    </span>
+                    <span className="truncate text-[11px] text-slate-500">
+                      {s.message_count} msg · {relativeTime(s.updated_at)}
+                      {s.status === 'archived' ? ' · archived' : ''}
+                    </span>
+                  </button>
+                )}
+
+                <SidebarRowActions
+                  session={s}
+                  isRenaming={renamingId === s.id}
+                  onStartRename={() => onStartRename(s)}
+                  onArchive={() => void onArchive(s.id, s.status !== 'archived')}
+                  onDelete={() => {
+                    if (
+                      window.confirm(
+                        `Delete "${s.title || 'Untitled session'}"? This cannot be undone.`,
+                      )
+                    ) {
+                      void onDelete(s.id)
+                    }
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+interface SidebarRowActionsProps {
+  session: ForgeSession
+  isRenaming: boolean
+  onStartRename: () => void
+  onArchive: () => void
+  onDelete: () => void
+}
+
+function SidebarRowActions({
+  session,
+  isRenaming,
+  onStartRename,
+  onArchive,
+  onDelete,
+}: SidebarRowActionsProps) {
+  if (isRenaming) return null
+  const archived = session.status === 'archived'
+  return (
+    <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+      <IconButton onClick={onStartRename} label="Rename">
+        <Pencil size={12} />
+      </IconButton>
+      <IconButton
+        onClick={onArchive}
+        label={archived ? 'Restore' : 'Archive'}
+      >
+        {archived ? <ArchiveRestore size={12} /> : <Archive size={12} />}
+      </IconButton>
+      <IconButton onClick={onDelete} label="Delete" tone="danger">
+        <Trash2 size={12} />
+      </IconButton>
+    </div>
+  )
+}
+
+interface IconButtonProps {
+  onClick: () => void
+  label: string
+  tone?: 'default' | 'danger'
+  children: React.ReactNode
+}
+
+function IconButton({ onClick, label, tone = 'default', children }: IconButtonProps) {
+  const toneClass =
+    tone === 'danger'
+      ? 'text-slate-500 hover:text-red-300 hover:bg-red-500/10'
+      : 'text-slate-500 hover:text-slate-200 hover:bg-slate-700/60'
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded p-1 ${toneClass}`}
+      aria-label={label}
+      title={label}
+    >
+      {children}
+    </button>
+  )
+}
+
+interface ConversationViewProps {
+  messages: ForgeMessage[]
+  loading: boolean
+  endRef: React.RefObject<HTMLDivElement | null>
+}
+
+function ConversationView({ messages, loading, endRef }: ConversationViewProps) {
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-4" data-testid="forge-conversation">
+      {loading && messages.length === 0 ? (
+        <p className="text-center text-sm text-slate-500">Loading messages…</p>
+      ) : messages.length === 0 ? (
+        <EmptyConversation />
+      ) : (
+        <ul className="space-y-3">
+          {messages.map((m) => (
+            <MessageBubble key={m.id} message={m} />
+          ))}
+        </ul>
+      )}
+      <div ref={endRef} />
+    </div>
+  )
+}
+
+function EmptyConversation() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-slate-500">
+      <MessageSquarePlus size={28} className="text-slate-600" aria-hidden />
+      <p>No messages yet — send the first one to get started.</p>
+    </div>
+  )
+}
+
+function MessageBubble({ message }: { message: ForgeMessage }) {
+  const isUser = message.role === 'user'
+  const isSystem = message.role === 'system'
+  const align = isUser ? 'items-end' : 'items-start'
+  const bubble = isUser
+    ? 'bg-amber-500/15 border-amber-500/30 text-amber-100'
+    : isSystem
+      ? 'bg-slate-800/40 border-slate-700 text-slate-400 italic'
+      : 'bg-slate-800/60 border-slate-700 text-slate-100'
+  return (
+    <li className={`flex flex-col ${align}`}>
+      <div
+        className={`max-w-[85%] rounded-lg border px-3 py-2 text-sm whitespace-pre-wrap break-words ${bubble}`}
+      >
+        {message.content}
+      </div>
+      <span className="mt-1 text-[10px] text-slate-500">
+        {message.role} · {relativeTime(message.created_at)}
+      </span>
+    </li>
+  )
+}
+
+interface ComposerProps {
+  value: string
+  onChange: (v: string) => void
+  onSend: () => void
+  disabled: boolean
+  placeholder?: string
+  inputRef: React.RefObject<HTMLTextAreaElement | null>
+}
+
+function Composer({ value, onChange, onSend, disabled, placeholder, inputRef }: ComposerProps) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      onSend()
+    }
+  }
+  return (
+    <div className="border-t border-slate-800 px-4 py-3">
+      <div className="flex items-end gap-2">
+        <textarea
+          ref={inputRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={2}
+          disabled={disabled}
+          placeholder={placeholder ?? 'Type a message…'}
+          className="flex-1 resize-none rounded-md border border-slate-700 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none disabled:opacity-60"
+          aria-label="Message input"
+        />
+        <button
+          type="button"
+          onClick={onSend}
+          disabled={disabled || value.trim().length === 0}
+          className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/20 px-3 py-2 text-sm font-medium text-amber-200 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Send size={14} aria-hidden />
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface NewSessionViewProps {
+  draft: string
+  onDraftChange: (v: string) => void
+  onStart: () => void
+  busy: boolean
+  composerRef: React.RefObject<HTMLTextAreaElement | null>
+}
+
+function NewSessionView({ draft, onDraftChange, onStart, busy, composerRef }: NewSessionViewProps) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      onStart()
+    }
+  }
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4 py-10 text-center">
+      <Hammer size={32} className="text-amber-400" aria-hidden />
+      <div>
+        <h2 className="text-lg font-semibold text-slate-100">Start a design session</h2>
+        <p className="mx-auto mt-1 max-w-md text-sm text-slate-400">
+          Describe a bead idea in your own words. Foundation bead: your input is just persisted
+          today — claude grilling and bead emission arrive in the next two beads.
+        </p>
+      </div>
+      <textarea
+        ref={composerRef}
+        value={draft}
+        onChange={(e) => onDraftChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        rows={5}
+        placeholder="What would you like to forge?"
+        className="w-full max-w-xl resize-none rounded-md border border-slate-700 bg-slate-950/40 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-amber-400 focus:outline-none"
+        aria-label="Draft input"
+      />
+      <button
+        type="button"
+        onClick={onStart}
+        disabled={busy}
+        className="inline-flex items-center gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/20 px-4 py-2 text-sm font-medium text-amber-200 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Plus size={14} aria-hidden />
+        {busy ? 'Starting…' : draft.trim() ? 'Start with this prompt' : 'Start empty session'}
+      </button>
+    </div>
+  )
+}

--- a/internal/web/frontend/src/pages/ForgePage.tsx
+++ b/internal/web/frontend/src/pages/ForgePage.tsx
@@ -102,6 +102,15 @@ export default function ForgePage() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
+  // Focus the draft textarea when switching to new-session mode. The effect
+  // runs after the render so NewSessionView is mounted and composerRef points
+  // at the draft input (not the old conversation textarea).
+  useEffect(() => {
+    if (activeId === null) {
+      composerRef.current?.focus()
+    }
+  }, [activeId])
+
   // Focus the rename input when entering rename mode.
   useEffect(() => {
     if (renamingId !== null) {
@@ -235,7 +244,6 @@ export default function ForgePage() {
           onNew={() => {
             setActiveId(null)
             setDraft('')
-            composerRef.current?.focus()
           }}
           onStartRename={(s) => {
             setRenamingId(s.id)

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -84,6 +84,16 @@ func (s *Server) routes() http.Handler {
 		r.Post("/prs/{id}/fix-comments", s.handlePRFixComments)
 		r.Post("/prs/{id}/fix-conflicts", s.handlePRFixConflicts)
 		r.Post("/prs/{id}/reset-counters", s.handlePRResetCounters)
+
+		// Beads-Forge sessions (Hearth 2.0). Foundation bead: persistence
+		// + draft input only — the AI integration and grilling stage land
+		// in follow-on beads. Sessions are scoped per-signed-in user.
+		r.Get("/forge/sessions", s.handleForgeSessionsList)
+		r.Post("/forge/sessions", s.handleForgeSessionsCreate)
+		r.Get("/forge/sessions/{id}", s.handleForgeSessionGet)
+		r.Patch("/forge/sessions/{id}", s.handleForgeSessionUpdate)
+		r.Delete("/forge/sessions/{id}", s.handleForgeSessionDelete)
+		r.Post("/forge/sessions/{id}/messages", s.handleForgeSessionAppend)
 	})
 
 	// Static UI fallback. The next bead replaces this with the embedded


### PR DESCRIPTION
## Changes

- **Beads-Forge page foundation** - Hearth 2.0 gains a new `/forge` route with a session sidebar, chat-style conversation view, and a free-text "new session" draft input. Sessions and messages are persisted in `state.db` via the new `forge_sessions` and `forge_session_messages` tables, and managed through the `/api/forge/sessions` REST endpoints. This is a foundation-only delivery — claude integration and bead emission arrive in follow-on beads. (Forge-qcqv)

## Original Issue (feature): Hearth 2.0: Beads-Forge page — UI skeleton, conversation persistence, draft input

First of three beads delivering a Hytte-Suggestions-style page in Hearth 2.0 for iteratively designing beads through conversation with claude. This bead delivers ONLY the foundation: a new /forge route (or /design — pick name during impl) with: a session list sidebar, a chat-style conversation view, a free-text 'new session' draft input, and the persistence layer. No claude integration yet (next bead handles that), no grilling yet (third bead). Scope is intentionally narrow so the layer can be reviewed in isolation.

---
Bead: Forge-qcqv | Branch: forge/Forge-qcqv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)