### PR TITLE
Bellows leaves monitoring worker for closed external PR after bellows_managed flip (Forge-ck69)

### DIFF
--- a/changelog.d/Forge-ck69.md
+++ b/changelog.d/Forge-ck69.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bellows orphan-worker sweep** - Every poll cycle now transitions any bellows worker stuck in `monitoring` whose underlying PR is missing or in a terminal status (`merged`/`closed`) to `done`. This clears stranded Hearth Workers panel entries left behind when an external PR is closed on GitHub before being assigned to bellows. (Forge-ck69)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -280,31 +280,19 @@ func (m *Monitor) reconcileTerminalStates(ctx context.Context) {
 // checkPR; the sweep is a no-op for them because the worker is already
 // "done" before this pass runs.
 func (m *Monitor) sweepOrphanedMonitoringWorkers() {
-	workers, err := m.db.MonitoringBellowsWorkers()
+	orphans, err := m.db.OrphanedMonitoringBellowsWorkers()
 	if err != nil {
-		log.Printf("[bellows] sweepOrphanedMonitoringWorkers: error listing monitoring workers: %v", err)
+		log.Printf("[bellows] sweepOrphanedMonitoringWorkers: error listing orphaned workers: %v", err)
 		return
 	}
-	for _, w := range workers {
-		if w.PRNumber == 0 {
-			continue
-		}
-		pr, err := m.db.GetPRByNumber(w.Anvil, w.PRNumber)
-		if err != nil {
-			log.Printf("[bellows] sweepOrphanedMonitoringWorkers: error looking up PR for worker %s: %v", w.ID, err)
-			continue
-		}
-		orphan := pr == nil || pr.Status == state.PRMerged || pr.Status == state.PRClosed
-		if !orphan {
-			continue
-		}
+	for _, o := range orphans {
 		reason := "no matching PR row"
-		if pr != nil {
-			reason = fmt.Sprintf("PR status=%s", pr.Status)
+		if o.PRStatus != "" {
+			reason = fmt.Sprintf("PR status=%s", o.PRStatus)
 		}
-		log.Printf("[bellows] Sweeping orphaned monitoring worker %s (%s)", w.ID, reason)
-		if err := m.db.UpdateWorkerStatus(w.ID, state.WorkerDone); err != nil {
-			log.Printf("[bellows] sweepOrphanedMonitoringWorkers: failed to update worker %s to done: %v", w.ID, err)
+		log.Printf("[bellows] Sweeping orphaned monitoring worker %s (%s)", o.WorkerID, reason)
+		if err := m.db.UpdateWorkerStatus(o.WorkerID, state.WorkerDone); err != nil {
+			log.Printf("[bellows] sweepOrphanedMonitoringWorkers: failed to update worker %s to done: %v", o.WorkerID, err)
 		}
 	}
 }

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -269,8 +269,50 @@ func (m *Monitor) reconcileTerminalStates(ctx context.Context) {
 	}
 }
 
+// sweepOrphanedMonitoringWorkers transitions any bellows worker stuck in
+// "monitoring" whose underlying PR is terminal (merged/closed) or missing
+// from the prs table to "done". This covers the case where an unmanaged
+// external PR's prs.status was persisted as merged/closed before it was
+// flipped to bellows_managed=1: from that point on OpenPRs() never surfaces
+// it again, so checkPR's CompleteWorkersByBead path cannot fire and the
+// worker would otherwise remain in monitoring forever. Forge-managed PRs
+// continue to transition via the existing CompleteWorkersByBead call in
+// checkPR; the sweep is a no-op for them because the worker is already
+// "done" before this pass runs.
+func (m *Monitor) sweepOrphanedMonitoringWorkers() {
+	workers, err := m.db.MonitoringBellowsWorkers()
+	if err != nil {
+		log.Printf("[bellows] sweepOrphanedMonitoringWorkers: error listing monitoring workers: %v", err)
+		return
+	}
+	for _, w := range workers {
+		if w.PRNumber == 0 {
+			continue
+		}
+		pr, err := m.db.GetPRByNumber(w.Anvil, w.PRNumber)
+		if err != nil {
+			log.Printf("[bellows] sweepOrphanedMonitoringWorkers: error looking up PR for worker %s: %v", w.ID, err)
+			continue
+		}
+		orphan := pr == nil || pr.Status == state.PRMerged || pr.Status == state.PRClosed
+		if !orphan {
+			continue
+		}
+		reason := "no matching PR row"
+		if pr != nil {
+			reason = fmt.Sprintf("PR status=%s", pr.Status)
+		}
+		log.Printf("[bellows] Sweeping orphaned monitoring worker %s (%s)", w.ID, reason)
+		if err := m.db.UpdateWorkerStatus(w.ID, state.WorkerDone); err != nil {
+			log.Printf("[bellows] sweepOrphanedMonitoringWorkers: failed to update worker %s to done: %v", w.ID, err)
+		}
+	}
+}
+
 // checkAll polls all open PRs and emits events for state changes.
 func (m *Monitor) checkAll(ctx context.Context) {
+	m.sweepOrphanedMonitoringWorkers()
+
 	prs, err := m.db.OpenPRs()
 	if err != nil {
 		log.Printf("[bellows] Error listing open PRs: %v", err)

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -1092,3 +1092,146 @@ func TestReconcileTerminalStates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, state.PROpen, updated.Status, "reconcile must not touch open rows (checkAll handles those)")
 }
+
+// TestSweepOrphanedMonitoringWorkers_TerminalPR is the primary regression test
+// for the orphaned-worker bug: when an ext-* PR's prs.status is already
+// merged/closed (because the unmanaged early-return persisted it before the
+// user flipped bellows_managed=1), OpenPRs() never surfaces it again, so the
+// normal CompleteWorkersByBead path in checkPR cannot fire. The sweep must
+// transition the stranded worker to "done" on its own.
+func TestSweepOrphanedMonitoringWorkers_TerminalPR(t *testing.T) {
+	cases := []struct {
+		name      string
+		prStatus  state.PRStatus
+		wantSwept bool
+	}{
+		{name: "merged ext-* PR sweeps its monitoring worker", prStatus: state.PRMerged, wantSwept: true},
+		{name: "closed ext-* PR sweeps its monitoring worker", prStatus: state.PRClosed, wantSwept: true},
+		{name: "open ext-* PR leaves monitoring worker in place", prStatus: state.PROpen, wantSwept: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, cleanup := openTempDB(t)
+			defer cleanup()
+
+			pr := &state.PR{
+				Number:         3073,
+				Anvil:          "munin",
+				BeadID:         "ext-3073",
+				Branch:         "feature/ext-3073",
+				Status:         state.PROpen,
+				BellowsManaged: true,
+				CreatedAt:      time.Now(),
+			}
+			require.NoError(t, db.InsertPR(pr))
+			require.NoError(t, db.UpdatePRStatus(pr.ID, tc.prStatus))
+
+			workerID := "bellows-munin-3073"
+			require.NoError(t, db.InsertWorker(&state.Worker{
+				ID:        workerID,
+				BeadID:    pr.BeadID,
+				Anvil:     pr.Anvil,
+				Branch:    pr.Branch,
+				Status:    state.WorkerMonitoring,
+				Phase:     "bellows",
+				PRNumber:  pr.Number,
+				StartedAt: time.Now(),
+			}))
+
+			m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil)
+			m.sweepOrphanedMonitoringWorkers()
+
+			workers, err := db.WorkersByBead(pr.BeadID, pr.Anvil, 0)
+			require.NoError(t, err)
+			require.Len(t, workers, 1)
+
+			if tc.wantSwept {
+				assert.Equal(t, state.WorkerDone, workers[0].Status, "sweep must transition orphaned worker to done")
+				require.NotNil(t, workers[0].CompletedAt, "completed_at must be set on swept worker")
+				completed, err := db.CompletedWorkers(0)
+				require.NoError(t, err)
+				found := false
+				for _, w := range completed {
+					if w.ID == workerID {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "swept worker must surface in CompletedWorkers")
+			} else {
+				assert.Equal(t, state.WorkerMonitoring, workers[0].Status, "sweep must not touch monitoring workers whose PR is still open")
+			}
+		})
+	}
+}
+
+// TestSweepOrphanedMonitoringWorkers_MissingPR verifies that a monitoring
+// bellows worker whose prs row has been deleted is still swept to done. This
+// guards against the orphan persisting after a manual SQL tweak or a future
+// code path that removes a PR row without completing its worker.
+func TestSweepOrphanedMonitoringWorkers_MissingPR(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	workerID := "bellows-munin-9999"
+	require.NoError(t, db.InsertWorker(&state.Worker{
+		ID:        workerID,
+		BeadID:    "ext-9999",
+		Anvil:     "munin",
+		Branch:    "feature/missing",
+		Status:    state.WorkerMonitoring,
+		Phase:     "bellows",
+		PRNumber:  9999,
+		StartedAt: time.Now(),
+	}))
+
+	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil)
+	m.sweepOrphanedMonitoringWorkers()
+
+	workers, err := db.WorkersByBead("ext-9999", "munin", 0)
+	require.NoError(t, err)
+	require.Len(t, workers, 1)
+	assert.Equal(t, state.WorkerDone, workers[0].Status)
+	require.NotNil(t, workers[0].CompletedAt)
+}
+
+// TestSweepOrphanedMonitoringWorkers_IgnoresNonBellowsWorkers verifies that
+// the sweep is scoped to phase=bellows and status=monitoring — pipeline
+// workers in other phases or statuses must remain untouched.
+func TestSweepOrphanedMonitoringWorkers_IgnoresNonBellowsWorkers(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    100,
+		Anvil:     "munin",
+		BeadID:    "forge-running",
+		Branch:    "forge/forge-running",
+		Status:    state.PRMerged, // terminal — would be swept if phase matched
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRStatus(pr.ID, state.PRMerged))
+
+	// A non-bellows worker (e.g. a smith) — must not be swept even if its
+	// bead's PR is merged.
+	require.NoError(t, db.InsertWorker(&state.Worker{
+		ID:        "smith-forge-running",
+		BeadID:    pr.BeadID,
+		Anvil:     pr.Anvil,
+		Branch:    pr.Branch,
+		Status:    state.WorkerRunning,
+		Phase:     "smith",
+		PRNumber:  pr.Number,
+		StartedAt: time.Now(),
+	}))
+
+	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil)
+	m.sweepOrphanedMonitoringWorkers()
+
+	w, err := db.WorkersByBead(pr.BeadID, pr.Anvil, 0)
+	require.NoError(t, err)
+	require.Len(t, w, 1)
+	assert.Equal(t, state.WorkerRunning, w[0].Status, "non-bellows workers must not be affected by the sweep")
+}

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -152,6 +152,11 @@ func (db *DB) migrate() error {
 	if _, err := db.conn.Exec(`CREATE INDEX IF NOT EXISTS idx_retries_clarification ON retries(clarification_needed)`); err != nil {
 		return fmt.Errorf("creating clarification index: %w", err)
 	}
+	// Composite index for fast PR lookups by (anvil, number) — used by the
+	// bellows orphan sweep JOIN and GetPRByNumber.
+	if _, err := db.conn.Exec(`CREATE INDEX IF NOT EXISTS idx_prs_anvil_number ON prs(anvil, number)`); err != nil {
+		return fmt.Errorf("creating prs anvil+number index: %w", err)
+	}
 	return nil
 }
 
