### PR TITLE
Beads-Forge over-splits simple tasks into multiple sequential beads (Forge-0dz9)

### DIFF
--- a/changelog.d/Forge-0dz9.md
+++ b/changelog.d/Forge-0dz9.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Beads-Forge over-splitting** - The emit-stage prompt now defaults to ONE bead per cohesive deliverable instead of one bead per verb (audit / migrate / test). It only splits when work crosses meaningful boundaries — different anvils, independent reviewers, or genuine cross-day blockers — using the heuristic "would a single developer do this in one branch, one sitting, one PR?". Adds a concrete few-shot example (a single dependency upgrade) and a counter-example (cross-surface migration) so the model recognises the right granularity. (Forge-0dz9)

--- a/internal/forgechat/emit.go
+++ b/internal/forgechat/emit.go
@@ -299,9 +299,33 @@ Input you have:
 - The full conversation, including grilling Q&A.
 - The set of registered anvils (below) — beads MUST target one of these by name.
 
-Your job: emit a JSON envelope listing every bead the user wants created. One bead per cohesive unit of work. Prefer multiple small beads with explicit dependencies over one mega-bead. Each bead must be self-contained enough that an AI agent can implement it without needing to read the others.
+Your job: emit a JSON envelope describing the bead(s) to create.
 
-Hard rules:
+**Default to ONE bead.** A bead is a unit of *deliverable*, not a unit of *verb*. Audit, implement, and test are stages of one PR — not three separate beads. If a single human developer would do the work in one branch, one sitting, one PR, then emit ONE bead. That is the common case.
+
+Split into multiple beads ONLY when the work crosses a meaningful boundary:
+- **Different anvils** — one bead per anvil is unavoidable (cross-anvil deps are not supported).
+- **Independent deliverables that ship on different timelines or to different reviewers** — e.g. a backend API change, a separate mobile client migration, and a separate web client migration that each merit their own PR.
+- **Work items that genuinely block on each other across days** — where the second bead truly cannot start until the first is merged, not just "would benefit from being done after."
+
+Do NOT split because:
+- The work has phases (audit, implement, test, document) — those are stages inside one PR.
+- The work touches multiple files or directories inside one anvil.
+- The work involves both production code and tests — tests belong with the change they verify.
+- "It might be safer to split it just in case." Default to one bead and trust the agent to handle the whole change.
+
+Heuristic when in doubt: "Would a single human developer do this on one branch in one sitting and send one PR?" If yes → ONE bead. If they would naturally need to coordinate with another reviewer or another team, or wait days for an upstream merge → split.
+
+### Example: ONE bead (do this)
+
+A dependency upgrade like react-day-picker v9 → v10, including auditing existing call sites, bumping the version, migrating the API usage, updating tests, and doing a visual QA pass, is **one** bead in one anvil. Even though the description can list four phases, it is one cohesive change reviewed in one PR.
+
+### Counter-example: multiple beads (split is justified)
+
+"Migrate the auth flow from session cookies to OIDC across the backend, the web client, and the mobile client." Three anvils, three reviewers, three PRs that ship on different timelines → three beads (one per surface), with explicit depends_on edges if the client beads need the backend change merged first.
+
+### Hard rules
+
 - Every bead targets exactly one anvil (the bd database lives in that anvil; cross-anvil deps are NOT supported).
 - depends_on lists sibling proposal ids ONLY (the strings in the "id" field). Do not invent bd-* ids.
 - A bead in anvil X may not depend on a bead in anvil Y. Split the work along anvil lines if needed.

--- a/internal/forgechat/emit_test.go
+++ b/internal/forgechat/emit_test.go
@@ -205,6 +205,29 @@ func TestBuildPrompt_EmitMode_IncludesAnvilList(t *testing.T) {
 	}
 }
 
+// TestBuildPrompt_EmitMode_PrefersSingleBead asserts the prompt instructs claude
+// to default to ONE bead instead of splitting per-verb. Regression guard for
+// the over-splitting bug where simple changes (e.g. a dependency upgrade) were
+// fanned out into four sequential beads (audit / bump / migrate / test).
+func TestBuildPrompt_EmitMode_PrefersSingleBead(t *testing.T) {
+	p := BuildPrompt(TurnRequest{
+		Stage:  StageReady,
+		Mode:   ModeEmit,
+		Title:  "Foo",
+		Plan:   "# plan",
+		Anvils: AnvilContext{"forge": "/path/to/forge"},
+	})
+	if !strings.Contains(p, "Default to ONE bead") {
+		t.Errorf("emit prompt must default to one bead, got %q", p)
+	}
+	if !strings.Contains(p, "one branch, one sitting, one PR") {
+		t.Errorf("emit prompt should include the one-developer-one-PR heuristic, got %q", p)
+	}
+	if !strings.Contains(p, "phases") {
+		t.Errorf("emit prompt should explicitly warn against splitting by phase, got %q", p)
+	}
+}
+
 func TestInterpretResponse_EmitParsesEnvelope(t *testing.T) {
 	out := "```json\n" +
 		`{"beads":[{"id":"p1","anvil":"a","title":"X","description":"d","type":"task","priority":2}]}` +


### PR DESCRIPTION
## Changes

- **Beads-Forge over-splitting** - The emit-stage prompt now defaults to ONE bead per cohesive deliverable instead of one bead per verb (audit / migrate / test). It only splits when work crosses meaningful boundaries — different anvils, independent reviewers, or genuine cross-day blockers — using the heuristic "would a single developer do this in one branch, one sitting, one PR?". Adds a concrete few-shot example (a single dependency upgrade) and a counter-example (cross-surface migration) so the model recognises the right granularity. (Forge-0dz9)

## Original Issue (bug): Beads-Forge over-splits simple tasks into multiple sequential beads

## Problem

The Beads-Forge final stage emits multiple sequential beads for work that is plainly a single self-contained task. Concrete example from today: a react-day-picker v9→v10 dependency upgrade on the munin client produced FOUR beads:

- Fhi.Metadata-lenyo — Audit react-day-picker usage in munin client
- Fhi.Metadata-xmrma — Bump react-day-picker to ^10.0.0 and resolve peer deps
- Fhi.Metadata-5hziz — Migrate munin client source to react-day-picker v10 API
- Fhi.Metadata-2kogb — Update tests and perform visual QA for react-day-picker v10

This is one PR's worth of work that any human dev would do in one sitting, in one branch, against one reviewer. Splitting it produces:
- Artificial sequencing overhead (each bead has its own Smith → Temper → Warden → PR cycle).
- Multi-PR chains that are harder to review than a single coherent diff.
- Worker thrash: temper has to re-run npm install/build at every step.
- A trail of beads to close by hand when the human collapses them back into one PR anyway.

All four beads were closed and replaced with a single Fhi.Metadata-fel9j covering the whole upgrade.

## Proposed fix

Retune the prompt that decides whether to emit one bead vs many in the Beads-Forge \"grilling → ready → create\" transition. Default to ONE bead unless the work crosses meaningful boundaries — see Design below for the heuristic. The current behaviour appears to be \"if you can list more than one phase, split it,\" which produces a bead per Verb (\"audit\", \"migrate\", \"test\") instead of per Deliverable.

---
Bead: Forge-0dz9 | Branch: forge/Forge-0dz9
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->