### PR TITLE
Hearth 2.0: pipeline visual overview with bellows nested under PR (Forge-v7ij)

### DIFF
--- a/changelog.d/Forge-v7ij.md
+++ b/changelog.d/Forge-v7ij.md
@@ -1,0 +1,2 @@
+category: Added
+- **Hearth 2.0 pipeline overview bar** - Added a horizontal Schematic → Smith → Temper → Warden → PR → Merged pipeline bar above the Queue/Workers/LiveActivity columns with a per-stage count and one row per active in-flight bead. Bellows status is now nested under the PR stage (monitoring / ci-fix / review-fix / rebase) instead of appearing as a standalone Workers row, and the Workers pane shows dimmed Idle slots equal to the remaining global Smith capacity. The status API now exposes `max_total_smiths`. (Forge-v7ij)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3220,6 +3220,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			CopilotRequestLimit:    copilotLimit,
 			CopilotLimitReached:    copilotLimit > 0 && copilotReqs >= float64(copilotLimit),
 			AnvilLastPoll:          anvilLastPoll,
+			MaxTotalSmiths:         d.cfg.Load().Settings.MaxTotalSmiths,
 		}
 		data, _ := json.Marshal(payload)
 		return ipc.Response{Type: "status", Payload: data}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4240,6 +4240,69 @@ func TestHandleIPC_Workers(t *testing.T) {
 		assert.NotEmpty(t, got.StartedAt)
 		assert.Empty(t, got.CompletedAt)
 	})
