### PR TITLE
Daemon pidfile check should verify process identity, not just PID liveness (Forge-4b55)

### DIFF
--- a/changelog.d/Forge-4b55.md
+++ b/changelog.d/Forge-4b55.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Stale pidfile crashloop on container restart** - Daemon startup now verifies that the PID in `forge.pid` actually belongs to a forge process (via `/proc/<pid>/comm` on Linux), not just that a process with that PID is alive. Containers killed before graceful shutdown no longer crashloop on restart with `Forge daemon already running` when an unrelated low-PID process inherits the stale pidfile. (Forge-4b55)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -4905,6 +4906,26 @@ func IsRunning() (int, bool) {
 	// On Unix, FindProcess always succeeds; Signal(0) checks liveness.
 	err = proc.Signal(syscall.Signal(0))
 	if err != nil {
+		return 0, false
+	}
+
+	// Liveness alone is not enough. In a container PID namespace, low PIDs
+	// like init or its children are almost always alive, so a stale pidfile
+	// from a killed pod (helm rollout mid-flight, OOM, drain past grace)
+	// would otherwise match an unrelated live process and crashloop every
+	// retry pod. Verify the process is actually a forge binary; if not,
+	// treat the pidfile as stale and remove it so the next writePID
+	// succeeds cleanly.
+	isForge, identErr := isForgeProcess(pid)
+	if identErr != nil {
+		slog.Warn("could not verify forge process identity; assuming alive", "pid", pid, "pidfile", pidPath, "err", identErr)
+		return pid, true
+	}
+	if !isForge {
+		slog.Warn("stale pidfile points to non-forge process; ignoring", "pid", pid, "pidfile", pidPath)
+		if err := os.Remove(pidPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			slog.Warn("failed to remove stale pidfile", "pidfile", pidPath, "err", err)
+		}
 		return 0, false
 	}
 

--- a/internal/daemon/identity_linux.go
+++ b/internal/daemon/identity_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package daemon
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// procFS is the procfs root used to verify daemon process identity.
+// Tests override this to point at a fixture directory.
+var procFS = "/proc"
+
+// isForgeProcess reports whether the process with the given pid is a forge
+// binary. It exists so IsRunning() can distinguish a live forge daemon from
+// an unrelated process that inherited a stale pidfile's PID — common in
+// container PID namespaces where init or its children sit at low PIDs.
+//
+// Verification:
+//  1. Read /proc/<pid>/comm and compare basename to "forge".
+//  2. If comm is unreadable for a reason other than ENOENT, fall back to
+//     /proc/<pid>/exe and compare the symlink target's basename to "forge".
+//
+// Returns (false, nil) when the process exists but is not forge, or when
+// the process is gone (ENOENT). Returns (false, err) only on unexpected
+// I/O errors that the caller should surface.
+func isForgeProcess(pid int) (bool, error) {
+	pidDir := filepath.Join(procFS, strconv.Itoa(pid))
+
+	data, err := os.ReadFile(filepath.Join(pidDir, "comm"))
+	switch {
+	case err == nil:
+		return filepath.Base(strings.TrimSpace(string(data))) == "forge", nil
+	case errors.Is(err, fs.ErrNotExist):
+		return false, nil
+	}
+
+	target, err := os.Readlink(filepath.Join(pidDir, "exe"))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+			return false, nil
+		}
+		return false, err
+	}
+	return filepath.Base(target) == "forge", nil
+}

--- a/internal/daemon/identity_linux.go
+++ b/internal/daemon/identity_linux.go
@@ -26,8 +26,10 @@ var procFS = "/proc"
 //     /proc/<pid>/exe and compare the symlink target's basename to "forge".
 //
 // Returns (false, nil) when the process exists but is not forge, or when
