### PR TITLE
Backend: extend beadDetailResponse with deps + add /api/bead/{id}/deps endpoint (Forge-98z7)

### DIFF
--- a/changelog.d/Forge-98z7.md
+++ b/changelog.d/Forge-98z7.md
@@ -1,0 +1,2 @@
+category: Added
+- **Bead detail dependency lists** - `/api/bead/{id}` now returns `blocks` and `blocked_by` arrays sourced from `bd show <id> --json`, and a new `/api/bead/{id}/deps?depth=N` endpoint walks the dep graph (capped at depth 3) for the Hearth 2.0 modal/graph views. (Forge-98z7)

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -58,6 +58,7 @@ func (s *Server) routes() http.Handler {
 		r.Get("/costs", s.handleCosts)
 		r.Get("/prs/all", s.handlePRs)
 		r.Get("/bead/{bead_id}", s.handleBeadDetail)
+		r.Get("/bead/{bead_id}/deps", s.handleBeadDeps)
 
 		// Destructive admin actions (Hearth 2.0).
 		r.Post("/worker/{id}/kill", s.handleKillWorker)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -437,6 +437,12 @@ func TestBeadDetail_InvalidID(t *testing.T) {
 }
 
 func TestBeadDetail_ResponseShapeIsArrayNotNull(t *testing.T) {
+	// fetchBeadDeps shells out to `bd show` for every detail lookup;
+	// stubbing it keeps the test hermetic on systems where bd is not
+	// installed and avoids paying the 5 s subprocess timeout for an
+	// unknown bead.
+	stubBdShow(t, func(_ string) ([]byte, error) { return []byte("[]"), nil })
+
 	srv := newServerWithDefaults(t, nil)
 	cookie := loginAndGetCookie(t, srv)
 
@@ -452,7 +458,7 @@ func TestBeadDetail_ResponseShapeIsArrayNotNull(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	for _, field := range []string{"workers", "events", "prs"} {
+	for _, field := range []string{"workers", "events", "prs", "blocks", "blocked_by"} {
 		raw, ok := body[field]
 		if !ok {
 			t.Errorf("field %q missing from response", field)

--- a/internal/web/views.go
+++ b/internal/web/views.go
@@ -1,10 +1,12 @@
 package web
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -322,17 +324,208 @@ type beadDetailWorker struct {
 	PRNumber    int     `json:"pr_number,omitempty"`
 }
 
+// beadDetailDepRef is a lightweight reference to a related bead. It is used
+// both for the immediate Blocks/BlockedBy lists on beadDetailResponse and
+// for the recursive tree returned by /api/bead/{id}/deps. The nested
+// Blocks/BlockedBy fields are populated only when the dep walker recurses
+// past depth 1; at the leaves they are nil and serialise as omitted.
+type beadDetailDepRef struct {
+	BeadID    string             `json:"bead_id"`
+	Anvil     string             `json:"anvil,omitempty"`
+	Title     string             `json:"title"`
+	Status    string             `json:"status"`
+	Priority  int                `json:"priority"`
+	Blocks    []beadDetailDepRef `json:"blocks,omitempty"`
+	BlockedBy []beadDetailDepRef `json:"blocked_by,omitempty"`
+}
+
 // beadDetailResponse is the consolidated JSON shape for /api/bead/{id}.
 type beadDetailResponse struct {
-	BeadID  string             `json:"bead_id"`
-	Anvil   string             `json:"anvil,omitempty"`
-	Queue   *beadDetailQueue   `json:"queue,omitempty"`
-	Ingot   *ingot.Ingot       `json:"ingot,omitempty"`
-	Retry   *beadDetailRetry   `json:"retry,omitempty"`
-	Cost    *beadDetailCost    `json:"cost,omitempty"`
-	Workers []beadDetailWorker `json:"workers"`
-	Events  []beadDetailEvent  `json:"events"`
-	PRs     []beadDetailPR     `json:"prs"`
+	BeadID    string             `json:"bead_id"`
+	Anvil     string             `json:"anvil,omitempty"`
+	Queue     *beadDetailQueue   `json:"queue,omitempty"`
+	Ingot     *ingot.Ingot       `json:"ingot,omitempty"`
+	Retry     *beadDetailRetry   `json:"retry,omitempty"`
+	Cost      *beadDetailCost    `json:"cost,omitempty"`
+	Workers   []beadDetailWorker `json:"workers"`
+	Events    []beadDetailEvent  `json:"events"`
+	PRs       []beadDetailPR     `json:"prs"`
+	Blocks    []beadDetailDepRef `json:"blocks"`
+	BlockedBy []beadDetailDepRef `json:"blocked_by"`
+}
+
+// beadDepsResponse is the JSON shape returned by /api/bead/{id}/deps.
+type beadDepsResponse struct {
+	BeadID    string             `json:"bead_id"`
+	Depth     int                `json:"depth"`
+	Blocks    []beadDetailDepRef `json:"blocks"`
+	BlockedBy []beadDetailDepRef `json:"blocked_by"`
+}
+
+// bdShowEntry mirrors the subset of `bd show <id> --json` we care about.
+// The bd CLI returns a JSON array; each entry exposes outgoing edges as
+// `dependents` (beads blocked by this one) and incoming edges as
+// `dependencies` (beads this one is blocked by). The `dependency_type`
+// field on each edge entry distinguishes "blocks" relations from softer
+// links (e.g. "discovered-from", "related"); only "blocks" is surfaced
+// as Blocks/BlockedBy.
+type bdShowEntry struct {
+	ID             string        `json:"id"`
+	Title          string        `json:"title"`
+	Status         string        `json:"status"`
+	Priority       int           `json:"priority"`
+	DependencyType string        `json:"dependency_type"`
+	Dependencies   []bdShowEntry `json:"dependencies"`
+	Dependents     []bdShowEntry `json:"dependents"`
+}
+
+// isBlockingDep reports whether a dep edge counts as a "blocks" relation.
+// Edges without an explicit dependency_type (e.g. nested arrays in older
+// bd versions) are treated as "blocks" so we don't silently drop them.
+func isBlockingDep(e bdShowEntry) bool {
+	return e.DependencyType == "" || e.DependencyType == "blocks"
+}
+
+// bdShowJSON is the command runner used by the dep helpers to invoke
+// `bd show <id> --json`. The variable is package-level so tests can swap it
+// for a fake without spawning real subprocesses.
+var bdShowJSON = func(ctx context.Context, beadID string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "bd", "show", beadID, "--json")
+	return cmd.Output()
+}
+
+// maxDepDepth caps the recursion depth on /api/bead/{id}/deps. The modal's
+// nested view only needs a couple of levels; 3 is enough for that without
+// pathological fan-out on large graphs.
+const maxDepDepth = 3
+
+// fetchBeadShow runs `bd show <id> --json` and returns the first entry.
+// Empty output, unparseable output, or non-zero exit codes are all reported
+// as errors so callers can degrade to empty dep lists.
+func fetchBeadShow(ctx context.Context, beadID string) (*bdShowEntry, error) {
+	out, err := bdShowJSON(ctx, beadID)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, errors.New("bd show: empty output")
+	}
+	var entries []bdShowEntry
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, errors.New("bd show: no entries")
+	}
+	return &entries[0], nil
+}
+
+// anvilLookup resolves a bead ID to its anvil name. The default lookup uses
+// the queue cache, which is the only in-process source of bead→anvil
+// associations. When the bead is not cached (e.g. closed beads outside the
+// queue) the lookup returns "".
+type anvilLookup func(beadID string) string
+
+// newAnvilLookup builds a lookup backed by a single queue_cache scan so
+// callers can resolve many bead IDs without re-querying the DB. When the
+// cache cannot be loaded, the returned lookup always returns "".
+func newAnvilLookup(db *state.DB) anvilLookup {
+	cache := map[string]string{}
+	if db != nil {
+		if items, err := db.QueueCache(); err == nil {
+			for _, it := range items {
+				if _, ok := cache[it.BeadID]; ok {
+					continue
+				}
+				cache[it.BeadID] = it.Anvil
+			}
+		}
+	}
+	return func(beadID string) string { return cache[beadID] }
+}
+
+// fetchBeadDeps returns the immediate (depth=1) Blocks and BlockedBy lists
+// for the given bead. Errors yield empty slices so the bead detail handler
+// can degrade gracefully when bd is missing or returns unexpected output.
+func fetchBeadDeps(ctx context.Context, beadID string, lookup anvilLookup) (blocks, blockedBy []beadDetailDepRef) {
+	entry, err := fetchBeadShow(ctx, beadID)
+	if err != nil {
+		return []beadDetailDepRef{}, []beadDetailDepRef{}
+	}
+	blocks = make([]beadDetailDepRef, 0, len(entry.Dependents))
+	for _, d := range entry.Dependents {
+		if !isBlockingDep(d) {
+			continue
+		}
+		blocks = append(blocks, makeDepRef(d, lookup))
+	}
+	blockedBy = make([]beadDetailDepRef, 0, len(entry.Dependencies))
+	for _, d := range entry.Dependencies {
+		if !isBlockingDep(d) {
+			continue
+		}
+		blockedBy = append(blockedBy, makeDepRef(d, lookup))
+	}
+	return blocks, blockedBy
+}
+
+// makeDepRef projects a bd show entry into the web layer's dep ref shape.
+func makeDepRef(e bdShowEntry, lookup anvilLookup) beadDetailDepRef {
+	ref := beadDetailDepRef{
+		BeadID:   e.ID,
+		Title:    e.Title,
+		Status:   e.Status,
+		Priority: e.Priority,
+	}
+	if lookup != nil {
+		ref.Anvil = lookup(e.ID)
+	}
+	return ref
+}
+
+// walkBeadDeps recursively expands a bead's dep graph up to `depth` levels
+// in each direction. The `visited` map both detects cycles and prevents
+// double-walking diamond-shaped graphs (where a bead is reachable through
+// multiple paths). When a bead is encountered that has already been
+// walked, its ref is included but its own Blocks/BlockedBy children are
+// elided so the response stays a tree rather than a DAG.
+func walkBeadDeps(ctx context.Context, beadID string, depth int, lookup anvilLookup, visited map[string]bool) (blocks, blockedBy []beadDetailDepRef) {
+	if depth <= 0 {
+		return nil, nil
+	}
+	entry, err := fetchBeadShow(ctx, beadID)
+	if err != nil {
+		return []beadDetailDepRef{}, []beadDetailDepRef{}
+	}
+	blocks = make([]beadDetailDepRef, 0, len(entry.Dependents))
+	for _, d := range entry.Dependents {
+		if !isBlockingDep(d) {
+			continue
+		}
+		ref := makeDepRef(d, lookup)
+		if !visited[d.ID] {
+			visited[d.ID] = true
+			if depth-1 > 0 {
+				ref.Blocks, ref.BlockedBy = walkBeadDeps(ctx, d.ID, depth-1, lookup, visited)
+			}
+		}
+		blocks = append(blocks, ref)
+	}
+	blockedBy = make([]beadDetailDepRef, 0, len(entry.Dependencies))
+	for _, d := range entry.Dependencies {
+		if !isBlockingDep(d) {
+			continue
+		}
+		ref := makeDepRef(d, lookup)
+		if !visited[d.ID] {
+			visited[d.ID] = true
+			if depth-1 > 0 {
+				ref.Blocks, ref.BlockedBy = walkBeadDeps(ctx, d.ID, depth-1, lookup, visited)
+			}
+		}
+		blockedBy = append(blockedBy, ref)
+	}
+	return blocks, blockedBy
 }
 
 // handleBeadDetail returns a consolidated view of one bead used by the
@@ -348,11 +541,13 @@ func (s *Server) handleBeadDetail(w http.ResponseWriter, r *http.Request) {
 	anvilHint := strings.TrimSpace(r.URL.Query().Get("anvil"))
 
 	resp := beadDetailResponse{
-		BeadID:  beadID,
-		Anvil:   anvilHint,
-		Workers: []beadDetailWorker{},
-		Events:  []beadDetailEvent{},
-		PRs:     []beadDetailPR{},
+		BeadID:    beadID,
+		Anvil:     anvilHint,
+		Workers:   []beadDetailWorker{},
+		Events:    []beadDetailEvent{},
+		PRs:       []beadDetailPR{},
+		Blocks:    []beadDetailDepRef{},
+		BlockedBy: []beadDetailDepRef{},
 	}
 
 	// Queue cache lookup. The DB only exposes a list helper, so we filter in
@@ -485,7 +680,59 @@ func (s *Server) handleBeadDetail(w http.ResponseWriter, r *http.Request) {
 	prs := collectBeadPRs(s.db, beadID, resp.Anvil)
 	resp.PRs = prs
 
+	// Dependency lists. `bd show <id> --json` is the source of truth for
+	// the bead graph and handles cross-anvil deps gracefully. Failures
+	// fall back to empty slices so the response shape stays stable.
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	resp.Blocks, resp.BlockedBy = fetchBeadDeps(ctx, beadID, newAnvilLookup(s.db))
+
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleBeadDeps walks the dependency graph for the given bead and returns
+// a tree shape that the modal/graph views in the SPA consume. The depth
+// query parameter defaults to 1 and is clamped to [1, maxDepDepth].
+func (s *Server) handleBeadDeps(w http.ResponseWriter, r *http.Request) {
+	beadID := chi.URLParam(r, "bead_id")
+	if !isValidBeadID(beadID) {
+		writeError(w, http.StatusBadRequest, "invalid bead id")
+		return
+	}
+	depth := 1
+	if raw := r.URL.Query().Get("depth"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "depth must be an integer")
+			return
+		}
+		if n < 1 {
+			n = 1
+		} else if n > maxDepDepth {
+			n = maxDepDepth
+		}
+		depth = n
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	// Seed the visited set with the root bead so it cannot reappear as a
+	// child of itself (e.g. a corrupt or pathological dep graph).
+	visited := map[string]bool{beadID: true}
+	blocks, blockedBy := walkBeadDeps(ctx, beadID, depth, newAnvilLookup(s.db), visited)
+	if blocks == nil {
+		blocks = []beadDetailDepRef{}
+	}
+	if blockedBy == nil {
+		blockedBy = []beadDetailDepRef{}
+	}
+	writeJSON(w, http.StatusOK, beadDepsResponse{
+		BeadID:    beadID,
+		Depth:     depth,
+		Blocks:    blocks,
+		BlockedBy: blockedBy,
+	})
 }
 
 // getBeadCost returns the cumulative bead_costs row for (beadID, anvil), or

--- a/internal/web/views.go
+++ b/internal/web/views.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Robin831/Forge/internal/cost"
+	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/ingot"
 	"github.com/Robin831/Forge/internal/ipc"
 	"github.com/Robin831/Forge/internal/state"
@@ -388,9 +389,14 @@ func isBlockingDep(e bdShowEntry) bool {
 
 // bdShowJSON is the command runner used by the dep helpers to invoke
 // `bd show <id> --json`. The variable is package-level so tests can swap it
-// for a fake without spawning real subprocesses.
-var bdShowJSON = func(ctx context.Context, beadID string) ([]byte, error) {
+// for a fake without spawning real subprocesses. The dir parameter is the
+// anvil's on-disk path; passing a non-empty value sets cmd.Dir so bd can
+// locate the Dolt database.
+var bdShowJSON = func(ctx context.Context, dir, beadID string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "bd", "show", beadID, "--json")
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	return cmd.Output()
 }
 
@@ -401,23 +407,28 @@ const maxDepDepth = 3
 
 // fetchBeadShow runs `bd show <id> --json` and returns the first entry.
 // Empty output, unparseable output, or non-zero exit codes are all reported
-// as errors so callers can degrade to empty dep lists.
-func fetchBeadShow(ctx context.Context, beadID string) (*bdShowEntry, error) {
-	out, err := bdShowJSON(ctx, beadID)
+// as errors so callers can degrade to empty dep lists. Both the array form
+// ([{...}]) and bare object form ({...}) are accepted, and leading/trailing
+// diagnostic noise from bd is tolerated via executil.DecodeJSON.
+func fetchBeadShow(ctx context.Context, dir, beadID string) (*bdShowEntry, error) {
+	out, err := bdShowJSON(ctx, dir, beadID)
 	if err != nil {
 		return nil, err
 	}
 	if len(out) == 0 {
 		return nil, errors.New("bd show: empty output")
 	}
+	// Try array form first (most bd versions wrap output in []).
 	var entries []bdShowEntry
-	if err := json.Unmarshal(out, &entries); err != nil {
-		return nil, err
+	if executil.DecodeJSON(out, &entries) == nil && len(entries) > 0 {
+		return &entries[0], nil
 	}
-	if len(entries) == 0 {
-		return nil, errors.New("bd show: no entries")
+	// Fall back to bare object form.
+	var single bdShowEntry
+	if executil.DecodeJSON(out, &single) == nil && single.ID != "" {
+		return &single, nil
 	}
-	return &entries[0], nil
+	return nil, errors.New("bd show: no entries")
 }
 
 // anvilLookup resolves a bead ID to its anvil name. The default lookup uses
@@ -428,13 +439,22 @@ type anvilLookup func(beadID string) string
 
 // newAnvilLookup builds a lookup backed by a single queue_cache scan so
 // callers can resolve many bead IDs without re-querying the DB. When the
-// cache cannot be loaded, the returned lookup always returns "".
+// cache cannot be loaded, the returned lookup always returns "". When a bead
+// ID appears in more than one anvil the lookup returns "" to avoid
+// non-deterministically attaching the wrong anvil to a dep ref.
 func newAnvilLookup(db *state.DB) anvilLookup {
 	cache := map[string]string{}
+	ambiguous := map[string]bool{}
 	if db != nil {
 		if items, err := db.QueueCache(); err == nil {
 			for _, it := range items {
+				if ambiguous[it.BeadID] {
+					continue
+				}
 				if _, ok := cache[it.BeadID]; ok {
+					// Bead exists in multiple anvils — omit rather than guess.
+					delete(cache, it.BeadID)
+					ambiguous[it.BeadID] = true
 					continue
 				}
 				cache[it.BeadID] = it.Anvil
@@ -445,10 +465,11 @@ func newAnvilLookup(db *state.DB) anvilLookup {
 }
 
 // fetchBeadDeps returns the immediate (depth=1) Blocks and BlockedBy lists
-// for the given bead. Errors yield empty slices so the bead detail handler
-// can degrade gracefully when bd is missing or returns unexpected output.
-func fetchBeadDeps(ctx context.Context, beadID string, lookup anvilLookup) (blocks, blockedBy []beadDetailDepRef) {
-	entry, err := fetchBeadShow(ctx, beadID)
+// for the given bead. dir is the anvil's on-disk path passed to bdShowJSON.
+// Errors yield empty slices so the bead detail handler can degrade gracefully
+// when bd is missing or returns unexpected output.
+func fetchBeadDeps(ctx context.Context, dir, beadID string, lookup anvilLookup) (blocks, blockedBy []beadDetailDepRef) {
+	entry, err := fetchBeadShow(ctx, dir, beadID)
 	if err != nil {
 		return []beadDetailDepRef{}, []beadDetailDepRef{}
 	}
@@ -484,16 +505,17 @@ func makeDepRef(e bdShowEntry, lookup anvilLookup) beadDetailDepRef {
 }
 
 // walkBeadDeps recursively expands a bead's dep graph up to `depth` levels
-// in each direction. The `visited` map both detects cycles and prevents
+// in each direction. dir is the anvil's on-disk path passed to bdShowJSON for
+// every fetch in the walk. The `visited` map both detects cycles and prevents
 // double-walking diamond-shaped graphs (where a bead is reachable through
 // multiple paths). When a bead is encountered that has already been
 // walked, its ref is included but its own Blocks/BlockedBy children are
 // elided so the response stays a tree rather than a DAG.
-func walkBeadDeps(ctx context.Context, beadID string, depth int, lookup anvilLookup, visited map[string]bool) (blocks, blockedBy []beadDetailDepRef) {
+func walkBeadDeps(ctx context.Context, dir, beadID string, depth int, lookup anvilLookup, visited map[string]bool) (blocks, blockedBy []beadDetailDepRef) {
 	if depth <= 0 {
 		return nil, nil
 	}
-	entry, err := fetchBeadShow(ctx, beadID)
+	entry, err := fetchBeadShow(ctx, dir, beadID)
 	if err != nil {
 		return []beadDetailDepRef{}, []beadDetailDepRef{}
 	}
@@ -506,7 +528,7 @@ func walkBeadDeps(ctx context.Context, beadID string, depth int, lookup anvilLoo
 		if !visited[d.ID] {
 			visited[d.ID] = true
 			if depth-1 > 0 {
-				ref.Blocks, ref.BlockedBy = walkBeadDeps(ctx, d.ID, depth-1, lookup, visited)
+				ref.Blocks, ref.BlockedBy = walkBeadDeps(ctx, dir, d.ID, depth-1, lookup, visited)
 			}
 		}
 		blocks = append(blocks, ref)
@@ -520,12 +542,22 @@ func walkBeadDeps(ctx context.Context, beadID string, depth int, lookup anvilLoo
 		if !visited[d.ID] {
 			visited[d.ID] = true
 			if depth-1 > 0 {
-				ref.Blocks, ref.BlockedBy = walkBeadDeps(ctx, d.ID, depth-1, lookup, visited)
+				ref.Blocks, ref.BlockedBy = walkBeadDeps(ctx, dir, d.ID, depth-1, lookup, visited)
 			}
 		}
 		blockedBy = append(blockedBy, ref)
 	}
 	return blocks, blockedBy
+}
+
+// resolveAnvilPath maps an anvil name to its on-disk path using the live
+// registry. Returns "" when the name is empty, the registry is not
+// configured, or the name is not registered.
+func (s *Server) resolveAnvilPath(name string) string {
+	if name == "" || s.anvils == nil {
+		return ""
+	}
+	return s.anvils()[name]
 }
 
 // handleBeadDetail returns a consolidated view of one bead used by the
@@ -685,7 +717,7 @@ func (s *Server) handleBeadDetail(w http.ResponseWriter, r *http.Request) {
 	// fall back to empty slices so the response shape stays stable.
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
-	resp.Blocks, resp.BlockedBy = fetchBeadDeps(ctx, beadID, newAnvilLookup(s.db))
+	resp.Blocks, resp.BlockedBy = fetchBeadDeps(ctx, s.resolveAnvilPath(resp.Anvil), beadID, newAnvilLookup(s.db))
 
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -719,8 +751,9 @@ func (s *Server) handleBeadDeps(w http.ResponseWriter, r *http.Request) {
 
 	// Seed the visited set with the root bead so it cannot reappear as a
 	// child of itself (e.g. a corrupt or pathological dep graph).
+	lookup := newAnvilLookup(s.db)
 	visited := map[string]bool{beadID: true}
-	blocks, blockedBy := walkBeadDeps(ctx, beadID, depth, newAnvilLookup(s.db), visited)
+	blocks, blockedBy := walkBeadDeps(ctx, s.resolveAnvilPath(lookup(beadID)), beadID, depth, lookup, visited)
 	if blocks == nil {
 		blocks = []beadDetailDepRef{}
 	}

--- a/internal/web/views_test.go
+++ b/internal/web/views_test.go
@@ -7,21 +7,31 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
 
+// bdShowMu serializes bdShowJSON swaps so that parallel tests cannot race
+// on the package-level variable. Each test that calls stubBdShow holds the
+// lock for its entire lifetime; only one such test can run at a time.
+var bdShowMu sync.Mutex
+
 // stubBdShow installs a temporary bdShowJSON implementation for the test.
-// The returned cleanup restores the original — t.Cleanup() invokes it
-// automatically so tests cannot leak state into each other even when they
-// run with t.Parallel().
+// bdShowMu is locked until t.Cleanup runs, serializing parallel tests that
+// use the global. The fn callback receives only the bead ID; the dir
+// parameter is ignored because tests use fixed in-memory fixtures.
 func stubBdShow(t *testing.T, fn func(beadID string) ([]byte, error)) {
 	t.Helper()
+	bdShowMu.Lock()
 	prev := bdShowJSON
-	bdShowJSON = func(_ context.Context, beadID string) ([]byte, error) {
+	bdShowJSON = func(_ context.Context, _ string, beadID string) ([]byte, error) {
 		return fn(beadID)
 	}
-	t.Cleanup(func() { bdShowJSON = prev })
+	t.Cleanup(func() {
+		bdShowJSON = prev
+		bdShowMu.Unlock()
+	})
 }
 
 // bdShowFixture builds a canned `bd show` JSON envelope for one bead and
@@ -61,7 +71,7 @@ func TestFetchBeadDeps_PopulatesBothDirections(t *testing.T) {
 		), nil
 	})
 
-	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-root", nil)
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "", "Forge-root", nil)
 	if len(blocks) != 1 || blocks[0].BeadID != "Forge-child" {
 		t.Fatalf("expected one blocks entry pointing at Forge-child, got %+v", blocks)
 	}
@@ -81,7 +91,7 @@ func TestFetchBeadDeps_IsolatedBead(t *testing.T) {
 		return bdShowFixture("Forge-lonely", "Lonely", "open", 3, nil, nil), nil
 	})
 
-	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-lonely", nil)
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "", "Forge-lonely", nil)
 	if blocks == nil || blockedBy == nil {
 		t.Fatalf("expected non-nil slices, got blocks=%v blockedBy=%v", blocks, blockedBy)
 	}
@@ -95,7 +105,7 @@ func TestFetchBeadDeps_BdErrorReturnsEmpty(t *testing.T) {
 		return nil, errors.New("bd missing")
 	})
 
-	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-err", nil)
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "", "Forge-err", nil)
 	if blocks == nil || blockedBy == nil {
 		t.Fatalf("expected non-nil slices on error, got nil")
 	}
@@ -436,7 +446,7 @@ func TestFetchBeadDeps_FiltersNonBlockingEdges(t *testing.T) {
 		return raw, nil
 	})
 
-	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-mixed", nil)
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "", "Forge-mixed", nil)
 	if len(blocks) != 1 || blocks[0].BeadID != "Forge-blocked-by-me" {
 		t.Errorf("blocks should contain only the blocking downstream, got %+v", blocks)
 	}

--- a/internal/web/views_test.go
+++ b/internal/web/views_test.go
@@ -1,0 +1,456 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// stubBdShow installs a temporary bdShowJSON implementation for the test.
+// The returned cleanup restores the original — t.Cleanup() invokes it
+// automatically so tests cannot leak state into each other even when they
+// run with t.Parallel().
+func stubBdShow(t *testing.T, fn func(beadID string) ([]byte, error)) {
+	t.Helper()
+	prev := bdShowJSON
+	bdShowJSON = func(_ context.Context, beadID string) ([]byte, error) {
+		return fn(beadID)
+	}
+	t.Cleanup(func() { bdShowJSON = prev })
+}
+
+// bdShowFixture builds a canned `bd show` JSON envelope for one bead and
+// optionally its outgoing/incoming dep entries. It is the test equivalent
+// of running `bd show <id> --json` against a Dolt database.
+func bdShowFixture(id, title, status string, priority int, dependents, dependencies []map[string]any) []byte {
+	entry := map[string]any{
+		"id":           id,
+		"title":        title,
+		"status":       status,
+		"priority":     priority,
+		"dependents":   dependents,
+		"dependencies": dependencies,
+	}
+	raw, _ := json.Marshal([]any{entry})
+	return raw
+}
+
+func depEntry(id, title, status string, priority int) map[string]any {
+	return map[string]any{
+		"id":              id,
+		"title":           title,
+		"status":          status,
+		"priority":        priority,
+		"dependency_type": "blocks",
+	}
+}
+
+func TestFetchBeadDeps_PopulatesBothDirections(t *testing.T) {
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		if beadID != "Forge-root" {
+			t.Errorf("unexpected bead id: %s", beadID)
+		}
+		return bdShowFixture("Forge-root", "Root", "in_progress", 2,
+			[]map[string]any{depEntry("Forge-child", "Child", "open", 3)},
+			[]map[string]any{depEntry("Forge-parent", "Parent", "closed", 1)},
+		), nil
+	})
+
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-root", nil)
+	if len(blocks) != 1 || blocks[0].BeadID != "Forge-child" {
+		t.Fatalf("expected one blocks entry pointing at Forge-child, got %+v", blocks)
+	}
+	if blocks[0].Title != "Child" || blocks[0].Status != "open" || blocks[0].Priority != 3 {
+		t.Errorf("blocks ref fields wrong: %+v", blocks[0])
+	}
+	if len(blockedBy) != 1 || blockedBy[0].BeadID != "Forge-parent" {
+		t.Fatalf("expected one blocked_by entry pointing at Forge-parent, got %+v", blockedBy)
+	}
+	if blockedBy[0].Status != "closed" || blockedBy[0].Priority != 1 {
+		t.Errorf("blocked_by ref fields wrong: %+v", blockedBy[0])
+	}
+}
+
+func TestFetchBeadDeps_IsolatedBead(t *testing.T) {
+	stubBdShow(t, func(_ string) ([]byte, error) {
+		return bdShowFixture("Forge-lonely", "Lonely", "open", 3, nil, nil), nil
+	})
+
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-lonely", nil)
+	if blocks == nil || blockedBy == nil {
+		t.Fatalf("expected non-nil slices, got blocks=%v blockedBy=%v", blocks, blockedBy)
+	}
+	if len(blocks) != 0 || len(blockedBy) != 0 {
+		t.Errorf("expected empty deps, got blocks=%+v blockedBy=%+v", blocks, blockedBy)
+	}
+}
+
+func TestFetchBeadDeps_BdErrorReturnsEmpty(t *testing.T) {
+	stubBdShow(t, func(_ string) ([]byte, error) {
+		return nil, errors.New("bd missing")
+	})
+
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-err", nil)
+	if blocks == nil || blockedBy == nil {
+		t.Fatalf("expected non-nil slices on error, got nil")
+	}
+	if len(blocks) != 0 || len(blockedBy) != 0 {
+		t.Errorf("expected empty deps on bd error, got blocks=%+v blockedBy=%+v", blocks, blockedBy)
+	}
+}
+
+func TestBeadDetail_IncludesDeps(t *testing.T) {
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		if beadID != "Forge-graph" {
+			return bdShowFixture(beadID, beadID, "open", 3, nil, nil), nil
+		}
+		return bdShowFixture("Forge-graph", "Graph root", "in_progress", 2,
+			[]map[string]any{depEntry("Forge-down", "Downstream", "open", 3)},
+			[]map[string]any{depEntry("Forge-up", "Upstream", "closed", 1)},
+		), nil
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-graph", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got struct {
+		Blocks    []beadDetailDepRef `json:"blocks"`
+		BlockedBy []beadDetailDepRef `json:"blocked_by"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Blocks) != 1 || got.Blocks[0].BeadID != "Forge-down" {
+		t.Errorf("blocks: %+v", got.Blocks)
+	}
+	if len(got.BlockedBy) != 1 || got.BlockedBy[0].BeadID != "Forge-up" {
+		t.Errorf("blocked_by: %+v", got.BlockedBy)
+	}
+}
+
+func TestBeadDetail_IsolatedBeadEmptyDeps(t *testing.T) {
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		return bdShowFixture(beadID, "Solo", "open", 3, nil, nil), nil
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-solo", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Parse as raw map so we can distinguish null from [].
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, field := range []string{"blocks", "blocked_by"} {
+		v, ok := raw[field]
+		if !ok {
+			t.Errorf("field %q missing", field)
+			continue
+		}
+		if string(v) == "null" {
+			t.Errorf("field %q is null; want []", field)
+		}
+		if !strings.HasPrefix(string(v), "[") {
+			t.Errorf("field %q is not an array: %s", field, string(v))
+		}
+	}
+}
+
+func TestDepsEndpoint_BasicTree(t *testing.T) {
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		switch beadID {
+		case "Forge-root":
+			return bdShowFixture("Forge-root", "Root", "in_progress", 2,
+				[]map[string]any{depEntry("Forge-leaf-b", "Leaf B", "open", 3)},
+				[]map[string]any{depEntry("Forge-leaf-a", "Leaf A", "closed", 1)},
+			), nil
+		case "Forge-leaf-a", "Forge-leaf-b":
+			return bdShowFixture(beadID, beadID, "open", 3, nil, nil), nil
+		}
+		return nil, errors.New("unexpected bead: " + beadID)
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-root/deps?depth=2", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got beadDepsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.BeadID != "Forge-root" {
+		t.Errorf("bead_id: got %q", got.BeadID)
+	}
+	if got.Depth != 2 {
+		t.Errorf("depth: got %d, want 2", got.Depth)
+	}
+	if len(got.Blocks) != 1 || got.Blocks[0].BeadID != "Forge-leaf-b" {
+		t.Fatalf("blocks: %+v", got.Blocks)
+	}
+	if len(got.BlockedBy) != 1 || got.BlockedBy[0].BeadID != "Forge-leaf-a" {
+		t.Fatalf("blocked_by: %+v", got.BlockedBy)
+	}
+	// Depth 2 walks one level past the immediate children, so the leaf's
+	// own deps must have been evaluated (and found empty). The nested
+	// fields use omitempty, so an empty result serialises as omitted —
+	// either way len() must be 0.
+	if len(got.Blocks[0].Blocks) != 0 || len(got.Blocks[0].BlockedBy) != 0 {
+		t.Errorf("expected empty nested lists on leaf node, got %+v", got.Blocks[0])
+	}
+}
+
+func TestDepsEndpoint_RespectsDepthCap(t *testing.T) {
+	// Build a 5-deep linear chain so we can confirm depth=5 is clamped to
+	// maxDepDepth (3) and stops walking past that.
+	chain := []string{"Forge-1", "Forge-2", "Forge-3", "Forge-4", "Forge-5", "Forge-6"}
+	var calls int32
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		for i, id := range chain {
+			if id == beadID {
+				if i+1 >= len(chain) {
+					return bdShowFixture(id, id, "open", 3, nil, nil), nil
+				}
+				next := chain[i+1]
+				return bdShowFixture(id, id, "open", 3,
+					[]map[string]any{depEntry(next, next, "open", 3)},
+					nil,
+				), nil
+			}
+		}
+		return bdShowFixture(beadID, beadID, "open", 3, nil, nil), nil
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-1/deps?depth=5", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got beadDepsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Depth != maxDepDepth {
+		t.Errorf("expected depth clamped to %d, got %d", maxDepDepth, got.Depth)
+	}
+	// Walking 3 levels from Forge-1 should reach Forge-2 → Forge-3 →
+	// Forge-4, but stop short of Forge-5.
+	level1 := got.Blocks
+	if len(level1) != 1 || level1[0].BeadID != "Forge-2" {
+		t.Fatalf("level 1: %+v", level1)
+	}
+	level2 := level1[0].Blocks
+	if len(level2) != 1 || level2[0].BeadID != "Forge-3" {
+		t.Fatalf("level 2: %+v", level2)
+	}
+	level3 := level2[0].Blocks
+	if len(level3) != 1 || level3[0].BeadID != "Forge-4" {
+		t.Fatalf("level 3: %+v", level3)
+	}
+	// Beyond depth 3 the recursion must stop — the level-3 child should
+	// have no further nested lists.
+	if len(level3[0].Blocks) != 0 || len(level3[0].BlockedBy) != 0 {
+		t.Errorf("depth cap violated: nested deps still populated at depth 4: %+v", level3[0])
+	}
+}
+
+func TestDepsEndpoint_HandlesCycles(t *testing.T) {
+	// Forge-a → Forge-b → Forge-a is the classic 2-node cycle. Without
+	// the visited dedup the walker would recurse indefinitely.
+	calls := map[string]int{}
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		calls[beadID]++
+		switch beadID {
+		case "Forge-a":
+			return bdShowFixture("Forge-a", "A", "open", 3,
+				[]map[string]any{depEntry("Forge-b", "B", "open", 3)},
+				nil,
+			), nil
+		case "Forge-b":
+			return bdShowFixture("Forge-b", "B", "open", 3,
+				[]map[string]any{depEntry("Forge-a", "A", "open", 3)},
+				nil,
+			), nil
+		}
+		return nil, errors.New("unexpected: " + beadID)
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-a/deps?depth=3", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	// The root bead is seeded in `visited`, so even though Forge-b points
+	// back at Forge-a the walker stops there. Forge-a itself should only
+	// be fetched once (for the root) and Forge-b only once (as a child).
+	if calls["Forge-a"] != 1 {
+		t.Errorf("Forge-a fetched %d times; want 1", calls["Forge-a"])
+	}
+	if calls["Forge-b"] != 1 {
+		t.Errorf("Forge-b fetched %d times; want 1", calls["Forge-b"])
+	}
+
+	var got beadDepsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Blocks) != 1 || got.Blocks[0].BeadID != "Forge-b" {
+		t.Fatalf("expected blocks=[Forge-b], got %+v", got.Blocks)
+	}
+	// Forge-b lists Forge-a as a dep, but the root was pre-marked as
+	// visited so its children must be elided.
+	subBlocks := got.Blocks[0].Blocks
+	if len(subBlocks) == 1 && subBlocks[0].BeadID == "Forge-a" {
+		// Including the ref is OK; what we must NOT do is recurse into
+		// it again, which would have happened if calls["Forge-a"] > 1.
+		if len(subBlocks[0].Blocks) != 0 {
+			t.Errorf("cycle expanded: %+v", subBlocks[0])
+		}
+	}
+}
+
+func TestDepsEndpoint_InvalidID(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/..%2Fetc%2Fpasswd/deps", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid id, got %d", rec.Code)
+	}
+}
+
+func TestDepsEndpoint_InvalidDepth(t *testing.T) {
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		return bdShowFixture(beadID, beadID, "open", 3, nil, nil), nil
+	})
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-x/deps?depth=notanumber", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-integer depth: expected 400, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/api/bead/Forge-x/deps?depth=0", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec = httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("depth=0 should clamp to 1, got %d", rec.Code)
+	}
+	var got beadDepsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Depth != 1 {
+		t.Errorf("depth=0 should clamp to 1, got %d", got.Depth)
+	}
+}
+
+func TestFetchBeadDeps_FiltersNonBlockingEdges(t *testing.T) {
+	// bd records several edge types (blocks, discovered-from, related, ...).
+	// Only "blocks" relations belong on the Blocks/BlockedBy lists.
+	stubBdShow(t, func(_ string) ([]byte, error) {
+		entry := map[string]any{
+			"id":       "Forge-mixed",
+			"title":    "Mixed",
+			"status":   "in_progress",
+			"priority": 2,
+			"dependents": []map[string]any{
+				{
+					"id":              "Forge-blocked-by-me",
+					"title":           "Real downstream",
+					"status":          "open",
+					"priority":        3,
+					"dependency_type": "blocks",
+				},
+				{
+					"id":              "Forge-spawned",
+					"title":           "Discovered-from sibling",
+					"status":          "open",
+					"priority":        3,
+					"dependency_type": "discovered-from",
+				},
+			},
+			"dependencies": []map[string]any{
+				{
+					"id":              "Forge-blocks-me",
+					"title":           "Real upstream",
+					"status":          "closed",
+					"priority":        1,
+					"dependency_type": "blocks",
+				},
+				{
+					"id":              "Forge-loose-link",
+					"title":           "Related, not blocking",
+					"status":          "open",
+					"priority":        3,
+					"dependency_type": "related",
+				},
+			},
+		}
+		raw, _ := json.Marshal([]any{entry})
+		return raw, nil
+	})
+
+	blocks, blockedBy := fetchBeadDeps(context.Background(), "Forge-mixed", nil)
+	if len(blocks) != 1 || blocks[0].BeadID != "Forge-blocked-by-me" {
+		t.Errorf("blocks should contain only the blocking downstream, got %+v", blocks)
+	}
+	if len(blockedBy) != 1 || blockedBy[0].BeadID != "Forge-blocks-me" {
+		t.Errorf("blocked_by should contain only the blocking upstream, got %+v", blockedBy)
+	}
+}
+
+func TestDepsEndpoint_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	req := httptest.NewRequest("GET", "/api/bead/Forge-x/deps", nil)
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Changes

- **Bead detail dependency lists** - `/api/bead/{id}` now returns `blocks` and `blocked_by` arrays sourced from `bd show <id> --json`, and a new `/api/bead/{id}/deps?depth=N` endpoint walks the dep graph (capped at depth 3) for the Hearth 2.0 modal/graph views. (Forge-98z7)

## Original Issue (task): Backend: extend beadDetailResponse with deps + add /api/bead/{id}/deps endpoint

Modify internal/web/views.go:326 to add `Blocks []beadDetailDepRef` and `BlockedBy []beadDetailDepRef` fields to beadDetailResponse, where beadDetailDepRef has bead_id, anvil, title, status, priority. Populate by shelling out to `bd show <id> --json` (option 1 — source of truth, handles cross-anvil). Inspect the JSON shape via `bd show --help` to confirm field names (likely `dependencies`/`dependents` or `blocks`/`blocked_by`). Add new HTTP handler `GET /api/bead/{id}/deps?depth=N` (cap N at 3) returning the same beadDetailDepRef shape walked recursively to depth N for the modal's nested view. Add unit tests in views_test.go asserting both fields populate for a bead with inbound+outbound deps and are empty for an isolated bead. This sub-task is the foundation — sub-tasks 2 and 3 consume these endpoints.

---
Bead: Forge-98z7 | Branch: forge/Forge-98z7
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)