+
+	t.Run("phase is populated for every pipeline stage", func(t *testing.T) {
+		// Clear out the row inserted by the previous subtest so we control
+		// the exact set of phases under assertion here.
+		_, err := db.Conn().Exec(`DELETE FROM workers`)
+		require.NoError(t, err)
+
+		phases := []string{"schematic", "smith", "temper", "warden", "bellows", "quench", "burnish", "rebase"}
+		started := time.Now().UTC().Truncate(time.Second)
+		for i, phase := range phases {
+			w := &state.Worker{
+				ID:        fmt.Sprintf("worker-phase-%d", i),
+				BeadID:    fmt.Sprintf("Forge-ph%02d", i),
+				Anvil:     "forge",
+				Status:    state.WorkerRunning,
+				Phase:     phase,
+				StartedAt: started,
+			}
+			require.NoError(t, db.InsertWorker(w))
+		}
+
+		resp := d.handleIPC(ipc.Command{Type: "workers"})
+		require.Equal(t, "ok", resp.Type)
+		var payload ipc.WorkersResponse
+		require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+		require.Len(t, payload.Workers, len(phases))
+
+		seen := map[string]bool{}
+		for _, w := range payload.Workers {
+			assert.NotEmpty(t, w.Phase, "worker %s missing phase", w.ID)
+			seen[w.Phase] = true
+		}
+		for _, phase := range phases {
+			assert.Truef(t, seen[phase], "expected to see phase %q in workers response", phase)
+		}
+	})
+}
+
+// TestHandleIPC_Status_MaxTotalSmiths verifies that the daemon's status
+// response exposes the configured concurrent-Smith cap so the Hearth 2.0
+// SPA can size the Workers pane's "Idle" placeholder slots.
+func TestHandleIPC_Status_MaxTotalSmiths(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-ipc-status-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := state.Open(filepath.Join(tmpDir, "state.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:        db,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		startTime: time.Now(),
+	}
+	d.cfg.Store(&config.Config{Settings: config.SettingsConfig{MaxTotalSmiths: 7}})
+
+	resp := d.handleIPC(ipc.Command{Type: "status"})
+	require.Equal(t, "status", resp.Type)
+
+	var payload ipc.StatusPayload
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	assert.Equal(t, 7, payload.MaxTotalSmiths)
 }
 
 // TestDaemon_RecordAnvilPoll verifies that the in-memory last-poll map is

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -100,6 +100,10 @@ type StatusPayload struct {
 	// persisted as events, so Hearth and `forge status` consume this field for
 	// fresh per-anvil timestamps instead of querying the events table.
 	AnvilLastPoll []AnvilPollItem `json:"anvil_last_poll,omitempty"`
+	// MaxTotalSmiths is the configured global cap on concurrent Smith workers.
+	// Hearth 2.0 uses this to size the "Idle" placeholder slots in the
+	// Workers pane (max_total_smiths - active_workers).
+	MaxTotalSmiths int `json:"max_total_smiths,omitempty"`
 }
 
 // AnvilPollItem reports the most recent poll outcome for a single anvil.

--- a/internal/web/frontend/src/api.ts
+++ b/internal/web/frontend/src/api.ts
@@ -74,6 +74,7 @@ export interface StatusResponse {
   copilot_premium_requests?: number
   copilot_request_limit?: number
   copilot_limit_reached?: boolean
+  max_total_smiths?: number
 }
 
 export interface CrucibleStatus {

--- a/internal/web/frontend/src/components/PipelineBar.tsx
+++ b/internal/web/frontend/src/components/PipelineBar.tsx
@@ -60,13 +60,13 @@ export function phaseToStage(phase: string | undefined): StageKey | null {
   }
 }
 
-// isBellowsMonitor reports whether the worker is the PR-monitor row that
-// bellows upserts for each open PR. We treat any worker with phase=bellows
-// AND no log_path AND a synthetic "bellows-<anvil>-<num>" id as the monitor,
-// while quench/burnish/rebase keep their own phase and remain regular
-// clickable rows.
+// isBellowsMonitor reports whether the worker is the synthetic PR-monitor row
+// that bellows upserts for each open PR. The synthetic row has a
+// "bellows-<anvil>-<num>" id prefix and no log_path. Pipeline workers that
+// temporarily enter phase=bellows are NOT synthetic monitors and must remain
+// visible as regular clickable rows.
 export function isBellowsMonitor(w: WorkerInfo): boolean {
-  return w.phase === 'bellows'
+  return w.phase === 'bellows' && !w.log_path && w.id.startsWith('bellows-')
 }
 
 // prSubLabel collapses any active bellows sub-state into a short caption
@@ -93,7 +93,12 @@ function bucket(workers: WorkerInfo[]): Map<StageKey, WorkerInfo[]> {
   const m = new Map<StageKey, WorkerInfo[]>()
   for (const s of STAGES) m.set(s, [])
   for (const w of workers) {
-    if (w.status !== 'pending' && w.status !== 'running' && w.status !== 'monitoring')
+    if (
+      w.status !== 'pending' &&
+      w.status !== 'running' &&
+      w.status !== 'monitoring' &&
+      w.status !== 'reviewing'
+    )
       continue
     const stage = phaseToStage(w.phase)
     if (!stage) continue
@@ -111,9 +116,13 @@ export default function PipelineBar({ workers }: PipelineBarProps) {
     const buckets = bucket(workers)
     return STAGES.map<StageInfo>((key) => {
       const list = buckets.get(key) ?? []
+      // Count unique beads (anvil+bead_id) rather than workers — a single bead
+      // can contribute multiple workers to the same stage (e.g. bellows monitor
+      // + quench), which would otherwise inflate the displayed count.
+      const uniqueBeads = new Set(list.map((w) => `${w.anvil}:${w.bead_id}`))
       return {
         key,
-        count: list.length,
+        count: uniqueBeads.size,
         workers: list,
         subLabel: key === 'pr' ? prSubLabel(list) : null,
       }
@@ -128,7 +137,12 @@ export default function PipelineBar({ workers }: PipelineBarProps) {
   const beadRows = useMemo(() => {
     const seen = new Map<string, { worker: WorkerInfo; stage: StageKey }>()
     for (const w of workers) {
-      if (w.status !== 'pending' && w.status !== 'running' && w.status !== 'monitoring')
+      if (
+        w.status !== 'pending' &&
+        w.status !== 'running' &&
+        w.status !== 'monitoring' &&
+        w.status !== 'reviewing'
+      )
         continue
       const stage = phaseToStage(w.phase)
       if (!stage) continue

--- a/internal/web/frontend/src/components/PipelineBar.tsx
+++ b/internal/web/frontend/src/components/PipelineBar.tsx
@@ -1,0 +1,275 @@
+import { useMemo } from 'react'
+import { ChevronRight } from 'lucide-react'
+import type { WorkerInfo } from '../api'
+
+// StageKey labels the six visible columns of the pipeline bar. The Bellows
+// PR-monitor is intentionally folded into the "pr" stage as a sub-label
+// rather than getting its own column — see the per-bead description.
+type StageKey = 'schematic' | 'smith' | 'temper' | 'warden' | 'pr' | 'merged'
+
+const STAGES: StageKey[] = ['schematic', 'smith', 'temper', 'warden', 'pr', 'merged']
+
+const STAGE_LABEL: Record<StageKey, string> = {
+  schematic: 'Schematic',
+  smith: 'Smith',
+  temper: 'Temper',
+  warden: 'Warden',
+  pr: 'PR',
+  merged: 'Merged',
+}
+
+// Stage accents mirror Hytte's Mezzanine PipelineBar palette so users moving
+// between the two dashboards get a consistent visual mapping. Each value is a
+// Tailwind class applied to the top border of the stage pill.
+const STAGE_ACCENT: Record<StageKey, string> = {
+  schematic: 'border-t-purple-500',
+  smith: 'border-t-orange-500',
+  temper: 'border-t-yellow-500',
+  warden: 'border-t-cyan-500',
+  pr: 'border-t-blue-500',
+  merged: 'border-t-green-500',
+}
+
+// phaseToStage projects a backend worker phase string onto one of the six
+// pipeline-bar stages. Bellows + its sub-workers (quench/burnish/rebase) all
+// land on "pr" because to the user they are one logical stage; we surface the
+// sub-state separately via prBellowsLabel.
+export function phaseToStage(phase: string | undefined): StageKey | null {
+  switch (phase) {
+    case 'schematic':
+      return 'schematic'
+    case 'smith':
+      return 'smith'
+    case 'temper':
+      return 'temper'
+    case 'warden':
+      return 'warden'
+    case 'bellows':
+    case 'quench':
+    case 'burnish':
+    case 'rebase':
+    case 'cifix':
+    case 'reviewfix':
+      return 'pr'
+    case 'merged':
+      return 'merged'
+    // crucible, smelter, schematic-fail and any unknown phase fall through
+    // and are not counted on the bar — they don't map cleanly to a stage.
+    default:
+      return null
+  }
+}
+
+// isBellowsMonitor reports whether the worker is the PR-monitor row that
+// bellows upserts for each open PR. We treat any worker with phase=bellows
+// AND no log_path AND a synthetic "bellows-<anvil>-<num>" id as the monitor,
+// while quench/burnish/rebase keep their own phase and remain regular
+// clickable rows.
+export function isBellowsMonitor(w: WorkerInfo): boolean {
+  return w.phase === 'bellows'
+}
+
+// prSubLabel collapses any active bellows sub-state into a short caption
+// shown under the PR pill. The order mirrors how a user would perceive
+// importance: rebase > ci-fix > review-fix > monitoring.
+function prSubLabel(prWorkers: WorkerInfo[]): string | null {
+  if (prWorkers.length === 0) return null
+  const hasPhase = (p: string) => prWorkers.some((w) => w.phase === p)
+  if (hasPhase('rebase')) return 'rebase'
+  if (hasPhase('quench') || hasPhase('cifix')) return 'ci-fix'
+  if (hasPhase('burnish') || hasPhase('reviewfix')) return 'review-fix'
+  if (hasPhase('bellows')) return 'monitoring'
+  return null
+}
+
+interface StageInfo {
+  key: StageKey
+  count: number
+  workers: WorkerInfo[]
+  subLabel: string | null
+}
+
+function bucket(workers: WorkerInfo[]): Map<StageKey, WorkerInfo[]> {
+  const m = new Map<StageKey, WorkerInfo[]>()
+  for (const s of STAGES) m.set(s, [])
+  for (const w of workers) {
+    if (w.status !== 'pending' && w.status !== 'running' && w.status !== 'monitoring')
+      continue
+    const stage = phaseToStage(w.phase)
+    if (!stage) continue
+    m.get(stage)!.push(w)
+  }
+  return m
+}
+
+interface PipelineBarProps {
+  workers: WorkerInfo[]
+}
+
+export default function PipelineBar({ workers }: PipelineBarProps) {
+  const stages = useMemo<StageInfo[]>(() => {
+    const buckets = bucket(workers)
+    return STAGES.map<StageInfo>((key) => {
+      const list = buckets.get(key) ?? []
+      return {
+        key,
+        count: list.length,
+        workers: list,
+        subLabel: key === 'pr' ? prSubLabel(list) : null,
+      }
+    })
+  }, [workers])
+
+  // For the bead-row strip below the stage bar, we want one row per active
+  // in-flight bead with a marker on its current stage. A bead is uniquely
+  // identified by (anvil, bead_id). We pick the first worker for each bead
+  // since multiple sub-workers (e.g. bellows monitor + quench) collapse onto
+  // the same PR stage anyway.
+  const beadRows = useMemo(() => {
+    const seen = new Map<string, { worker: WorkerInfo; stage: StageKey }>()
+    for (const w of workers) {
+      if (w.status !== 'pending' && w.status !== 'running' && w.status !== 'monitoring')
+        continue
+      const stage = phaseToStage(w.phase)
+      if (!stage) continue
+      const key = `${w.anvil}:${w.bead_id}`
+      // Prefer the non-bellows-monitor entry when a bead has both (e.g. quench
+      // running while bellows monitors the PR) so the bead row shows the more
+      // informative sub-state in the PR column.
+      const existing = seen.get(key)
+      if (!existing || (existing.worker.phase === 'bellows' && w.phase !== 'bellows')) {
+        seen.set(key, { worker: w, stage })
+      }
+    }
+    return Array.from(seen.values())
+  }, [workers])
+
+  return (
+    <section
+      aria-label="Pipeline overview"
+      data-testid="pipeline-bar"
+      className="rounded-xl border border-slate-800 bg-slate-900/40 p-3"
+    >
+      <h2 className="mb-2 px-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        Pipeline
+      </h2>
+      <div className="flex items-stretch gap-1 overflow-x-auto pb-1">
+        {stages.map((s, i) => (
+          <div key={s.key} className="flex min-w-0 flex-1 items-stretch">
+            {i > 0 && (
+              <div
+                className="flex items-center px-0.5 text-slate-700"
+                aria-hidden="true"
+              >
+                <ChevronRight size={14} />
+              </div>
+            )}
+            <StagePill stage={s} />
+          </div>
+        ))}
+      </div>
+
+      {beadRows.length > 0 && (
+        <ul
+          aria-label="In-flight beads"
+          className="mt-3 flex flex-col gap-1 border-t border-slate-800 pt-2"
+        >
+          {beadRows.map(({ worker, stage }) => (
+            <BeadRow key={`${worker.anvil}:${worker.bead_id}`} worker={worker} stage={stage} />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+interface StagePillProps {
+  stage: StageInfo
+}
+
+function StagePill({ stage }: StagePillProps) {
+  return (
+    <div
+      role="region"
+      aria-label={`${STAGE_LABEL[stage.key]} stage`}
+      data-testid={`pipeline-stage-${stage.key}`}
+      className={`flex min-w-[88px] flex-1 flex-col rounded-md border border-slate-700/60 border-t-2 bg-slate-900/60 ${STAGE_ACCENT[stage.key]}`}
+    >
+      <div className="flex items-center justify-between px-2.5 py-1.5">
+        <span className="text-[11px] font-medium text-slate-200">
+          {STAGE_LABEL[stage.key]}
+        </span>
+        <span
+          className={`flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-[10px] font-semibold ${
+            stage.count > 0
+              ? 'bg-amber-500/20 text-amber-200'
+              : 'bg-slate-800 text-slate-500'
+          }`}
+          data-testid={`pipeline-count-${stage.key}`}
+        >
+          {stage.count}
+        </span>
+      </div>
+      {stage.subLabel && (
+        <div
+          className="border-t border-slate-700/40 px-2.5 py-1 text-[10px] uppercase tracking-wide text-blue-300"
+          data-testid="pipeline-pr-sublabel"
+        >
+          Bellows: {stage.subLabel}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface BeadRowProps {
+  worker: WorkerInfo
+  stage: StageKey
+}
+
+function BeadRow({ worker, stage }: BeadRowProps) {
+  return (
+    <li
+      data-testid="pipeline-bead-row"
+      data-bead-id={worker.bead_id}
+      className="flex items-center gap-2 rounded-md bg-slate-900/40 px-2 py-1 text-xs"
+    >
+      <span className="w-24 shrink-0 truncate font-mono text-[11px] text-slate-400">
+        {worker.bead_id}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-slate-200">
+        {worker.title || worker.bead_id}
+      </span>
+      <div className="flex items-center gap-1">
+        {STAGES.map((s) => (
+          <span
+            key={s}
+            aria-label={STAGE_LABEL[s]}
+            className={`h-1.5 w-4 rounded-sm ${
+              s === stage
+                ? activeMarkerClass(stage)
+                : 'bg-slate-800'
+            }`}
+          />
+        ))}
+      </div>
+    </li>
+  )
+}
+
+function activeMarkerClass(stage: StageKey): string {
+  switch (stage) {
+    case 'schematic':
+      return 'bg-purple-400'
+    case 'smith':
+      return 'bg-orange-400'
+    case 'temper':
+      return 'bg-yellow-400'
+    case 'warden':
+      return 'bg-cyan-400'
+    case 'pr':
+      return 'bg-blue-400'
+    case 'merged':
+      return 'bg-green-400'
+  }
+}

--- a/internal/web/frontend/src/components/WorkersPane.tsx
+++ b/internal/web/frontend/src/components/WorkersPane.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
-import { Skull, Users } from 'lucide-react'
+import { MonitorOff, Skull, Users } from 'lucide-react'
 import { actions, type WorkerInfo } from '../api'
 import { useAction } from '../hooks/useAction'
 import { relativeTime } from '../lib/format'
+import { isBellowsMonitor } from './PipelineBar'
 import ConfirmModal from './ConfirmModal'
 import Pane, { EmptyState } from './Pane'
 
@@ -10,6 +11,12 @@ interface WorkersPaneProps {
   workers: WorkerInfo[]
   loading: boolean
   error: string | null
+  // maxTotalSmiths is the global concurrent-Smith cap reported by /api/status.
+  // The pane renders (maxTotalSmiths - active workers) dimmed Idle slots so
+  // the user can see remaining capacity at a glance. Zero or negative values
+  // disable the placeholders entirely (e.g. when the daemon has not yet
+  // reported a value).
+  maxTotalSmiths?: number
   onSelectWorker?: (worker: WorkerInfo) => void
   onActionSuccess?: () => void
 }
@@ -29,19 +36,35 @@ export default function WorkersPane({
   workers,
   loading,
   error,
+  maxTotalSmiths = 0,
   onSelectWorker,
   onActionSuccess,
 }: WorkersPaneProps) {
   const { run, busy } = useAction()
   const [killTarget, setKillTarget] = useState<WorkerInfo | null>(null)
 
+  // The Bellows PR-monitor row is intentionally filtered out — it produces no
+  // smith log, so a row with no log modal would look broken. Its state is now
+  // surfaced inside the Pipeline bar's PR stage. Bellows-spawned sub-workers
+  // (quench/burnish/rebase) keep their own phase and remain clickable here.
+  const visibleWorkers = workers.filter((w) => !isBellowsMonitor(w))
+
   // Sort by started_at descending so newest workers are at the top — matches
   // hearth TUI behaviour and Hytte's WorkersCard.
-  const sorted = [...workers].sort((a, b) => {
+  const sorted = [...visibleWorkers].sort((a, b) => {
     const aT = Date.parse(a.started_at) || 0
     const bT = Date.parse(b.started_at) || 0
     return bT - aT
   })
+
+  // Idle slot count = (configured cap) - (active Smith-like workers). We only
+  // count workers that occupy a Smith slot (pending/running) and that are not
+  // bellows monitors (already filtered above). When the daemon reports a cap
+  // of 0 we omit the placeholders entirely.
+  const activeSlotWorkers = sorted.filter(
+    (w) => w.status === 'pending' || w.status === 'running',
+  )
+  const idleCount = Math.max(0, maxTotalSmiths - activeSlotWorkers.length)
 
   const handleKill = async () => {
     if (!killTarget) return
@@ -57,11 +80,11 @@ export default function WorkersPane({
       <Pane
         title="Workers"
         icon={<Users size={16} className="text-sky-400" aria-hidden />}
-        count={workers.length}
+        count={visibleWorkers.length}
         loading={loading}
         error={error}
       >
-        {sorted.length === 0 && !loading ? (
+        {sorted.length === 0 && idleCount === 0 && !loading ? (
           <EmptyState message="No active workers." />
         ) : (
           <ul className="divide-y divide-slate-800">
@@ -139,6 +162,18 @@ export default function WorkersPane({
                 </li>
               )
             })}
+            {idleCount > 0 &&
+              Array.from({ length: idleCount }).map((_, i) => (
+                <li
+                  key={`idle-${i}`}
+                  data-testid="workers-idle-slot"
+                  className="flex items-center gap-3 border-t border-dashed border-slate-800/80 px-4 py-3 text-slate-600"
+                  aria-label={`Idle slot ${i + 1}`}
+                >
+                  <MonitorOff size={16} aria-hidden />
+                  <span className="text-xs uppercase tracking-wide">Idle</span>
+                </li>
+              ))}
           </ul>
         )}
       </Pane>

--- a/internal/web/frontend/src/components/WorkersPane.tsx
+++ b/internal/web/frontend/src/components/WorkersPane.tsx
@@ -57,12 +57,13 @@ export default function WorkersPane({
     return bT - aT
   })
 
-  // Idle slot count = (configured cap) - (active Smith-like workers). We only
-  // count workers that occupy a Smith slot (pending/running) and that are not
-  // bellows monitors (already filtered above). When the daemon reports a cap
-  // of 0 we omit the placeholders entirely.
+  // Idle slot count = (configured cap) - (active Smith-like workers). We count
+  // workers that occupy a Smith slot (pending/running/reviewing) and that are
+  // not bellows monitors (already filtered above). "reviewing" covers Warden
+  // phase workers (state.WorkerReviewing) which also hold a slot. When the
+  // daemon reports a cap of 0 we omit the placeholders entirely.
   const activeSlotWorkers = sorted.filter(
-    (w) => w.status === 'pending' || w.status === 'running',
+    (w) => w.status === 'pending' || w.status === 'running' || w.status === 'reviewing',
   )
   const idleCount = Math.max(0, maxTotalSmiths - activeSlotWorkers.length)
 

--- a/internal/web/frontend/src/pages/DashboardPage.tsx
+++ b/internal/web/frontend/src/pages/DashboardPage.tsx
@@ -14,6 +14,7 @@ import WorkersPane from '../components/WorkersPane'
 import LiveActivity from '../components/LiveActivity'
 import WorkerLogModal from '../components/WorkerLogModal'
 import CruciblesPane from '../components/CruciblesPane'
+import PipelineBar from '../components/PipelineBar'
 
 const POLL_INTERVAL_MS = 5000
 
@@ -87,7 +88,9 @@ export default function DashboardPage() {
         />
       )}
 
-      <main className="grid flex-1 grid-cols-1 gap-4 lg:grid-cols-[repeat(3,minmax(280px,1fr))]">
+      <PipelineBar workers={workers.data?.workers ?? []} />
+
+      <main className="grid flex-1 grid-cols-1 gap-4 lg:grid-cols-3">
         <QueuePane
           loading={queue.loading}
           error={queue.error}
@@ -97,6 +100,7 @@ export default function DashboardPage() {
           loading={workers.loading}
           error={workers.error}
           workers={workers.data?.workers ?? []}
+          maxTotalSmiths={status.data?.max_total_smiths ?? 0}
           onSelectWorker={setLogWorker}
         />
         <LiveActivity />


### PR DESCRIPTION
## Changes

- **Hearth 2.0 pipeline overview bar** - Added a horizontal Schematic → Smith → Temper → Warden → PR → Merged pipeline bar above the Queue/Workers/LiveActivity columns with a per-stage count and one row per active in-flight bead. Bellows status is now nested under the PR stage (monitoring / ci-fix / review-fix / rebase) instead of appearing as a standalone Workers row, and the Workers pane shows dimmed Idle slots equal to the remaining global Smith capacity. The status API now exposes `max_total_smiths`. (Forge-v7ij)

## Original Issue (feature): Hearth 2.0: pipeline visual overview with bellows nested under PR

Hearth 2.0 lacks a visual overview of where each in-flight bead is in the pipeline. Hytte's Mezzanine page shows a horizontal pipeline (Schematic → Smith → Temper → Warden → PR → CI/Review → Merge), with the active bead's current stage highlighted, plus Idle slots where future worker output will appear. Bring that pattern to Hearth 2.0.

## Pipeline bar

Render a horizontal pipeline bar at the top of the dashboard, ABOVE the Queue / Workers / LiveActivity columns. Stages, left to right:

1. Schematic
2. Smith
3. Temper
4. Warden
5. PR (with **Bellows** nested as a sub-state — see below)
6. Merged

Each stage is a small pill showing the count of beads currently in that stage, derived from the workers list (`status` field) and the PR table (PR phase).

Below the pipeline bar, render one row per active in-flight bead with its position marked on the pipeline. Mirror Mezzanine's layout if it's a clean reference.

## Bellows nested under PR

Bellows is a PR-monitor, not a stage that produces a smith log. In Mezzanine it lives under the PR stage as a sub-state ("Bellows: monitoring", "Bellows: ci-fix in progress", etc.). Replicate that in Hearth 2.0:

- Bellows rows should NOT appear as standalone clickable workers in the Workers pane.
- Inside the PR stage of the pipeline bar, show bellows status as a small label/icon: "monitoring", "ci-fix", "review-fix", "rebase".
- Clicking the PR stage opens the PR's detail (deferred to a separate bead if not trivial — at minimum, no log modal).
- The actual bellows-spawned sub-workers (quench, burnish, rebase) DO have logs and stay clickable.

A separate bead Forge-XXXX (filed alongside this one) handles the broader "no log modal for bellows" behaviour change so the two can be reviewed independently. Cross-link there.

## Idle slots

Mezzanine shows N "Idle" placeholder boxes where N = max concurrent workers minus active workers. They give a visual sense of remaining capacity. Replicate:

- Render `max_total_smiths - active_workers` idle slots in the Workers pane.
- Each slot is a dimmed placeholder card; a new worker fills it as soon as it starts.
- Pull `max_total_smiths` from the daemon status response.

## Backend

The current `/api/workers` response should already carry enough state to derive each worker's pipeline position (smith vs bellows vs temper vs warden). If not, extend with a `phase` field (one of: schematic, smith, temper, warden, pr, bellows-mon, bellows-cifix, bellows-reviewfix, bellows-rebase, merged). The pipeline component aggregates client-side.

Check `internal/web/views.go` for the workers list response shape and extend if needed.

## Tests

- Backend: assert the new `phase` field is populated for each worker.
- Frontend: render with a mocked fixture covering one bead in each stage; pipeline bar shows the right counts; bellows row is not in the Workers pane.

## Acceptance

- `make build`, `make test`, `npm run lint`, `npm run build`, `npm test` (frontend) all pass.
- Pipeline bar renders with counts per stage.
- Each in-flight bead has a row showing its current stage.
- Bellows workers do not appear as standalone clickable rows.
- Idle slots appear in the Workers pane equal to remaining capacity.
- Changelog fragment in changelog.d/ (category: Added).

## Non-goals

- Animated stage-transition effects. Static highlight is enough.
- Clicking the pipeline stage to filter the Workers/Queue panes. Could be a follow-up.
- Reorganising the Workers pane internals. This bead adds the pipeline bar + relocates bellows; the existing worker card stays.

## Reference

- web/src/pages/MezzaninePage.tsx and web/src/components/mezzanine/PipelineBar.tsx in the Hytte repo — the visual pattern to mirror. The Hytte source is at /home/robin/source/Hytte for inspiration; do not import code from there.
- internal/web/frontend/src/components/WorkersPane.tsx — current Workers rendering.
- internal/web/views.go — backend workers response; extend if the phase isn't already exposed.
- internal/bellows/ — to understand the bellows sub-state taxonomy (monitoring / ci-fix / review-fix / rebase).


---
Bead: Forge-v7ij | Branch: forge/Forge-v7ij
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)