-// the process is gone (ENOENT). Returns (false, err) only on unexpected
-// I/O errors that the caller should surface.
+// the process is gone (ENOENT). Returns (false, err) when identity cannot
+// be verified — including permission-denied errors from procfs hidepid
+// mounts — so the caller can treat the process as alive rather than
+// deleting the pidfile.
 func isForgeProcess(pid int) (bool, error) {
 	pidDir := filepath.Join(procFS, strconv.Itoa(pid))
 
@@ -41,9 +43,12 @@ func isForgeProcess(pid int) (bool, error) {
 
 	target, err := os.Readlink(filepath.Join(pidDir, "exe"))
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrPermission) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
+		// Permission errors (e.g. hidepid) mean we cannot verify identity;
+		// return the error so IsRunning() assumes alive rather than removing
+		// a potentially valid pidfile.
 		return false, err
 	}
 	return filepath.Base(target) == "forge", nil

--- a/internal/daemon/identity_linux_test.go
+++ b/internal/daemon/identity_linux_test.go
@@ -1,0 +1,134 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withProcFS swaps the package-level procFS root for the duration of the test.
+func withProcFS(t *testing.T, root string) {
+	t.Helper()
+	prev := procFS
+	procFS = root
+	t.Cleanup(func() { procFS = prev })
+}
+
+// writeFakeProcEntry sets up a fake /proc/<pid>/comm (and optionally an
+// /proc/<pid>/exe symlink) under root, mimicking the real procfs layout.
+func writeFakeProcEntry(t *testing.T, root string, pid int, comm string, exeTarget string) {
+	t.Helper()
+	pidDir := filepath.Join(root, strconv.Itoa(pid))
+	require.NoError(t, os.MkdirAll(pidDir, 0o755))
+	if comm != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(pidDir, "comm"), []byte(comm+"\n"), 0o644))
+	}
+	if exeTarget != "" {
+		require.NoError(t, os.Symlink(exeTarget, filepath.Join(pidDir, "exe")))
+	}
+}
+
+func TestIsForgeProcess_CommMatchesForge(t *testing.T) {
+	root := t.TempDir()
+	withProcFS(t, root)
+	writeFakeProcEntry(t, root, 12345, "forge", "")
+
+	ok, err := isForgeProcess(12345)
+	require.NoError(t, err)
+	assert.True(t, ok, "comm == forge should be identified as a forge process")
+}
+
+func TestIsForgeProcess_CommIsDifferentBinary(t *testing.T) {
+	root := t.TempDir()
+	withProcFS(t, root)
+	// Mimics the production failure mode: container PID 1 is "tini" or
+	// some other init, not forge, but a stale pidfile points at it.
+	writeFakeProcEntry(t, root, 7, "tini", "")
+
+	ok, err := isForgeProcess(7)
+	require.NoError(t, err)
+	assert.False(t, ok, "non-forge comm must not be treated as a forge process")
+}
+
+func TestIsForgeProcess_PidGoneReturnsFalse(t *testing.T) {
+	root := t.TempDir()
+	withProcFS(t, root)
+
+	ok, err := isForgeProcess(99999)
+	require.NoError(t, err, "ENOENT must be treated as 'process gone', not an error")
+	assert.False(t, ok)
+}
+
+func TestIsForgeProcess_CommBasenameOnPath(t *testing.T) {
+	// comm normally contains a bare basename, but defensively handle the
+	// case where the kernel reports a path-like value — only the basename
+	// should be compared.
+	root := t.TempDir()
+	withProcFS(t, root)
+	writeFakeProcEntry(t, root, 555, "/usr/local/bin/forge", "")
+
+	ok, err := isForgeProcess(555)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestIsForgeProcess_LookalikeBinaryIsNotForge(t *testing.T) {
+	// "forge-worker" must not be mistaken for the forge daemon — basename
+	// comparison requires an exact match.
+	root := t.TempDir()
+	withProcFS(t, root)
+	writeFakeProcEntry(t, root, 777, "forge-worker", "")
+
+	ok, err := isForgeProcess(777)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestIsForgeProcess_RealTestProcessIsNotForge(t *testing.T) {
+	// Sanity check against the real procfs: the running test binary is
+	// "<pkg>.test" (or similar), never "forge". This guards against the
+	// original bug where any live PID was treated as a forge process.
+	ok, err := isForgeProcess(os.Getpid())
+	require.NoError(t, err)
+	assert.False(t, ok, "test binary should not be identified as forge")
+}
+
+func TestIsRunning_StalePidfileToNonForgeProcessIsCleanedUp(t *testing.T) {
+	// Reproduces the production scenario: a pidfile left on a PVC after a
+	// kill -9 points at a PID (the test process here) which is alive but
+	// is not a forge binary. IsRunning() must return (0, false) and remove
+	// the stale pidfile so the next writePID() can claim it.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".forge"), 0o755))
+
+	pidPath := filepath.Join(home, ".forge", PIDFileName)
+	require.NoError(t, os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o644))
+
+	pid, running := IsRunning()
+	assert.Equal(t, 0, pid)
+	assert.False(t, running, "non-forge PID must not be treated as a running forge daemon")
+
+	_, err := os.Stat(pidPath)
+	assert.True(t, os.IsNotExist(err), "stale pidfile should have been removed")
+}
+
+func TestIsRunning_PidfileWithDeadPidReturnsNotRunning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".forge"), 0o755))
+
+	// PID well above the typical pid_max for transient processes — almost
+	// certainly does not exist.
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".forge", PIDFileName), []byte("4194303"), 0o644))
+
+	pid, running := IsRunning()
+	assert.Equal(t, 0, pid)
+	assert.False(t, running)
+}

