### PR TITLE
Bellows does not re-emit EventReviewChanges when unresolved threads persist across review-fix cycles (Forge-gwu4)

### DIFF
--- a/changelog.d/Forge-gwu4.md
+++ b/changelog.d/Forge-gwu4.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bellows re-emits EventReviewChanges when unresolved threads persist after a burnish cycle** - Mirrors the CI-fix still-failing branch on the review-fix path so PRs with new review comments after a completed burnish reliably trigger a fresh burnish on the next bellows poll. Respects `max_review_fix_attempts` and skips PRs already in `needs_fix`. (Forge-gwu4)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -426,6 +426,12 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 			HasPendingReviews:    pr.HasPendingReviews,
 			IsConflicting:        conflictSeed,
 			HasUnresolvedThreads: threadsSeed,
+			// PRStatus.NeedsChanges() returns true when unresolved threads exist,
+			// so without seeding this in lockstep with threadsSeed the primary
+			// review-changes branch would re-fire on the first poll for any PR
+			// already in needs_fix or post-fix state — masking the secondary
+			// still-unresolved retry branch and dispatching duplicates.
+			NeedsChanges: threadsSeed,
 		}
 	}
 	// When CI is still in progress, preserve the last *completed* CIPassing value

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -57,16 +57,17 @@ type Handler func(ctx context.Context, event PREvent)
 // Monitor watches open PRs and dispatches events on status changes.
 type Monitor struct {
 	db               *state.DB
-	vcsLookup        func(anvil string) vcs.Provider
-	interval         time.Duration
-	anvilPaths       map[string]string // anvil name → path
-	pathsMu          sync.RWMutex      // protects anvilPaths
-	handlers         []Handler
-	mu               sync.Mutex
-	lastStatuses     map[string]*prSnapshot // anvil/PR number → last known state
-	refresh          chan struct{}          // channel to trigger immediate poll
-	autoLearnRules   func() bool            // auto-learn warden rules from Copilot comments on PR merge
-	maxCIFixAttempts func() int             // returns current max CI fix attempts from config
+	vcsLookup            func(anvil string) vcs.Provider
+	interval             time.Duration
+	anvilPaths           map[string]string // anvil name → path
+	pathsMu              sync.RWMutex      // protects anvilPaths
+	handlers             []Handler
+	mu                   sync.Mutex
+	lastStatuses         map[string]*prSnapshot // anvil/PR number → last known state
+	refresh              chan struct{}          // channel to trigger immediate poll
+	autoLearnRules       func() bool            // auto-learn warden rules from Copilot comments on PR merge
+	maxCIFixAttempts     func() int             // returns current max CI fix attempts from config
+	maxReviewFixAttempts func() int             // returns current max review fix attempts from config
 	learnMuGuard     sync.Mutex             // protects learnMu map
 	learnMu          map[string]*sync.Mutex // per-anvil mutex serializing auto-learn
 	learnSem         chan struct{}          // caps overall concurrent auto-learn goroutines
@@ -92,28 +93,33 @@ type prSnapshot struct {
 // provider for a given anvil name, enabling per-anvil platform support.
 // The autoLearnRules function is called on each PR merge to check whether
 // warden rule learning is enabled, so hot-reloaded config changes take effect
-// without restarting the daemon. The maxCIFixAttempts function returns the
-// current max CI fix attempts from config (may be nil, in which case the
-// state.DefaultMaxCIFixAttempts is used).
-func New(db *state.DB, vcsLookup func(anvil string) vcs.Provider, interval time.Duration, anvilPaths map[string]string, autoLearnRules func() bool, maxCIFixAttempts func() int) *Monitor {
+// without restarting the daemon. The maxCIFixAttempts and maxReviewFixAttempts
+// functions return the current max fix attempts from config (either may be nil,
+// in which case state.DefaultMaxCIFixAttempts / state.DefaultMaxReviewFixAttempts
+// is used).
+func New(db *state.DB, vcsLookup func(anvil string) vcs.Provider, interval time.Duration, anvilPaths map[string]string, autoLearnRules func() bool, maxCIFixAttempts func() int, maxReviewFixAttempts func() int) *Monitor {
 	if interval < 30*time.Second {
 		interval = 30 * time.Second
 	}
 	if maxCIFixAttempts == nil {
 		maxCIFixAttempts = func() int { return state.DefaultMaxCIFixAttempts }
 	}
+	if maxReviewFixAttempts == nil {
+		maxReviewFixAttempts = func() int { return state.DefaultMaxReviewFixAttempts }
+	}
 	return &Monitor{
-		db:               db,
-		vcsLookup:        vcsLookup,
-		interval:         interval,
-		anvilPaths:       anvilPaths,
-		lastStatuses:     make(map[string]*prSnapshot),
-		refresh:          make(chan struct{}, 1),
-		autoLearnRules:   autoLearnRules,
-		maxCIFixAttempts: maxCIFixAttempts,
-		learnMu:          make(map[string]*sync.Mutex),
-		learnSem:         make(chan struct{}, 4), // allow up to 4 concurrent auto-learn goroutines
-		wasUnmanaged:     make(map[string]bool),
+		db:                   db,
+		vcsLookup:            vcsLookup,
+		interval:             interval,
+		anvilPaths:           anvilPaths,
+		lastStatuses:         make(map[string]*prSnapshot),
+		refresh:              make(chan struct{}, 1),
+		autoLearnRules:       autoLearnRules,
+		maxCIFixAttempts:     maxCIFixAttempts,
+		maxReviewFixAttempts: maxReviewFixAttempts,
+		learnMu:              make(map[string]*sync.Mutex),
+		learnSem:             make(chan struct{}, 4), // allow up to 4 concurrent auto-learn goroutines
+		wasUnmanaged:         make(map[string]bool),
 	}
 }
 
@@ -633,6 +639,26 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 		_ = m.db.UpdatePRStatus(pr.ID, state.PRNeedsFix)
 		_ = m.db.LogEvent(state.EventReviewChanges, fmt.Sprintf("PR #%d: %s", pr.Number, details), pr.BeadID, pr.Anvil)
 		_ = m.db.LogEvent(state.EventPRNeedsFix, fmt.Sprintf("PR #%d: review fix needed", pr.Number), pr.BeadID, pr.Anvil)
+	} else if newSnap.HasUnresolvedThreads && lastSnap.HasUnresolvedThreads {
+		// Review still has unresolved threads with no transition. Catches the gap
+		// where NotifyReviewFixCompleted() resets pr.Status to open after a burnish
+		// cycle but bellows never re-emits EventReviewChanges because threads stayed
+		// > 0 across the cycle. Mirrors the CI-fix still-failing branch above.
+		maxR := m.maxReviewFixAttempts()
+		if pr.Status != state.PRNeedsFix && pr.ReviewFixCount > 0 && pr.ReviewFixCount < maxR {
+			m.emit(ctx, PREvent{
+				PRNumber:  pr.Number,
+				BeadID:    pr.BeadID,
+				Anvil:     pr.Anvil,
+				Branch:    status.HeadRefName,
+				EventType: EventReviewChanges,
+				Details:   fmt.Sprintf("PR still has unresolved review threads after fix attempt %d/%d", pr.ReviewFixCount, maxR),
+				Timestamp: time.Now(),
+			})
+			_ = m.db.UpdatePRStatus(pr.ID, state.PRNeedsFix)
+			_ = m.db.LogEvent(state.EventReviewChanges, fmt.Sprintf("PR #%d review fix retry needed (attempt %d/%d)", pr.Number, pr.ReviewFixCount, maxR), pr.BeadID, pr.Anvil)
+			_ = m.db.LogEvent(state.EventPRNeedsFix, fmt.Sprintf("PR #%d review fix retry needed", pr.Number), pr.BeadID, pr.Anvil)
+		}
 	}
 
 	// If all merge-readiness conditions are met and the PR was in needs_fix,

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -1369,7 +1369,7 @@ func TestSweepOrphanedMonitoringWorkers_TerminalPR(t *testing.T) {
 				StartedAt: time.Now(),
 			}))
 