@@ -813,17 +818,41 @@ func (db *DB) WorkersByAnvil(anvil string) ([]Worker, error) {
 		ORDER BY started_at DESC`, anvil)
 }
 
-// MonitoringBellowsWorkers returns every worker row whose phase is "bellows"
-// and whose status is "monitoring". The bellows poll loop uses this to sweep
-// orphaned monitoring workers whose underlying PR has reached a terminal
-// state (merged/closed) outside the normal transition path — e.g. an external
-// PR that was closed on GitHub before it was assigned to bellows, so its
-// prs.status is already "closed" by the time OpenPRs would have surfaced it,
-// leaving the worker stranded in monitoring.
-func (db *DB) MonitoringBellowsWorkers() ([]Worker, error) {
-	return db.queryWorkers(`SELECT id, bead_id, anvil, branch, pid, status, phase, title, pr_number, started_at, completed_at, log_path
-		FROM workers WHERE phase = 'bellows' AND status = 'monitoring'
-		ORDER BY started_at`)
+// OrphanedWorkerInfo identifies a bellows monitoring worker whose underlying PR
+// is missing or in a terminal state. PRStatus is empty when no PR row exists.
+type OrphanedWorkerInfo struct {
+	WorkerID string
+	PRStatus string
+}
+
+// OrphanedMonitoringBellowsWorkers returns bellows monitoring workers whose
+// underlying PR is missing or already terminal (merged/closed), using a single
+// LEFT JOIN query rather than per-row GetPRByNumber lookups.
+func (db *DB) OrphanedMonitoringBellowsWorkers() ([]OrphanedWorkerInfo, error) {
+	rows, err := db.conn.Query(`
+		SELECT w.id, COALESCE(latest.status, '') AS pr_status
+		FROM workers w
+		LEFT JOIN (
+			SELECT anvil, number, status
+			FROM prs
+			WHERE id IN (SELECT MAX(id) FROM prs GROUP BY anvil, number)
+		) latest ON latest.anvil = w.anvil AND latest.number = w.pr_number
+		WHERE w.phase = 'bellows' AND w.status = 'monitoring' AND w.pr_number != 0
+		  AND (latest.status IS NULL OR latest.status IN ('merged', 'closed'))
+		ORDER BY w.started_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []OrphanedWorkerInfo
+	for rows.Next() {
+		var o OrphanedWorkerInfo
+		if err := rows.Scan(&o.WorkerID, &o.PRStatus); err != nil {
+			return nil, err
+		}
+		result = append(result, o)
+	}
+	return result, rows.Err()
 }
 
 // CompletedWorkers returns workers in terminal states (done, failed, timeout),

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -813,6 +813,19 @@ func (db *DB) WorkersByAnvil(anvil string) ([]Worker, error) {
 		ORDER BY started_at DESC`, anvil)
 }
 
+// MonitoringBellowsWorkers returns every worker row whose phase is "bellows"
+// and whose status is "monitoring". The bellows poll loop uses this to sweep
+// orphaned monitoring workers whose underlying PR has reached a terminal
+// state (merged/closed) outside the normal transition path — e.g. an external
+// PR that was closed on GitHub before it was assigned to bellows, so its
+// prs.status is already "closed" by the time OpenPRs would have surfaced it,
+// leaving the worker stranded in monitoring.
+func (db *DB) MonitoringBellowsWorkers() ([]Worker, error) {
+	return db.queryWorkers(`SELECT id, bead_id, anvil, branch, pid, status, phase, title, pr_number, started_at, completed_at, log_path
+		FROM workers WHERE phase = 'bellows' AND status = 'monitoring'
+		ORDER BY started_at`)
+}
+
 // CompletedWorkers returns workers in terminal states (done, failed, timeout),
 // ordered by most recently completed first. Limit 0 means no limit.
 func (db *DB) CompletedWorkers(limit int) ([]Worker, error) {


### PR DESCRIPTION
## Changes

- **Bellows orphan-worker sweep** - Every poll cycle now transitions any bellows worker stuck in `monitoring` whose underlying PR is missing or in a terminal status (`merged`/`closed`) to `done`. This clears stranded Hearth Workers panel entries left behind when an external PR is closed on GitHub before being assigned to bellows. (Forge-ck69)

## Original Issue (bug): Bellows leaves monitoring worker for closed external PR after bellows_managed flip

## Problem

When a user manually assigns bellows to an external PR (`ext-*`, `bellows_managed=1`) and the PR later closes or merges on GitHub, the bellows worker row in `state.db` stays in `monitoring` indefinitely. Hearth 2.0 keeps surfacing it under Workers even though the underlying PR is terminal.

Concrete: on skybert-forge today (2026-05-13) the worker `bellows-munin-3073` for ext-3073 was still `monitoring` after the user closed PR #3073 on GitHub. The companion ext-3082 worker (still open) was correctly active. After manual cleanup
```sql
UPDATE workers SET status='done', completed_at='2026-05-13T06:59:48.765714Z' WHERE id='bellows-munin-3073';
```
the panel cleared. By contrast, Forge-created PRs (`bellows_managed=1` from creation) transition cleanly via `CompleteWorkersByBead(pr.BeadID)` inside `checkPR` — the bug is specific to ext-* PRs that flip from unmanaged → managed.

## Root cause

In `internal/bellows/bellows.go` the two relevant code paths are:

1. **Unmanaged ext-* early-return** (around line 456-465 in `checkPR`): for `ext-* && !bellows_managed`, the function persists merged/closed status unconditionally and returns. So an ext-* PR can be sitting at `prs.status=merged` or `prs.status=closed` in our DB *before* the user clicks "assign bellows".
2. **Managed terminal-detection branches** (around lines 476 and 517 in `checkPR`): the `IsMerged && pr.Status != PRMerged` and `IsClosed && pr.Status != PRClosed` branches are the ones that call `CompleteWorkersByBead(pr.BeadID)`. They are gated on `pr.Status` not already being terminal.
3. **`OpenPRs()` filter** (`internal/state/db.go:1035`): only returns PRs whose status is non-terminal. So once the PR is at `prs.status=merged|closed`, it falls out of the poll set entirely.

Sequence that produces the bug:
- ext-3073 exists with `bellows_managed=0`, `status=open`.
- User merges/closes the PR on GitHub.
- One bellows poll cycle later, the unmanaged-path early-return persists `prs.status=closed`.
- User now flips `bellows_managed=1` (via the assign-bellows IPC/API). A worker row `bellows-munin-3073` is created with `status=monitoring`.
- From this point on `OpenPRs()` never returns ext-3073 again, so `checkPR` never runs for it, so the managed terminal-detection branches never fire, so `CompleteWorkersByBead` is never called. The worker row is orphaned in `monitoring`.

The same bug can also happen in the reverse order if the assignment happened first AND the close fired between two polls AND the cached `lastStatuses` was wiped (e.g. daemon restart): the snapshot seeding can mask the open→closed transition. The dominant scenario is the one above, however.

## Proposed fix

One or both of the following — option A is the smaller, more surgical fix and is the recommended path:

**Option A (preferred): orphan-worker sweep in bellows.**

At the start of each `checkAll` poll (or as a sibling pass in `Run`), enumerate workers where `phase='bellows'` and `status='monitoring'`, and for each one look up the corresponding PR row. If the PR is in a terminal status (`merged`, `closed`) — or has no matching PR row at all — call `db.UpdateWorkerStatus(workerID, WorkerDone)` with `completed_at=now`. Net add: ~15 lines in `internal/bellows/bellows.go` plus a helper on `state.DB` to enumerate monitoring bellows workers.

**Option B (complementary): close the race on bellows assignment.**

In the IPC handler that flips `bellows_managed=0 → 1` (find via `grep -rn "bellows_managed" cmd/ internal/`), check the persisted `prs.status` and refuse to create a `monitoring` worker if the PR is already in a terminal state — or proactively call the terminal-branch logic (event emit + ingot update + no worker insert). This prevents the orphan from being created in the first place.

A also catches any *other* path that could leave a bellows worker stranded (e.g. a future bug, a manual SQL tweak, a daemon-restart-mid-merge scenario), so it is the safer long-term fix.

## Acceptance

- Manually creating the buggy state and running one bellows poll cycle transitions the orphaned worker to `done`:
  1. With Forge running, create or pick an `ext-*` PR row, set `bellows_managed=0`.
  2. Close it on GitHub.
  3. After the next bellows poll, confirm `prs.status=closed` (or `=merged`).
  4. Set `bellows_managed=1` for that row and insert a `bellows-<anvil>-<num>` worker with `status=monitoring` (mimics the IPC flip path).
  5. Within one bellows poll cycle, the worker should transition to `status=done` with `completed_at` set.
- The Hearth 2.0 Workers panel no longer shows bellows entries for terminal-state external PRs.
- `CompletedWorkers` returns the swept worker so it appears in history rather than just disappearing.
- Forge-managed (`bellows-managed=1` since creation) PRs continue to follow the existing `CompleteWorkersByBead` path — no regression there.
- A unit test covers the orphan-sweep path: insert a bellows monitoring worker whose PR is in `merged` status, run one pass of the sweep, assert worker is `done`.

---
Bead: Forge-ck69 | Branch: forge/Forge-ck69
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->