--- a/internal/daemon/identity_linux_test.go
+++ b/internal/daemon/identity_linux_test.go
@@ -99,6 +99,79 @@ func TestIsForgeProcess_RealTestProcessIsNotForge(t *testing.T) {
 	assert.False(t, ok, "test binary should not be identified as forge")
 }
 
+func TestIsForgeProcess_ExeFallbackForgeProcess(t *testing.T) {
+	// When comm is unreadable (EACCES, e.g. hidepid) but exe points to forge,
+	// the function should fall back to exe and correctly identify the process.
+	if os.Getuid() == 0 {
+		t.Skip("permission-based tests cannot run as root")
+	}
+	root := t.TempDir()
+	withProcFS(t, root)
+	pid := 12345
+	pidDir := filepath.Join(root, strconv.Itoa(pid))
+	require.NoError(t, os.MkdirAll(pidDir, 0o755))
+
+	commPath := filepath.Join(pidDir, "comm")
+	require.NoError(t, os.WriteFile(commPath, []byte("something\n"), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(commPath, 0o644) })
+
+	require.NoError(t, os.Symlink("/usr/local/bin/forge", filepath.Join(pidDir, "exe")))
+
+	ok, err := isForgeProcess(pid)
+	require.NoError(t, err)
+	assert.True(t, ok, "exe fallback should identify forge when comm is unreadable")
+}
+
+func TestIsForgeProcess_ExeFallbackNonForgeProcess(t *testing.T) {
+	// When comm is unreadable but exe points to a non-forge binary, the
+	// function should correctly return false via the exe fallback.
+	if os.Getuid() == 0 {
+		t.Skip("permission-based tests cannot run as root")
+	}
+	root := t.TempDir()
+	withProcFS(t, root)
+	pid := 12346
+	pidDir := filepath.Join(root, strconv.Itoa(pid))
+	require.NoError(t, os.MkdirAll(pidDir, 0o755))
+
+	commPath := filepath.Join(pidDir, "comm")
+	require.NoError(t, os.WriteFile(commPath, []byte("something\n"), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(commPath, 0o644) })
+
+	require.NoError(t, os.Symlink("/usr/bin/python3", filepath.Join(pidDir, "exe")))
+
+	ok, err := isForgeProcess(pid)
+	require.NoError(t, err)
+	assert.False(t, ok, "exe fallback should not identify non-forge binary as forge")
+}
+
+func TestIsForgeProcess_PermissionDeniedOnBothReturnsError(t *testing.T) {
+	// On a hidepid procfs mount, both comm and exe may be inaccessible.
+	// The function must return an error (not false, nil) so IsRunning()
+	// assumes the process is alive rather than deleting the pidfile.
+	if os.Getuid() == 0 {
+		t.Skip("permission-based tests cannot run as root")
+	}
+	root := t.TempDir()
+	withProcFS(t, root)
+	pid := 12347
+	pidDir := filepath.Join(root, strconv.Itoa(pid))
+	require.NoError(t, os.MkdirAll(pidDir, 0o755))
+
+	commPath := filepath.Join(pidDir, "comm")
+	require.NoError(t, os.WriteFile(commPath, []byte("forge\n"), 0o644))
+
+	// Make the directory non-executable so all entries (comm, exe) become
+	// inaccessible — mimicking hidepid=2 behaviour.
+	// Register pidDir cleanup first so it runs LAST (LIFO), after comm cleanup.
+	t.Cleanup(func() { _ = os.Chmod(commPath, 0o644) })
+	t.Cleanup(func() { _ = os.Chmod(pidDir, 0o755) })
+	require.NoError(t, os.Chmod(pidDir, 0o000))
+
+	_, err := isForgeProcess(pid)
+	assert.Error(t, err, "permission denied on both comm and exe should return an error, not (false, nil)")
+}
+
 func TestIsRunning_StalePidfileToNonForgeProcessIsCleanedUp(t *testing.T) {
 	// Reproduces the production scenario: a pidfile left on a PVC after a
 	// kill -9 points at a PID (the test process here) which is alive but

--- a/internal/daemon/identity_other.go
+++ b/internal/daemon/identity_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package daemon
+
+// isForgeProcess is a no-op on non-Linux platforms. Windows relies on the
+// named pipe as a liveness proxy in IsRunning(), and macOS keeps the
+// historical behavior of trusting the Signal(0) liveness check. Returning
+// true preserves the prior semantics: IsRunning() proceeds as if the
+// liveness check were authoritative.
+func isForgeProcess(pid int) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
## Changes

- **Stale pidfile crashloop on container restart** - Daemon startup now verifies that the PID in `forge.pid` actually belongs to a forge process (via `/proc/<pid>/comm` on Linux), not just that a process with that PID is alive. Containers killed before graceful shutdown no longer crashloop on restart with `Forge daemon already running` when an unrelated low-PID process inherits the stale pidfile. (Forge-4b55)

## Original Issue (bug): Daemon pidfile check should verify process identity, not just PID liveness

## Problem

When a Forge pod is killed before `shutdown.Run()` gets a chance to clean up — failed helm rollout that scales the old pod down mid-flight, OOM kill, node drain exceeding the termination grace period — the `forge.pid` file at `/home/forge/.forge/forge.pid` is left behind on the PVC. The next pod to mount the PVC crashloops forever with `Forge daemon already running (PID 7)` before the daemon has even started. Recovery requires scaling to zero, mounting the PVC in a debug pod, deleting the pidfile, and scaling back up.

## Root cause

`internal/daemon/daemon.go:IsRunning` reads the pidfile, then checks liveness with `proc.Signal(0)` on Unix. In a fresh container PID namespace there is almost always *something* alive at low PIDs (container PID 1, init children, etc.), so the stale PID matches a live but unrelated process and the check returns `true`. The check has no way of knowing the running process is in fact a different Forge instance. The Windows path uses the named pipe as a liveness proxy and is unaffected — this is Linux-only.

## Proposed fix

Verify process identity, not just liveness. On Linux read `/proc/<pid>/comm` (or `/proc/<pid>/exe` for stronger identity) and check the basename matches `forge`. If the PID exists but is not a forge process, treat it as a stale pidfile: warn and continue startup as if the file weren't there.

---
Bead: Forge-4b55 | Branch: forge/Forge-4b55
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)