-			m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil)
+			m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil)
 			m.sweepOrphanedMonitoringWorkers()
 
 			workers, err := db.WorkersByBead(pr.BeadID, pr.Anvil, 0)
@@ -1416,7 +1416,7 @@ func TestSweepOrphanedMonitoringWorkers_MissingPR(t *testing.T) {
 		StartedAt: time.Now(),
 	}))
 
-	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil)
 	m.sweepOrphanedMonitoringWorkers()
 
 	workers, err := db.WorkersByBead("ext-9999", "munin", 0)
@@ -1457,7 +1457,7 @@ func TestSweepOrphanedMonitoringWorkers_IgnoresNonBellowsWorkers(t *testing.T) {
 		StartedAt: time.Now(),
 	}))
 
-	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil)
 	m.sweepOrphanedMonitoringWorkers()
 
 	w, err := db.WorkersByBead(pr.BeadID, pr.Anvil, 0)

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -18,22 +18,22 @@ import (
 
 func TestNew_MinimumInterval(t *testing.T) {
 	// Intervals below 30s should be clamped to 30s
-	m := New(nil, nil, 5*time.Second, nil, nil, nil)
+	m := New(nil, nil, 5*time.Second, nil, nil, nil, nil)
 	assert.Equal(t, 30*time.Second, m.interval)
 }
 
 func TestNew_IntervalAboveMin(t *testing.T) {
-	m := New(nil, nil, 2*time.Minute, nil, nil, nil)
+	m := New(nil, nil, 2*time.Minute, nil, nil, nil, nil)
 	assert.Equal(t, 2*time.Minute, m.interval)
 }
 
 func TestNew_ExactMinimum(t *testing.T) {
-	m := New(nil, nil, 30*time.Second, nil, nil, nil)
+	m := New(nil, nil, 30*time.Second, nil, nil, nil, nil)
 	assert.Equal(t, 30*time.Second, m.interval)
 }
 
 func TestOnEvent_RegistersHandler(t *testing.T) {
-	m := New(nil, nil, time.Minute, nil, nil, nil)
+	m := New(nil, nil, time.Minute, nil, nil, nil, nil)
 	m.mu.Lock()
 	initial := len(m.handlers)
 	m.mu.Unlock()
@@ -48,7 +48,7 @@ func TestOnEvent_RegistersHandler(t *testing.T) {
 }
 
 func TestEmit_DispatchesToAllHandlers(t *testing.T) {
-	m := New(nil, nil, time.Minute, nil, nil, nil)
+	m := New(nil, nil, time.Minute, nil, nil, nil, nil)
 
 	var mu sync.Mutex
 	var received []string
@@ -262,13 +262,14 @@ func TestSnapshotTransitionLogic(t *testing.T) {
 // returning the event types that would be emitted for a given state change.
 // This is used only in tests to verify the logic is correct.
 func computeTransitionEvents(old, new *prSnapshot) []string {
-	return computeTransitionEventsWithPR(old, new, "", 0, 5)
+	return computeTransitionEventsWithPR(old, new, "", 0, 5, 0, 5)
 }
 
 // computeTransitionEventsWithPR extends computeTransitionEvents with PR-level
-// state for the secondary CI retry check. prStatus and ciFixCount come from
-// the state.PR record; maxCI is the configured max CI fix attempts.
-func computeTransitionEventsWithPR(old, new *prSnapshot, prStatus string, ciFixCount, maxCI int) []string {
+// state for the secondary CI and review-fix retry checks. prStatus, ciFixCount
+// and reviewFixCount come from the state.PR record; maxCI / maxReview are the
+// configured caps.
+func computeTransitionEventsWithPR(old, new *prSnapshot, prStatus string, ciFixCount, maxCI, reviewFixCount, maxReview int) []string {
 	var events []string
 
 	if new.IsMerged && !old.IsMerged {
@@ -294,6 +295,11 @@ func computeTransitionEventsWithPR(old, new *prSnapshot, prStatus string, ciFixC
 
 	if (new.NeedsChanges && !old.NeedsChanges) || (new.HasUnresolvedThreads && !old.HasUnresolvedThreads) {
 		events = append(events, EventReviewChanges)
+	} else if new.HasUnresolvedThreads && old.HasUnresolvedThreads {
+		// Secondary check: review threads still unresolved after a completed fix attempt.
+		if prStatus != "needs_fix" && reviewFixCount > 0 && reviewFixCount < maxReview {
+			events = append(events, EventReviewChanges)
+		}
 	}
 
 	if new.IsConflicting && !old.IsConflicting {
@@ -370,7 +376,7 @@ func TestCheckAll_BellowsManagedPRsGetWorkerRow(t *testing.T) {
 	require.NoError(t, db.InsertPR(extUnmanaged))
 	require.NoError(t, db.UpdatePRBellowsManaged(extUnmanaged.ID, false))
 
-	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil)
 	m.checkAll(context.Background())
 
 	workers, err := db.ActiveWorkers()
@@ -402,7 +408,7 @@ func TestCheckAll_WorkerRowNotDuplicatedOnRepeatPolls(t *testing.T) {
 	}
 	require.NoError(t, db.InsertPR(pr))
 
-	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil)
 	m.checkAll(context.Background())
 	m.checkAll(context.Background())
 	m.checkAll(context.Background())
@@ -508,7 +514,7 @@ func TestCIFixRetryLogic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fired := computeTransitionEventsWithPR(&tt.old, &tt.new, tt.prStatus, tt.ciFixCount, tt.maxCI)
+			fired := computeTransitionEventsWithPR(&tt.old, &tt.new, tt.prStatus, tt.ciFixCount, tt.maxCI, 0, 5)
 			if tt.wantCIFail {
 				assert.Contains(t, fired, EventCIFailed)
 			} else {
@@ -516,6 +522,230 @@ func TestCIFixRetryLogic(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReviewFixRetryLogic verifies the secondary review-changes detection that
+// re-emits EventReviewChanges when a previous burnish attempt completed but
+// the PR still has unresolved review threads. Mirrors TestCIFixRetryLogic for
+// the review-fix path (Forge-gwu4).
+func TestReviewFixRetryLogic(t *testing.T) {
+	tests := []struct {
+		name           string
+		old            prSnapshot
+		new            prSnapshot
+		prStatus       string
+		reviewFixCount int
+		maxReview      int
+		wantReview     bool
+	}{
+		{
+			name:           "threads still unresolved, fix completed (status=open), retries remain → review_changes",
+			old:            prSnapshot{HasUnresolvedThreads: true},
+			new:            prSnapshot{HasUnresolvedThreads: true},
+			prStatus:       "open",
+			reviewFixCount: 1,
+			maxReview:      5,
+			wantReview:     true,
+		},
+		{
+			name:           "threads still unresolved, fix in progress (status=needs_fix) → no event",
+			old:            prSnapshot{HasUnresolvedThreads: true},
+			new:            prSnapshot{HasUnresolvedThreads: true},
+			prStatus:       "needs_fix",
+			reviewFixCount: 1,
+			maxReview:      5,
+			wantReview:     false,
+		},
+		{
+			name:           "threads still unresolved, max attempts reached → no event",
+			old:            prSnapshot{HasUnresolvedThreads: true},
+			new:            prSnapshot{HasUnresolvedThreads: true},
+			prStatus:       "open",
+			reviewFixCount: 5,
+			maxReview:      5,
+			wantReview:     false,
+		},
+		{
+			name:           "threads still unresolved, no previous fix attempts → no event",
+			old:            prSnapshot{HasUnresolvedThreads: true},
+			new:            prSnapshot{HasUnresolvedThreads: true},
+			prStatus:       "open",
+			reviewFixCount: 0,
+			maxReview:      5,
+			wantReview:     false,
+		},
+		{
+			name:           "threads still unresolved, attempt 4 of 5 → review_changes",
+			old:            prSnapshot{HasUnresolvedThreads: true},
+			new:            prSnapshot{HasUnresolvedThreads: true},
+			prStatus:       "open",
+			reviewFixCount: 4,
+			maxReview:      5,
+			wantReview:     true,
+		},
+		{
+			name:           "threads transition 0→>0 still fires via primary branch",
+			old:            prSnapshot{HasUnresolvedThreads: false},
+			new:            prSnapshot{HasUnresolvedThreads: true},
+			prStatus:       "open",
+			reviewFixCount: 0,
+			maxReview:      5,
+			wantReview:     true,
+		},
+		{
+			name:           "genuinely zero threads on both polls → no event",
+			old:            prSnapshot{HasUnresolvedThreads: false},
+			new:            prSnapshot{HasUnresolvedThreads: false},
+			prStatus:       "open",
+			reviewFixCount: 1,
+			maxReview:      5,
+			wantReview:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fired := computeTransitionEventsWithPR(&tt.old, &tt.new, tt.prStatus, 0, 5, tt.reviewFixCount, tt.maxReview)
+			if tt.wantReview {
+				assert.Contains(t, fired, EventReviewChanges)
+			} else {
+				assert.NotContains(t, fired, EventReviewChanges)
+			}
+		})
+	}
+}
+
+// TestCheckPR_ReviewStillUnresolved_ReemitsEvent is the end-to-end regression
+// test for Forge-gwu4: after a burnish cycle completes (PR.Status flipped back
+// to open, ReviewFixCount=1) and unresolved review threads remain, the next
+// bellows poll must re-emit EventReviewChanges and flip the PR back to
+// needs_fix so a new burnish dispatches.
+func TestCheckPR_ReviewStillUnresolved_ReemitsEvent(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	// Insert a PR that already went through one burnish cycle: open status,
+	// ReviewFixCount=1, threads still unresolved. The seeding guard at
+	// bellows.go:415-417 preserves HasUnresolvedThreads=true when
+	// ReviewFixCount > 0, so lastSnap.HasUnresolvedThreads=true on the first
+	// poll. Combined with newSnap.HasUnresolvedThreads=true from the VCS
+	// status, the primary transition branch (new && !last) cannot fire — only
+	// the secondary "still unresolved" branch can.
+	pr := &state.PR{
+		Number:         700,
+		Anvil:          "test-anvil",
+		BeadID:         "forge-stillunresolved",
+		Branch:         "forge/forge-stillunresolved",
+		Status:         state.PROpen,
+		ReviewFixCount: 1,
+		CreatedAt:      time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	// InsertPR does not write the mergeability flags; set them explicitly.
+	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, false, true, false, false))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:             "OPEN",
+		UnresolvedThreads: 2,
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil,
+		func() int { return 5 })
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.Contains(t, events, EventReviewChanges,
+		"EventReviewChanges must re-fire when threads stay unresolved across a burnish cycle")
+
+	updated, err := db.GetPRByID(pr.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.PRNeedsFix, updated.Status,
+		"PR must be flipped back to needs_fix so a new burnish dispatches")
+}
+
+// TestCheckPR_ReviewStillUnresolved_RespectsMaxAttempts verifies that the
+// retry cap honoured by the still-unresolved branch matches max_review_fix_attempts.
+func TestCheckPR_ReviewStillUnresolved_RespectsMaxAttempts(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:         701,
+		Anvil:          "test-anvil",
+		BeadID:         "forge-reviewcap",
+		Branch:         "forge/forge-reviewcap",
+		Status:         state.PROpen,
+		ReviewFixCount: 5, // at the cap
+		CreatedAt:      time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, false, true, false, false))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:             "OPEN",
+		UnresolvedThreads: 2,
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil,
+		func() int { return 5 })
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventReviewChanges,
+		"EventReviewChanges must NOT fire once the review-fix cap is reached")
+
+	updated, err := db.GetPRByID(pr.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.PROpen, updated.Status,
+		"PR status must not be flipped to needs_fix when the cap is reached")
+}
+
+// TestCheckPR_ReviewStillUnresolved_SkipsInFlightBurnish verifies that a PR
+// already in needs_fix (a burnish is in flight) does not receive a duplicate
+// dispatch from the still-unresolved branch.
+func TestCheckPR_ReviewStillUnresolved_SkipsInFlightBurnish(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:         702,
+		Anvil:          "test-anvil",
+		BeadID:         "forge-reviewinflight",
+		Branch:         "forge/forge-reviewinflight",
+		Status:         state.PRNeedsFix,
+		ReviewFixCount: 1,
+		CreatedAt:      time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, false, true, false, false))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:             "OPEN",
+		UnresolvedThreads: 2,
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil,
+		func() int { return 5 })
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventReviewChanges,
+		"EventReviewChanges must NOT fire while a burnish is already in flight (status=needs_fix)")
 }
 
 // TestCheckPR_CIInProgressDoesNotTriggerFailure verifies that bellows does not
