### PR TITLE
Beads-Forge drafting agent: give it filesystem access and resolve anvil path from bead metadata (Forge-9w62)

### DIFF
--- a/changelog.d/Forge-9w62.md
+++ b/changelog.d/Forge-9w62.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Beads-Forge drafter can now read the target anvil** - The drafting and grilling turns are granted read-only Read/Grep/Glob access, and the session's anvil name is resolved against the live registry so the AI is told the absolute path up-front instead of asking the user where the codebase lives. (Forge-9w62)

--- a/internal/forgechat/emit.go
+++ b/internal/forgechat/emit.go
@@ -369,3 +369,22 @@ func formatAnvilContext(anvils AnvilContext) string {
 	}
 	return b.String()
 }
+
+// formatSingleAnvilContext renders the session-scoped anvil for drafting /
+// plan / grilling prompts. The block is structured so the agent reads it
+// once at prompt-time and uses the absolute path in subsequent Read / Grep /
+// Glob tool calls. We emit nothing when the anvil has no name or path —
+// half-resolved context is worse than none (the agent fabricates the rest).
+func formatSingleAnvilContext(a AnvilTarget) string {
+	name := strings.TrimSpace(a.Name)
+	path := strings.TrimSpace(a.Path)
+	if name == "" || path == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n## Target anvil\n\n")
+	fmt.Fprintf(&b, "- name: `%s`\n", name)
+	fmt.Fprintf(&b, "- path: `%s`\n", path)
+	b.WriteString("\nUse this path with Read / Grep / Glob to audit the codebase. Pass absolute paths under it; do not ask the user where the code lives.\n")
+	return b.String()
+}

--- a/internal/forgechat/forgechat.go
+++ b/internal/forgechat/forgechat.go
@@ -76,6 +76,22 @@ type TurnRequest struct {
 	// beads (ModeEmit). Keys are anvil names; values are short hints. Unused
 	// for chat / plan / grill modes.
 	Anvils AnvilContext
+	// Anvil is the session-scoped target for drafting / plan / grilling turns
+	// — the bead being designed already has an anvil association, so the AI
+	// is told the resolved name + absolute path up-front and uses it to read
+	// the codebase via Read / Grep / Glob. Nil leaves the anvil context out
+	// of the prompt (the AI then has to ask, which is what we're fixing).
+	Anvil *AnvilTarget
+}
+
+// AnvilTarget is the resolved name + on-disk path of the anvil that owns a
+// drafting / grilling session. The path is the absolute filesystem path the
+// daemon would use when launching tools against that anvil — we render it
+// into the prompt so the agent never has to ask the user where the code
+// lives.
+type AnvilTarget struct {
+	Name string
+	Path string
 }
 
 // EmittedMessage is one assistant message produced by a turn. The kind