@@ -545,7 +775,7 @@ func TestCheckPR_CIInProgressDoesNotTriggerFailure(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -589,7 +819,7 @@ func TestCheckPR_CICompletedFailureTriggersCIFailed(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -620,7 +850,7 @@ func TestCheckPR_PassingThenInProgressThenFailure(t *testing.T) {
 
 	fake := &fakeVCSProvider{}
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -677,7 +907,7 @@ func TestCheckPR_StatusContextPendingBlocksCIFailed(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -716,7 +946,7 @@ func TestCheckPR_CompletedEmptyConclusionBlocksCIFailed(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -749,7 +979,7 @@ func TestCheckPR_TitleBackfill(t *testing.T) {
 		Title: "My PR title",
 	}}
 
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.checkAll(context.Background())
 
 	updated, err := db.GetPRByID(pr.ID)
@@ -838,7 +1068,7 @@ func TestCheckPR_PRMergedUpdatesIngotStatus(t *testing.T) {
 	seedIngot(t, db.Conn(), pr.BeadID, pr.Anvil)
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 
 	m.checkAll(context.Background())
 
@@ -865,7 +1095,7 @@ func TestCheckPR_PRClosedUpdatesIngotStatus(t *testing.T) {
 	seedIngot(t, db.Conn(), pr.BeadID, pr.Anvil)
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "CLOSED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 
 	m.checkAll(context.Background())
 
@@ -894,7 +1124,7 @@ func TestCheckPR_MissingIngotIsNoOp(t *testing.T) {
 
 	var events []string
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -941,7 +1171,7 @@ func TestCheckPR_NeedsFixToMergedTransition(t *testing.T) {
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -976,7 +1206,7 @@ func TestCheckPR_NeedsFixToClosedTransition(t *testing.T) {
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "CLOSED"}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -1015,7 +1245,7 @@ func TestCheckPR_OpenWithCIFailureStillTransitionsToNeedsFix(t *testing.T) {
 		},
 	}}
 
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 	m.checkAll(context.Background())
 
 	updated, err := db.GetPRByID(pr.ID)
@@ -1046,7 +1276,7 @@ func TestReconcileTerminalStates(t *testing.T) {
 	seedIngot(t, db.Conn(), mergedPR.BeadID, mergedPR.Anvil)
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
 
 	m.reconcileTerminalStates(context.Background())
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -934,6 +934,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return d.cfg.Load().Settings.AutoLearnRules
 	}, func() int {
 		return d.cfg.Load().Settings.MaxCIFixAttempts
+	}, func() int {
+		return d.cfg.Load().Settings.MaxReviewFixAttempts
 	})
 	d.lifecycleMgr = lifecycle.New(d.db, d.logger, d.handleLifecycleAction)
 	d.lifecycleMgr.SetThresholds(

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -624,7 +624,7 @@ func TestHandleIPC_RetryBead_ExhaustedPR(t *testing.T) {
 	lm := lifecycle.New(db, logger, func(_ context.Context, _ lifecycle.ActionRequest) {})
 
 	// Create bellows monitor (won't actually run, just needs to exist for reset).
-	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil)
+	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil, nil)
 
 	d := &Daemon{
 		db:             db,
@@ -775,7 +775,7 @@ func TestHandleIPC_RetryBead_NonBeadPR(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	lm := lifecycle.New(db, logger, func(_ context.Context, _ lifecycle.ActionRequest) {})
-	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil)
+	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil, nil)
 
 	d := &Daemon{
 		db:             db,


### PR DESCRIPTION
## Changes

- **Bellows re-emits EventReviewChanges when unresolved threads persist after a burnish cycle** - Mirrors the CI-fix still-failing branch on the review-fix path so PRs with new review comments after a completed burnish reliably trigger a fresh burnish on the next bellows poll. Respects `max_review_fix_attempts` and skips PRs already in `needs_fix`. (Forge-gwu4)

## Original Issue (bug): Bellows does not re-emit EventReviewChanges when unresolved threads persist across review-fix cycles

## Problem

After the first burnish (review-fix) cycle completes on a PR, any subsequent unresolved review threads on the same PR never trigger another burnish — bellows sees no transition and silently sits there. The PR is open and non-mergeable but bellows is effectively asleep.

Observed on skybert-forge today (2026-05-13) for ext-3082 (the still-open companion to ext-3073 from bead 04): quench fixed the initial CI failures, then the reviewer left new review comments. The bellows worker `bellows-munin-3082` is in `monitoring` (correct), Hearth shows the PR with unresolved threads, but no burnish ever spawns. The PR sits with `prs.status=open` and the threads stay unresolved indefinitely.

## Root cause

`internal/bellows/bellows.go` has asymmetric transition coverage between CI fixes and review fixes:

**CI flow (line 538-585)** has *three* branches:
1. `newSnap.CIPassing && !lastSnap.CIPassing` → emit EventCIPassed.
2. `!newSnap.CIPassing && !ciInProgress && lastSnap.CIPassing` → emit EventCIFailed (first failure).
3. `!newSnap.CIPassing && !ciInProgress && !lastSnap.CIPassing` → still-failing branch: re-emit EventCIFailed if `pr.Status != PRNeedsFix && pr.CIFixCount > 0 && pr.CIFixCount < maxCI`. This is the branch that keeps the retry loop alive across multiple quench attempts.

**Review flow (line 619-636)** has *one* branch:
1. `(newSnap.NeedsChanges && !lastSnap.NeedsChanges) || (newSnap.HasUnresolvedThreads && !lastSnap.HasUnresolvedThreads)` → emit EventReviewChanges.

No equivalent of the still-failing branch. Combined with the seeding guard at line 408-412:
```go
threadsSeed := pr.HasUnresolvedThreads
if threadsSeed && pr.Status != state.PRNeedsFix && pr.ReviewFixCount == 0 {
    threadsSeed = false
}
```
this is what happens after the first burnish:
- Daemon calls `NotifyReviewFixCompleted` → DB row flips `prs.status: needs_fix → open` (via `UpdatePRStatusIfNeedsFix` in `internal/lifecycle/lifecycle.go:499`).
- Daemon calls `ResetPRState` → snapshot cache wiped.
- Reviewer leaves new comments. `prs.has_unresolved_threads` is true.
- Next bellows poll: `pr.ReviewFixCount=1`, so the seeding guard does NOT clear threadsSeed. `lastSnap.HasUnresolvedThreads=true`.
- `newSnap.HasUnresolvedThreads=true`.
- Transition test `(new && !last)` evaluates to `(true && !true) = false`. No event emitted. No burnish.

The seeding guard's `ReviewFixCount == 0` clause is deliberate — once a burnish has run, the guard refuses to pretend threads were absent. But the missing still-failing branch means there is now no path to ever fire EventReviewChanges again until threads transition from 0 back to N+. Reviewers don't usually resolve all threads and then re-add comments; they add to the existing pile. So in practice the bead is stuck.

The CI-path equivalent of this guard plus the still-failing branch is the entire reason that loop keeps working — burnish needs the mirror.

## Proposed fix

Mechanical: add a parallel "still has unresolved threads" branch in `checkPR`, immediately after the existing review-fix block at line 619-636 (using `else if` against the existing condition so the two are mutually exclusive — matches the CI pattern). Pseudo-diff:

```go
// existing block at 619-636 (unchanged)
if (newSnap.NeedsChanges && !lastSnap.NeedsChanges) || (newSnap.HasUnresolvedThreads && !lastSnap.HasUnresolvedThreads) {
    // ...emit EventReviewChanges, set PRNeedsFix...
} else if newSnap.HasUnresolvedThreads && lastSnap.HasUnresolvedThreads {
    // Review still has unresolved threads with no transition. Catches the gap
    // where NotifyReviewFixCompleted() resets pr.Status to open after a burnish
    // cycle but bellows never re-emits EventReviewChanges because threads stayed
    // > 0 across the cycle. Mirrors the CI-fix still-failing branch above.
    maxR := m.maxReviewFixAttempts()
    if pr.Status != state.PRNeedsFix && pr.ReviewFixCount > 0 && pr.ReviewFixCount < maxR {
        m.emit(ctx, PREvent{
            PRNumber:  pr.Number,
            BeadID:    pr.BeadID,
            Anvil:     pr.Anvil,
            Branch:    status.HeadRefName,
            EventType: EventReviewChanges,
            Details:   fmt.Sprintf("PR still has unresolved review threads after fix attempt %d/%d", pr.ReviewFixCount, maxR),
            Timestamp: time.Now(),
        })
        _ = m.db.UpdatePRStatus(pr.ID, state.PRNeedsFix)
        _ = m.db.LogEvent(state.EventReviewChanges, fmt.Sprintf("PR #%d review fix retry needed (attempt %d/%d)", pr.Number, pr.ReviewFixCount, maxR), pr.BeadID, pr.Anvil)
        _ = m.db.LogEvent(state.EventPRNeedsFix, fmt.Sprintf("PR #%d review fix retry needed", pr.Number), pr.BeadID, pr.Anvil)
    }
}
```

Guards (mirror of CI path):
- `pr.Status != state.PRNeedsFix` — only re-emit if the PR is currently *not* in a fix cycle. Prevents firing during an in-flight burnish.
- `pr.ReviewFixCount > 0` — only after at least one attempt completed (i.e. only relevant in the post-first-fix state where the seeding guard refuses to clear `threadsSeed`).
- `pr.ReviewFixCount < maxR` — respect the configured cap so runaway retries are still blocked. Likely `m.maxReviewFixAttempts()` already exists; confirm the helper name in this file.

A cleaner alternative would be to also re-emit when `(NewUnresolvedCount > LastUnresolvedCount)`, but bellows tracks bool not int. Counting is out of scope; the still-failing branch is sufficient.

## Acceptance

- A PR that's already had one completed burnish cycle and now has new unresolved threads triggers a fresh burnish within one bellows poll, as long as `pr.ReviewFixCount < max_review_fix_attempts`.
- The retry cap is respected: when `pr.ReviewFixCount == max_review_fix_attempts`, no re-emit fires (existing `needs_human` flow takes over).
- An in-flight burnish (`pr.Status == PRNeedsFix`) does NOT receive duplicate dispatches from this branch.
- A PR whose threads are still genuinely 0 (never had review changes) is unaffected — the branch only fires when `lastSnap.HasUnresolvedThreads && newSnap.HasUnresolvedThreads`.
- Unit test mirroring the CI still-failing test exists for this branch.
- Manual end-to-end: assign bellows to an external PR with CI failures + review comments, run quench to green, push a new commented review, observe burnish dispatching within one poll.

## Notes

Sister bug to bead 04 (`04-bellows-cleanup-external-prs.sh`) — both are transition-detection gaps in bellows. 04 is the cleanup-after-terminal gap (worker rows orphaned in `monitoring`); this one is the retry-after-fix gap (burnish never re-fires).

The symptom is identical from the user's perspective ("bellows isn't doing anything") but the failures occur on opposite sides of the PR lifecycle: 04 is post-merge/close, 05 is mid-flight. They should be fixed independently; do not bundle them in one PR.

When building the unit test, the existing CI still-failing test (search for `CIFixCount.*maxCI` in `internal/bellows/bellows_test.go` if it exists, otherwise nearest equivalent) is the template — set up two consecutive polls with both snapshots having unresolved threads, advance the PR row to `pr.ReviewFixCount=1`, assert EventReviewChanges fires on the second poll.

File of interest: `internal/bellows/bellows.go:619-636` (the existing one-branch review block) and `internal/bellows/bellows.go:564-585` (the CI still-failing template). Likely also touches `bellows_test.go`.

The whole forge has been hammering away just fine on CI failures, but it turns out review comments slip right through the cracks like a dropped nail.

---
Bead: Forge-gwu4 | Branch: forge/Forge-gwu4
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->