@@ -178,6 +194,8 @@ func BuildPrompt(req TurnRequest) string {
 
 	if req.Mode == ModeEmit {
 		b.WriteString(formatAnvilContext(req.Anvils))
+	} else if req.Anvil != nil {
+		b.WriteString(formatSingleAnvilContext(*req.Anvil))
 	}
 
 	if len(req.History) > 0 {
@@ -339,6 +357,13 @@ func VerdictToMessages(v *grillingVerdict) ([]EmittedMessage, bool) {
 // System-level prompts. These are deliberately verbose so callers don't need
 // to add boilerplate. The grilling prompt embeds the user's grill-me skill
 // (per the bead description) verbatim.
+//
+// Filesystem access: drafting / plan / grilling turns may use the Read,
+// Grep, and Glob tools against the target anvil (whose absolute path is
+// rendered into the prompt). The agent must not modify files, write code,
+// run destructive commands, or ask the user where the anvil lives — that
+// information is provided up-front. The capability is intentionally read-
+// only: this is a design conversation, not an implementation session.
 const systemPromptDrafting = `You are a senior software architect helping the user shape a new bead (work item) into a clear, actionable engineering plan.
 
 You are in the DRAFTING stage. Respond conversationally:
@@ -346,11 +371,15 @@ You are in the DRAFTING stage. Respond conversationally:
 - propose approaches and trade-offs,
 - identify risks and missing pieces.
 
-Do NOT use any tools. Do NOT explore the filesystem. Respond with prose only — markdown is fine. Keep responses focused; aim for one or two short paragraphs unless the user explicitly asks for more.`
+You have READ-ONLY access to the target anvil's codebase via the Read, Grep, and Glob tools. The anvil's absolute path is rendered below — use it directly; do NOT ask the user where the codebase lives or for filesystem permission. Before grilling the user with design questions, answer the ones you can answer yourself by reading the code (call sites, API shapes, existing tests, conventions). Do NOT modify any files. Do NOT run destructive shell commands. Do NOT create new files.
+
+Respond with prose only — markdown is fine. Keep responses focused; aim for one or two short paragraphs unless the user explicitly asks for more.`
 
 const systemPromptPlan = `You are a senior software architect summarising a Beads-Forge design conversation into a focused implementation plan.
 
-The user has been iterating on an idea with you and now wants a concrete plan they can hand to a coding agent. Output ONLY the plan as markdown. Do NOT include conversational preamble or sign-off. Do NOT use any tools or read files.
+The user has been iterating on an idea with you and now wants a concrete plan they can hand to a coding agent. Output ONLY the plan as markdown. Do NOT include conversational preamble or sign-off.
+
+You may use the Read, Grep, and Glob tools against the target anvil (path rendered below) to ground the plan in the real codebase — concrete file paths and function signatures beat made-up ones. Do NOT modify files, write new code, or run destructive commands.
 
 The plan must include:
 - a one-sentence problem statement,
@@ -365,7 +394,9 @@ const systemPromptGrilling = `Interview me relentlessly about every aspect of th
 
 Questions should have options and recommendation(s); the user responds by either writing or picking an option.
 
-You are in the GRILLING stage. The user has agreed on a high-level plan (above) and now wants you to interrogate every decision until the design tree is exhausted. Each turn, emit ONE structured JSON envelope of the next set of questions — pick the most decision-blocking ones first, do not dump the entire tree at once. When you genuinely cannot find another question worth asking, return done:true.`
+You are in the GRILLING stage. The user has agreed on a high-level plan (above) and now wants you to interrogate every decision until the design tree is exhausted. Each turn, emit ONE structured JSON envelope of the next set of questions — pick the most decision-blocking ones first, do not dump the entire tree at once. When you genuinely cannot find another question worth asking, return done:true.
+
+You have READ-ONLY access to the target anvil via the Read, Grep, and Glob tools (the anvil's absolute path is rendered below). Use those tools to answer your own questions about the code before asking the user — never ask the user where the codebase lives or for filesystem permission. Do NOT modify any files.`
 
 const tailDrafting = `Respond now with your conversational reply. Plain markdown text only.`
 

--- a/internal/forgechat/forgechat.go
+++ b/internal/forgechat/forgechat.go
@@ -360,10 +360,10 @@ func VerdictToMessages(v *grillingVerdict) ([]EmittedMessage, bool) {
 //
 // Filesystem access: drafting / plan / grilling turns may use the Read,
 // Grep, and Glob tools against the target anvil (whose absolute path is
-// rendered into the prompt). The agent must not modify files, write code,
-// run destructive commands, or ask the user where the anvil lives — that
-// information is provided up-front. The capability is intentionally read-
-// only: this is a design conversation, not an implementation session.
+// rendered into the prompt). The agent is instructed to use only those
+// read-only tools; it must not modify files, write code, or run destructive
+// commands. This is a design conversation, not an implementation session.
+// Note: tool access is enforced by instruction, not by a hard allowlist.
 const systemPromptDrafting = `You are a senior software architect helping the user shape a new bead (work item) into a clear, actionable engineering plan.
 
 You are in the DRAFTING stage. Respond conversationally:
@@ -371,7 +371,7 @@ You are in the DRAFTING stage. Respond conversationally:
 - propose approaches and trade-offs,
 - identify risks and missing pieces.
 
-You have READ-ONLY access to the target anvil's codebase via the Read, Grep, and Glob tools. The anvil's absolute path is rendered below — use it directly; do NOT ask the user where the codebase lives or for filesystem permission. Before grilling the user with design questions, answer the ones you can answer yourself by reading the code (call sites, API shapes, existing tests, conventions). Do NOT modify any files. Do NOT run destructive shell commands. Do NOT create new files.
+You may explore the target anvil's codebase using the Read, Grep, and Glob tools. The anvil's absolute path is rendered below — use it directly; do NOT ask the user where the codebase lives or for filesystem permission. Before grilling the user with design questions, answer the ones you can answer yourself by reading the code (call sites, API shapes, existing tests, conventions). Limit yourself to read-only inspection: do NOT modify any files, do NOT run shell commands, do NOT create new files. This is a design conversation only.
 
 Respond with prose only — markdown is fine. Keep responses focused; aim for one or two short paragraphs unless the user explicitly asks for more.`
 
@@ -379,7 +379,7 @@ const systemPromptPlan = `You are a senior software architect summarising a Bead
 
 The user has been iterating on an idea with you and now wants a concrete plan they can hand to a coding agent. Output ONLY the plan as markdown. Do NOT include conversational preamble or sign-off.
 
-You may use the Read, Grep, and Glob tools against the target anvil (path rendered below) to ground the plan in the real codebase — concrete file paths and function signatures beat made-up ones. Do NOT modify files, write new code, or run destructive commands.
+You may use the Read, Grep, and Glob tools against the target anvil (path rendered below) to ground the plan in the real codebase — concrete file paths and function signatures beat made-up ones. Limit yourself to read-only inspection: do NOT modify files, write new code, or run shell commands.
 
 The plan must include:
 - a one-sentence problem statement,
@@ -396,7 +396,7 @@ Questions should have options and recommendation(s); the user responds by either
 
 You are in the GRILLING stage. The user has agreed on a high-level plan (above) and now wants you to interrogate every decision until the design tree is exhausted. Each turn, emit ONE structured JSON envelope of the next set of questions — pick the most decision-blocking ones first, do not dump the entire tree at once. When you genuinely cannot find another question worth asking, return done:true.
 
-You have READ-ONLY access to the target anvil via the Read, Grep, and Glob tools (the anvil's absolute path is rendered below). Use those tools to answer your own questions about the code before asking the user — never ask the user where the codebase lives or for filesystem permission. Do NOT modify any files.`
+You may explore the target anvil via the Read, Grep, and Glob tools (the anvil's absolute path is rendered below). Use those tools to answer your own questions about the code before asking the user — never ask the user where the codebase lives or for filesystem permission. Limit yourself to read-only inspection: do NOT modify any files, do NOT run shell commands.`
 
 const tailDrafting = `Respond now with your conversational reply. Plain markdown text only.`
 

--- a/internal/forgechat/forgechat_test.go
+++ b/internal/forgechat/forgechat_test.go
@@ -32,6 +32,77 @@ func TestBuildPrompt_PlanModeAsksForMarkdownOnly(t *testing.T) {
 	}
 }
 
+func TestBuildPrompt_DraftingPromptsEnableReadOnlyTools(t *testing.T) {
+	for _, mode := range []Mode{ModeChat, ModePlan, ModeGrill} {
+		stage := StageDrafting
+		if mode == ModeGrill {
+			stage = StageGrilling
+		}
+		p := BuildPrompt(TurnRequest{Stage: stage, Mode: mode})
+		if !strings.Contains(p, "Read") || !strings.Contains(p, "Grep") || !strings.Contains(p, "Glob") {
+			t.Fatalf("mode %q prompt should advertise Read/Grep/Glob tools, got:\n%s", mode, p)
+		}
+		if strings.Contains(p, "Do NOT use any tools") {
+			t.Fatalf("mode %q prompt must no longer forbid tool use", mode)
+		}
+	}
+}
+
+func TestBuildPrompt_AnvilContextRendersWhenProvided(t *testing.T) {
+	target := &AnvilTarget{Name: "munin", Path: "/repos/munin"}
+	p := BuildPrompt(TurnRequest{
+		Stage: StageDrafting,
+		Mode:  ModeChat,
+		Anvil: target,
+	})
+	if !strings.Contains(p, "## Target anvil") {
+		t.Fatalf("drafting prompt should include the anvil context block, got:\n%s", p)
+	}
+	if !strings.Contains(p, "`munin`") {
+		t.Fatalf("drafting prompt should name the anvil, got:\n%s", p)
+	}
+	if !strings.Contains(p, "/repos/munin") {
+		t.Fatalf("drafting prompt should embed the anvil absolute path, got:\n%s", p)
+	}
+}
+
+func TestBuildPrompt_NilAnvilOmitsContextBlock(t *testing.T) {
+	p := BuildPrompt(TurnRequest{Stage: StageDrafting, Mode: ModeChat})
+	if strings.Contains(p, "## Target anvil") {
+		t.Fatalf("nil Anvil should not render the target-anvil block, got:\n%s", p)
+	}
+}
+
+func TestBuildPrompt_HalfResolvedAnvilOmitsContextBlock(t *testing.T) {
+	// Path missing — emitting "name: munin / path: " is worse than nothing
+	// because the AI will fabricate the missing piece.
+	p := BuildPrompt(TurnRequest{
+		Stage: StageDrafting,
+		Mode:  ModeChat,
+		Anvil: &AnvilTarget{Name: "munin"},
+	})
+	if strings.Contains(p, "## Target anvil") {
+		t.Fatalf("half-resolved Anvil should be omitted, got:\n%s", p)
+	}
+}
+
+func TestBuildPrompt_EmitModeStillUsesAnvilsListNotTargetAnvil(t *testing.T) {
+	// Emission mode lists every registered anvil; the session-scoped Anvil is
+	// not meaningful there (the AI may target a different anvil per bead).
+	p := BuildPrompt(TurnRequest{
+		Stage:  StageReady,
+		Mode:   ModeEmit,
+		Anvils: AnvilContext{"munin": "/repos/munin", "other": "/repos/other"},
+		Anvil:  &AnvilTarget{Name: "munin", Path: "/repos/munin"},
+	})
+	if !strings.Contains(p, "## Registered anvils") {
+		t.Fatalf("emit prompt should list registered anvils, got:\n%s", p)
+	}
+	if strings.Contains(p, "## Target anvil") {
+		t.Fatalf("emit prompt must not include the single-anvil block (it picks per bead)")
+	}
+}
+
 func TestParseGrillingResponse_FencedJSON(t *testing.T) {
 	out := "Some preamble\n```json\n" +
 		`{"questions":[{"prompt":"Sync or async?","options":[{"id":"sync","label":"Sync"},{"id":"async","label":"Async"}],"recommendation":"async","rationale":"Avoids blocking the daemon"}]}` +

--- a/internal/web/forge_chat.go
+++ b/internal/web/forge_chat.go
@@ -225,6 +225,7 @@ func (s *Server) handleForgeSessionTurn(w http.ResponseWriter, r *http.Request) 
 		Title:   row.Title,
 		Plan:    row.Plan,
 		History: history,
+		Anvil:   s.resolveSessionAnvil(row.Anvil),
 	}
 	turnResp, err := s.chatRunner.Turn(turnCtx, turnReq)
 	if err != nil {
@@ -298,6 +299,41 @@ func optMsg(m *state.ForgeSessionMessage) []state.ForgeSessionMessage {
 		return nil
 	}
 	return []state.ForgeSessionMessage{*m}
+}
+
+// resolveSessionAnvil maps a session's anvil name to its registered absolute
+// path so the drafting / grilling prompt can tell the AI where the code
+// lives. Returns nil when the registry isn't wired (no daemon-side anvils
+// callback), when the session has no anvil association, or when the named
+// anvil is no longer registered — in those cases we'd rather emit no anvil
+// context than feed claude a wrong or stale path.
+//
+// Name resolution is case-insensitive to match the daemon's anvil routing
+// (e.g. a session created with "Munin" still resolves to the configured
+// "munin" key), and the canonical key + path are returned so the prompt
+// renders the names the daemon actually uses.
+func (s *Server) resolveSessionAnvil(name string) *forgechat.AnvilTarget {
+	if s.anvils == nil {
+		return nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	registry := s.anvils()
+	if len(registry) == 0 {
+		return nil
+	}
+	if path, ok := registry[name]; ok && strings.TrimSpace(path) != "" {
+		return &forgechat.AnvilTarget{Name: name, Path: path}
+	}
+	lower := strings.ToLower(name)
+	for k, path := range registry {
+		if strings.ToLower(k) == lower && strings.TrimSpace(path) != "" {
+			return &forgechat.AnvilTarget{Name: k, Path: path}
+		}
+	}
+	return nil
 }
 
 // respondTurn writes a unified response shape for the turn endpoint. The

--- a/internal/web/forge_chat.go
+++ b/internal/web/forge_chat.go
@@ -328,12 +328,18 @@ func (s *Server) resolveSessionAnvil(name string) *forgechat.AnvilTarget {
 		return &forgechat.AnvilTarget{Name: name, Path: path}
 	}
 	lower := strings.ToLower(name)
+	var matched *forgechat.AnvilTarget
 	for k, path := range registry {
 		if strings.ToLower(k) == lower && strings.TrimSpace(path) != "" {
-			return &forgechat.AnvilTarget{Name: k, Path: path}
+			if matched != nil {
+				// Multiple keys differ only by case — ambiguous, return nil to
+				// avoid feeding claude a nondeterministically chosen path.
+				return nil
+			}
+			matched = &forgechat.AnvilTarget{Name: k, Path: path}
 		}
 	}
-	return nil
+	return matched
 }
 
 // respondTurn writes a unified response shape for the turn endpoint. The

--- a/internal/web/forge_chat_test.go
+++ b/internal/web/forge_chat_test.go
@@ -366,6 +366,39 @@ func TestForgeTurn_ResolvesAnvilCaseInsensitively(t *testing.T) {
 	}
 }
 
+// When two registry keys differ only by case (e.g. "munin" and "Munin") the
+// case-insensitive fallback scan is ambiguous — map iteration order is random,
+// so picking the first hit would be nondeterministic. resolveSessionAnvil must
+// return nil in that case rather than feeding the runner a randomly-chosen path.
+// The session name "MUNIN" has no exact-match key, so the fallback scan runs
+// and encounters both "munin" and "Munin".
+func TestForgeTurn_AmbiguousCaseAnvilProducesNilTarget(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{}
+	srv.SetChatRunner(runner)
+	srv.SetAnvilLister(func() map[string]string {
+		return map[string]string{
+			"munin": "/repos/munin-lower",
+			"Munin": "/repos/munin-upper",
+		}
+	})
+	cookie := loginAndGetCookie(t, srv)
+	// "MUNIN" has no exact match; the case-insensitive scan finds two candidates.
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start","anvil":"MUNIN"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	calls := runner.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(calls))
+	}
+	if calls[0].Anvil != nil {
+		t.Fatalf("ambiguous case-insensitive anvil should resolve to nil, got %+v", calls[0].Anvil)
+	}
+}
+
 // Unknown / unregistered anvil names should produce a nil Anvil rather than a
 // stale half-resolved one — emitting "name: X, path: " would worse than
 // nothing because the AI would fabricate the missing path. Verify the

--- a/internal/web/forge_chat_test.go
+++ b/internal/web/forge_chat_test.go
@@ -308,3 +308,89 @@ func TestForgeTurn_RunnerErrorReportsBadGateway(t *testing.T) {
 	}
 }
 
+// Forge-9w62: the drafting agent kept asking the user for the anvil path even
+// though the session was created with an anvil association. The handler now
+// resolves the path from the live registry and feeds it to the runner via
+// TurnRequest.Anvil — verify the wiring end-to-end so a future refactor that
+// drops the lookup fails this test loudly.
+func TestForgeTurn_ResolvesSessionAnvilForRunner(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{}
+	srv.SetChatRunner(runner)
+	srv.SetAnvilLister(func() map[string]string {
+		return map[string]string{"munin": "/repos/munin"}
+	})
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start","anvil":"munin"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	calls := runner.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(calls))
+	}
+	if calls[0].Anvil == nil {
+		t.Fatalf("runner should have received the resolved anvil, got nil")
+	}
+	if calls[0].Anvil.Name != "munin" || calls[0].Anvil.Path != "/repos/munin" {
+		t.Fatalf("unexpected anvil: %+v", calls[0].Anvil)
+	}
+}
+
+// Case-insensitive matching mirrors the daemon's anvil routing: a session
+// stored as "Munin" still resolves against the registered "munin" key so a
+// case-mismatch in the SPA doesn't reintroduce the "where is the codebase?"
+// failure mode.
+func TestForgeTurn_ResolvesAnvilCaseInsensitively(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{}
+	srv.SetChatRunner(runner)
+	srv.SetAnvilLister(func() map[string]string {
+		return map[string]string{"munin": "/repos/munin"}
+	})
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start","anvil":"Munin"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	calls := runner.Calls()
+	if len(calls) != 1 || calls[0].Anvil == nil {
+		t.Fatalf("expected resolved anvil, got %+v", calls)
+	}
+	if calls[0].Anvil.Name != "munin" || calls[0].Anvil.Path != "/repos/munin" {
+		t.Fatalf("expected canonical anvil munin → /repos/munin, got %+v", calls[0].Anvil)
+	}
+}
+
+// Unknown / unregistered anvil names should produce a nil Anvil rather than a
+// stale half-resolved one — emitting "name: X, path: " would worse than
+// nothing because the AI would fabricate the missing path. Verify the
+// handler still succeeds (the AI can ask the user as a fallback) but does
+// not feed the runner a poisoned anvil.
+func TestForgeTurn_UnknownAnvilProducesNilTarget(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{}
+	srv.SetChatRunner(runner)
+	srv.SetAnvilLister(func() map[string]string {
+		return map[string]string{"other": "/repos/other"}
+	})
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start","anvil":"gone"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	calls := runner.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 runner call, got %d", len(calls))
+	}
+	if calls[0].Anvil != nil {
+		t.Fatalf("unknown anvil should resolve to nil, got %+v", calls[0].Anvil)
+	}
+}
+


### PR DESCRIPTION
## Changes

- **Beads-Forge drafter can now read the target anvil** - The drafting and grilling turns are granted read-only Read/Grep/Glob access, and the session's anvil name is resolved against the live registry so the AI is told the absolute path up-front instead of asking the user where the codebase lives. (Forge-9w62)

## Original Issue (bug): Beads-Forge drafting agent: give it filesystem access and resolve anvil path from bead metadata

## Problem

When drafting a new bead in Hearth 2.0's Beads-Forge UI, the drafting agent claims it can't read the codebase yet (\"in this drafting stage I'm working without filesystem access\") and falls back to asking trivial design questions whose answers are sitting in the repo. Worse, it then asks the user for the filesystem path of the anvil — even though the anvil is already chosen on the page and the path is known to Forge from `forge.yaml`.

Observed during today's react-day-picker v9→v10 draft:
- \"if you want to move straight to a concrete plan, just say the word and I'll start digging through the codebase\" — drafting flow shouldn't require user permission to grep.
- \"Where is the munin client codebase located? I need filesystem access to audit actual react-day-picker usage\" — the bead already targets the munin anvil; the path is `anvils.munin.path` in the daemon's config.
- Two consecutive questions both blocked on the same path the agent already had access to derive.

## Proposed fix

Two independent improvements to the drafting-agent setup:

1. **Give the drafting agent the same read-only filesystem tools the planning agent has** (Read, Grep, Glob). Drafting without code visibility is what produces the \"trivial question\" failure mode. The agent should be able to answer its own questions about call sites, API shape, test layout etc. before grilling the user.

2. **Resolve the anvil path from the bead's anvil association** rather than asking. The Beads-Forge page already has the anvil selected; the daemon already knows `anvils.<name>.path` from config. The drafter's system prompt should be fed the resolved absolute path (or have a tool that returns it given the anvil name) so it never needs to ask.

---
Bead: Forge-9w62 | Branch: forge/Forge-9w62
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->