### PR TITLE
reevaluateTrackedPR clobbers user-assigned bellows_managed on ext-* PRs (Forge-l125)

### DIFF
--- a/changelog.d/Forge-l125.md
+++ b/changelog.d/Forge-l125.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bellows assignment on external PRs now persists across reconcile cycles** - The reconcile loop's defensive ext-* clobber was silently reverting user-initiated `assign_bellows` actions within one poll, which made bellows quietly stop handling the PR. Manual assignments are now tracked separately via a new `bellows_manually_assigned` column and preserved by reconcile; the legacy auto-adoption release path still fires for ext-* PRs that were not user-pinned. A companion `unassign_bellows` IPC action clears both flags for clean release. (Forge-l125)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -725,16 +725,18 @@ func (d *Daemon) reconcileOpenPRs(ctx context.Context) {
 // per-instance marker rolls out. Re-evaluating on every reconcile makes the
 // transition automatic — no manual state.db edits or pod resets required.
 //
-// Synthetic ext-* PRs are never bellows-managed regardless of marker state.
+// Synthetic ext-* PRs are not eligible for bellows management via the legacy
+// auto-adoption path, but a user can explicitly assign bellows to them via the
+// assign_bellows IPC action; those user-pinned rows carry
+// bellows_manually_assigned=1 and must be left alone by reconcile (Forge-l125).
 func (d *Daemon) reevaluateTrackedPR(existing *state.PR, pr vcs.OpenPR, anvilName string, forgeManaged bool, myForgeID string) {
 	// ext-* rows are synthetic identifiers for PRs Forge did not create.
-	// They are never eligible for bellows management regardless of marker state;
-	// defensively clear bellows_managed if it somehow got set.
+	// Clear bellows_managed only when it was set by legacy auto-adoption —
+	// not when the user explicitly assigned bellows via assign_bellows.
 	if strings.HasPrefix(existing.BeadID, "ext-") {
-		if existing.BellowsManaged {
-			// ext-* must never be bellows-managed; defensive correction.
+		if existing.BellowsManaged && !existing.BellowsManuallyAssigned {
 			_ = d.db.UpdatePRBellowsManaged(existing.ID, false)
-			d.logger.Info("reconcile: cleared bellows_managed on ext-* PR",
+			d.logger.Info("reconcile: cleared bellows_managed on auto-adopted ext-* PR",
 				"pr", pr.Number, "anvil", anvilName, "bead", existing.BeadID)
 		}
 		return
@@ -4657,13 +4659,27 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 
 		case "assign_bellows":
 			if pa.PRID > 0 {
-				if err := d.db.UpdatePRBellowsManaged(pa.PRID, true); err != nil {
+				// Set both bellows_managed=1 and bellows_manually_assigned=1 so
+				// the reconcile loop's defensive ext-* clobber leaves this PR alone.
+				if err := d.db.UpdatePRBellowsAssignment(pa.PRID, true, true); err != nil {
 					msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to assign bellows: %v", err)})
 					return ipc.Response{Type: "error", Payload: msg}
 				}
 			}
 			_ = d.db.LogEvent("bellows_assigned", fmt.Sprintf("PR #%d assigned to bellows for lifecycle management", pa.PRNumber), pa.BeadID, pa.Anvil)
 			d.logger.Info("bellows assigned to external PR via pr_action", "pr", pa.PRNumber, "anvil", pa.Anvil)
+
+		case "unassign_bellows":
+			if pa.PRID > 0 {
+				// Clear both flags so reconcile no longer treats this PR as
+				// user-pinned and bellows stops running lifecycle workers for it.
+				if err := d.db.UpdatePRBellowsAssignment(pa.PRID, false, false); err != nil {
+					msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to unassign bellows: %v", err)})
+					return ipc.Response{Type: "error", Payload: msg}
+				}
+			}
+			_ = d.db.LogEvent("bellows_unassigned", fmt.Sprintf("PR #%d released from bellows lifecycle management", pa.PRNumber), pa.BeadID, pa.Anvil)
+			d.logger.Info("bellows unassigned from PR via pr_action", "pr", pa.PRNumber, "anvil", pa.Anvil)
 
 		case "approve":
 			reqID, _ := d.reqTracker.Track()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3377,6 +3377,18 @@ func TestReconcileOpenPRs_ReevaluatesAlreadyTrackedPRs(t *testing.T) {
 	row500, _ := db.GetPRByNumber("test-anvil", 500)
 	require.NoError(t, db.UpdatePRBellowsManaged(row500.ID, true))
 
+	// 600: synthetic ext-* PR that the user explicitly assigned to bellows via
+	//      the assign_bellows IPC action. Both bellows_managed=1 and
+	//      bellows_manually_assigned=1 are set. Reconcile must leave it alone
+	//      (Forge-l125): the previous overly-broad ext-* clobber was reverting
+	//      manual assignments within one poll cycle.
+	require.NoError(t, db.InsertPR(&state.PR{
+		Number: 600, Anvil: "test-anvil", BeadID: "ext-600",
+		Branch: "feature/user-assigned", Status: state.PROpen, CreatedAt: now,
+	}))
+	row600, _ := db.GetPRByNumber("test-anvil", 600)
+	require.NoError(t, db.UpdatePRBellowsAssignment(row600.ID, true, true))
+
 	mock := &mockVCSProvider{
 		openPRs: []vcs.OpenPR{
 			{Number: 100, Branch: "forge/g1a58", Body: "Bead: Fhi.Metadata-g1a58\n" + vcs.MarkerForID(siblingID)},
@@ -3384,6 +3396,7 @@ func TestReconcileOpenPRs_ReevaluatesAlreadyTrackedPRs(t *testing.T) {
 			{Number: 300, Branch: "feature/legacy-ext", Body: "Some external PR with our marker by accident\n" + vcs.MarkerForID(myID)},
 			{Number: 400, Branch: "forge/Forge-promote", Body: "Bead: Forge-promote\n" + vcs.MarkerForID(myID)},
 			{Number: 500, Branch: "forge/Forge-legacy", Body: "Bead: Forge-legacy\n<!-- forge-managed: true -->"},
+			{Number: 600, Branch: "feature/user-assigned", Body: "external PR body, no markers"},
 		},
 	}
 
@@ -3414,7 +3427,7 @@ func TestReconcileOpenPRs_ReevaluatesAlreadyTrackedPRs(t *testing.T) {
 	got300, err := db.GetPRByNumber("test-anvil", 300)
 	require.NoError(t, err)
 	assert.False(t, got300.BellowsManaged,
-		"ext-* PRs must never be bellows-managed regardless of marker state — defensive correction")
+		"legacy auto-adopted ext-* PRs (no manual-assignment flag) must be released by reconcile — defensive correction")
 
 	got400, err := db.GetPRByNumber("test-anvil", 400)
 	require.NoError(t, err)
@@ -3425,6 +3438,13 @@ func TestReconcileOpenPRs_ReevaluatesAlreadyTrackedPRs(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, got500.BellowsManaged,
 		"PR carrying only the legacy generic marker is ambiguous in multi-forge deployments and must be released")
+
+	got600, err := db.GetPRByNumber("test-anvil", 600)
+	require.NoError(t, err)
+	assert.True(t, got600.BellowsManaged,
+		"ext-* PRs that the user manually assigned via assign_bellows must NOT be clobbered by reconcile (Forge-l125)")
+	assert.True(t, got600.BellowsManuallyAssigned,
+		"manual-assignment marker must persist across reconcile cycles")
 }
 
 func TestReconcileMergedBeads(t *testing.T) {

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -244,7 +244,7 @@ type PRActionPayload struct {
 	Anvil    string `json:"anvil"`
 	BeadID   string `json:"bead_id"`
 	Branch   string `json:"branch"`
-	Action   string `json:"action"` // "open_browser" | "merge" | "quench" | "burnish" | "rebase" | "close" | "approve" | "assign_bellows"
+	Action   string `json:"action"` // "open_browser" | "merge" | "quench" | "burnish" | "rebase" | "close" | "approve" | "assign_bellows" | "unassign_bellows"
 }
 
 // WardenRerunPayload is the payload for a "warden_rerun" command.

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -129,6 +129,7 @@ func (db *DB) migrate() error {
 		{"forge_sessions", "plan", `ALTER TABLE forge_sessions ADD COLUMN plan TEXT NOT NULL DEFAULT ''`},
 		{"forge_session_messages", "kind", `ALTER TABLE forge_session_messages ADD COLUMN kind TEXT NOT NULL DEFAULT 'text'`},
 		{"forge_session_messages", "metadata", `ALTER TABLE forge_session_messages ADD COLUMN metadata TEXT NOT NULL DEFAULT ''`},
+		{"prs", "bellows_manually_assigned", `ALTER TABLE prs ADD COLUMN bellows_manually_assigned INTEGER NOT NULL DEFAULT 0`},
 	}
 	for _, m := range migrations {
 		exists, err := db.columnExists(m.table, m.column)
@@ -984,8 +985,9 @@ type PR struct {
 	HasUnresolvedThreads bool
 	HasPendingReviews    bool
 	HasApproval          bool
-	Title                string
-	BellowsManaged       bool // true = bellows runs lifecycle workers (quench, burnish, rebase)
+	Title                   string
+	BellowsManaged          bool // true = bellows runs lifecycle workers (quench, burnish, rebase)
+	BellowsManuallyAssigned bool // true = a user explicitly assigned bellows via IPC; reconcile must not clobber
 }
 
 // IsExternal returns true if this PR was discovered via GitHub reconciliation
@@ -1017,7 +1019,7 @@ func (db *DB) InsertPR(pr *PR) error {
 
 // PRByNumber returns the PR record for a given GitHub PR number, or nil if not found.
 func (db *DB) PRByNumber(number int) (*PR, error) {
-	prs, err := db.queryPRs(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed
+	prs, err := db.queryPRs(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed, bellows_manually_assigned
 		FROM prs WHERE number = ? ORDER BY id DESC LIMIT 1`, number)
 	if err != nil {
 		return nil, err
@@ -1063,19 +1065,19 @@ func (db *DB) UpdatePRLifecycle(id int, ciFixCount, reviewFixCount, rebaseCount 
 
 // GetPRByID returns a PR by its primary key id, or nil if not found.
 func (db *DB) GetPRByID(id int) (*PR, error) {
-	return db.queryPR(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed
+	return db.queryPR(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed, bellows_manually_assigned
 		FROM prs WHERE id = ?`, id)
 }
 
 // GetPRByNumber returns a PR by its anvil and number.
 func (db *DB) GetPRByNumber(anvil string, number int) (*PR, error) {
-	return db.queryPR(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed
+	return db.queryPR(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed, bellows_manually_assigned
 		FROM prs WHERE anvil = ? AND number = ? ORDER BY id DESC LIMIT 1`, anvil, number)
 }
 
 // OpenPRs returns all PRs with non-terminal status.
 func (db *DB) OpenPRs() ([]PR, error) {
-	return db.queryPRs(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed
+	return db.queryPRs(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed, bellows_manually_assigned
 		FROM prs WHERE status IN ` + nonTerminalPRStatusSQL() + `
 		ORDER BY created_at`)
 }
@@ -1104,9 +1106,9 @@ func (db *DB) queryPRs(query string, args ...any) ([]PR, error) {
 		var status string
 		var createdAt string
 		var lastChecked sql.NullString
-		var ciPassing, isConflicting, hasThreads, hasPendingReviews, hasApproval, bellowsManaged int
+		var ciPassing, isConflicting, hasThreads, hasPendingReviews, hasApproval, bellowsManaged, bellowsManuallyAssigned int
 		if err := rows.Scan(&p.ID, &p.Number, &p.Anvil, &p.BeadID, &p.Branch, &p.BaseBranch,
-			&status, &createdAt, &lastChecked, &p.CIFixCount, &p.ReviewFixCount, &p.RebaseCount, &ciPassing, &isConflicting, &hasThreads, &hasPendingReviews, &hasApproval, &p.Title, &bellowsManaged); err != nil {
+			&status, &createdAt, &lastChecked, &p.CIFixCount, &p.ReviewFixCount, &p.RebaseCount, &ciPassing, &isConflicting, &hasThreads, &hasPendingReviews, &hasApproval, &p.Title, &bellowsManaged, &bellowsManuallyAssigned); err != nil {
 			return nil, err
 		}
 		p.Status = PRStatus(status)
@@ -1116,6 +1118,7 @@ func (db *DB) queryPRs(query string, args ...any) ([]PR, error) {
 		p.HasPendingReviews = hasPendingReviews != 0
 		p.HasApproval = hasApproval != 0
 		p.BellowsManaged = bellowsManaged != 0
+		p.BellowsManuallyAssigned = bellowsManuallyAssigned != 0
 		p.CreatedAt = parseTime(createdAt)
 
 		if lastChecked.Valid {
@@ -1130,7 +1133,7 @@ func (db *DB) queryPRs(query string, args ...any) ([]PR, error) {
 // MergedPRs returns all PRs with status=merged that have a non-empty,
 // non-external bead_id (i.e. beads that Forge can attempt to close).
 func (db *DB) MergedPRs() ([]PR, error) {
-	return db.queryPRs(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed
+	return db.queryPRs(`SELECT id, number, anvil, bead_id, branch, base_branch, status, created_at, last_checked, ci_fix_count, review_fix_count, rebase_count, ci_passing, is_conflicting, has_unresolved_threads, has_pending_reviews, has_approval, title, bellows_managed, bellows_manually_assigned
 		FROM prs WHERE status = 'merged' AND bead_id != '' AND bead_id NOT LIKE 'ext-%'
 		ORDER BY created_at, id`)
 }
@@ -1259,6 +1262,18 @@ func (db *DB) UpdatePRMergeability(id int, ciPassing, isConflicting, hasUnresolv
 // When true, bellows will run lifecycle workers (quench, burnish, rebase) for this PR.
 func (db *DB) UpdatePRBellowsManaged(id int, managed bool) error {
 	_, err := db.conn.Exec(`UPDATE prs SET bellows_managed = ? WHERE id = ?`, boolToInt(managed), id)
+	return err
+}
+
+// UpdatePRBellowsAssignment sets both the bellows_managed and bellows_manually_assigned
+// flags for a PR atomically. The manual flag records that a user explicitly
+// assigned (or released) bellows via IPC, so the reconcile loop can distinguish
+// user-initiated assignments from legacy auto-adoption and avoid clobbering them.
+func (db *DB) UpdatePRBellowsAssignment(id int, managed, manuallyAssigned bool) error {
+	_, err := db.conn.Exec(
+		`UPDATE prs SET bellows_managed = ?, bellows_manually_assigned = ? WHERE id = ?`,
+		boolToInt(managed), boolToInt(manuallyAssigned), id,
+	)
 	return err
 }
 

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1007,18 +1007,24 @@ func (p *PR) IsExternal() bool {
 // bellows_managed defaults to 0 for ext-* (externally created) PRs so the
 // reconcile loop's auto-adoption release path is not triggered on every fresh
 // insert; users opt in via the assign_bellows IPC action which sets both flags
-// (Forge-l125). An explicit pr.BellowsManaged=true on the struct overrides the
-// default so callers can pre-pin an ext-* row at insert time.
+// (Forge-l125). An explicit pr.BellowsManaged=true on the struct pre-pins an ext-*
+// row at insert time and automatically sets bellows_manually_assigned=1 so that
+// reconcile does not clear the flag on the next cycle.
 func (db *DB) InsertPR(pr *PR) error {
 	bellowsManaged := 1
-	if pr.IsExternal() && !pr.BellowsManaged {
-		bellowsManaged = 0
+	bellowsManuallyAssigned := 0
+	if pr.IsExternal() {
+		if pr.BellowsManaged {
+			bellowsManuallyAssigned = 1
+		} else {
+			bellowsManaged = 0
+		}
 	}
 	res, err := db.conn.Exec(
-		`INSERT INTO prs (number, anvil, bead_id, branch, base_branch, status, created_at, ci_fix_count, review_fix_count, has_pending_reviews, title, bellows_managed)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+		`INSERT INTO prs (number, anvil, bead_id, branch, base_branch, status, created_at, ci_fix_count, review_fix_count, has_pending_reviews, title, bellows_managed, bellows_manually_assigned)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`,
 		pr.Number, pr.Anvil, pr.BeadID, pr.Branch, pr.BaseBranch, string(pr.Status),
-		pr.CreatedAt.Format(dbTimeLayout), pr.CIFixCount, pr.ReviewFixCount, pr.Title, bellowsManaged,
+		pr.CreatedAt.Format(dbTimeLayout), pr.CIFixCount, pr.ReviewFixCount, pr.Title, bellowsManaged, bellowsManuallyAssigned,
 	)
 	if err != nil {
 		return err

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1002,12 +1002,19 @@ func (p *PR) IsExternal() bool {
 // has_pending_reviews is explicitly set to 1 (pending) so new PRs don't appear in
 // Ready to Merge until bellows confirms no reviews are pending. This closes the race
 // window where GitHub assigns reviewers (e.g. Copilot) asynchronously after PR creation.
+// bellows_managed is explicitly set to 0 for ext-* (externally created) PRs so the
+// reconcile loop's auto-adoption release path is not triggered on every fresh insert;
+// users opt in via the assign_bellows IPC action which sets both flags (Forge-l125).
 func (db *DB) InsertPR(pr *PR) error {
+	bellowsManaged := 1
+	if pr.IsExternal() {
+		bellowsManaged = 0
+	}
 	res, err := db.conn.Exec(
-		`INSERT INTO prs (number, anvil, bead_id, branch, base_branch, status, created_at, ci_fix_count, review_fix_count, has_pending_reviews, title)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
+		`INSERT INTO prs (number, anvil, bead_id, branch, base_branch, status, created_at, ci_fix_count, review_fix_count, has_pending_reviews, title, bellows_managed)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
 		pr.Number, pr.Anvil, pr.BeadID, pr.Branch, pr.BaseBranch, string(pr.Status),
-		pr.CreatedAt.Format(dbTimeLayout), pr.CIFixCount, pr.ReviewFixCount, pr.Title,
+		pr.CreatedAt.Format(dbTimeLayout), pr.CIFixCount, pr.ReviewFixCount, pr.Title, bellowsManaged,
 	)
 	if err != nil {
 		return err

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -144,8 +144,10 @@ func (db *DB) migrate() error {
 		}
 	}
 	// Data fixup: ext- PRs that existed before the bellows_managed migration
-	// got bellows_managed=1 from the column default. Correct them to 0.
-	if _, err := db.conn.Exec(`UPDATE prs SET bellows_managed = 0 WHERE bead_id LIKE 'ext-%' AND bellows_managed = 1`); err != nil {
+	// got bellows_managed=1 from the column default. Correct them to 0, but
+	// leave user-pinned rows (bellows_manually_assigned=1) alone so that
+	// manual assignments survive a daemon restart (Forge-l125).
+	if _, err := db.conn.Exec(`UPDATE prs SET bellows_managed = 0 WHERE bead_id LIKE 'ext-%' AND bellows_managed = 1 AND bellows_manually_assigned = 0`); err != nil {
 		return fmt.Errorf("fixing ext- bellows_managed: %w", err)
 	}
 
@@ -1002,12 +1004,14 @@ func (p *PR) IsExternal() bool {
 // has_pending_reviews is explicitly set to 1 (pending) so new PRs don't appear in
 // Ready to Merge until bellows confirms no reviews are pending. This closes the race
 // window where GitHub assigns reviewers (e.g. Copilot) asynchronously after PR creation.
-// bellows_managed is explicitly set to 0 for ext-* (externally created) PRs so the
-// reconcile loop's auto-adoption release path is not triggered on every fresh insert;
-// users opt in via the assign_bellows IPC action which sets both flags (Forge-l125).
+// bellows_managed defaults to 0 for ext-* (externally created) PRs so the
+// reconcile loop's auto-adoption release path is not triggered on every fresh
+// insert; users opt in via the assign_bellows IPC action which sets both flags
+// (Forge-l125). An explicit pr.BellowsManaged=true on the struct overrides the
+// default so callers can pre-pin an ext-* row at insert time.
 func (db *DB) InsertPR(pr *PR) error {
 	bellowsManaged := 1
-	if pr.IsExternal() {
+	if pr.IsExternal() && !pr.BellowsManaged {
 		bellowsManaged = 0
 	}
 	res, err := db.conn.Exec(

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -65,6 +65,87 @@ func TestDB_PRLifecycle(t *testing.T) {
 	}
 }
 
+// TestDB_BellowsAssignment exercises the bellows_managed / bellows_manually_assigned
+// pair set by the assign_bellows IPC action (Forge-l125). The manual flag must
+// persist across reads so the reconcile loop can distinguish user-pinned PRs
+// from legacy auto-adoption.
+func TestDB_BellowsAssignment(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-bellows-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	pr := &PR{
+		Number: 42, Anvil: "anvil-1", BeadID: "ext-42",
+		Branch: "feature/external", Status: PROpen, CreatedAt: time.Now(),
+	}
+	if err := db.InsertPR(pr); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh insert: both flags must default to 0 for ext-* PRs (the migration
+	// data-fixup clears bellows_managed=1 defaults on ext-* rows; manual flag
+	// defaults to 0 column-wise).
+	got, err := db.GetPRByID(pr.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BellowsManaged || got.BellowsManuallyAssigned {
+		t.Fatalf("fresh ext-* PR should have both flags off, got managed=%v manual=%v",
+			got.BellowsManaged, got.BellowsManuallyAssigned)
+	}
+
+	// assign_bellows sets both flags.
+	if err := db.UpdatePRBellowsAssignment(pr.ID, true, true); err != nil {
+		t.Fatal(err)
+	}
+	got, err = db.GetPRByID(pr.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.BellowsManaged || !got.BellowsManuallyAssigned {
+		t.Fatalf("after assign_bellows expected both flags set, got managed=%v manual=%v",
+			got.BellowsManaged, got.BellowsManuallyAssigned)
+	}
+
+	// unassign_bellows clears both flags.
+	if err := db.UpdatePRBellowsAssignment(pr.ID, false, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err = db.GetPRByID(pr.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BellowsManaged || got.BellowsManuallyAssigned {
+		t.Fatalf("after unassign_bellows expected both flags clear, got managed=%v manual=%v",
+			got.BellowsManaged, got.BellowsManuallyAssigned)
+	}
+
+	// UpdatePRBellowsManaged alone must not touch the manual flag.
+	if err := db.UpdatePRBellowsAssignment(pr.ID, true, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpdatePRBellowsManaged(pr.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	got, err = db.GetPRByID(pr.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BellowsManaged {
+		t.Fatalf("expected bellows_managed=false after UpdatePRBellowsManaged(false)")
+	}
+	if !got.BellowsManuallyAssigned {
+		t.Fatalf("UpdatePRBellowsManaged must not clear bellows_manually_assigned")
+	}
+}
+
 func TestDB_QueueCache(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
 	if err != nil {


### PR DESCRIPTION
## Changes

- **Bellows assignment on external PRs now persists across reconcile cycles** - The reconcile loop's defensive ext-* clobber was silently reverting user-initiated `assign_bellows` actions within one poll, which made bellows quietly stop handling the PR. Manual assignments are now tracked separately via a new `bellows_manually_assigned` column and preserved by reconcile; the legacy auto-adoption release path still fires for ext-* PRs that were not user-pinned. A companion `unassign_bellows` IPC action clears both flags for clean release. (Forge-l125)

## Original Issue (bug): reevaluateTrackedPR clobbers user-assigned bellows_managed on ext-* PRs

## Problem

User-initiated `assign_bellows` actions on external (ext-*) PRs do not stick. The IPC handler sets `prs.bellows_managed=1`, but the next reconciliation cycle resets it to 0, after which bellows quietly stops handling the PR. The symptom looks like "bellows is broken" but it's actually "bellows assignment got reverted within seconds and bellows is now correctly skipping a PR it thinks is unmanaged."

Direct evidence from skybert forge (`forge-54959db797-dxjjq`, namespace `tn-heimdall`) as of 2026-05-13 07:25 UTC: PR ext-3082 was assigned to bellows earlier in the day, quench ran once and fixed CI (`ci_fix_count=1`, `ci_passing=1`), reviewer left new comments (`has_unresolved_threads=1`). The DB row currently shows `bellows_managed=0` — no manual edit was made. Same picture for the now-merged ext-3073: `review_fix_count=1` (burnish DID run at least once) but `bellows_managed=0` in the row. Every recent ext-* PR in the table is `bellows_managed=0` regardless of whether bellows was ever actively driving it.

This breaks the "assign bellows to an external PR" feature entirely on the second poll after assignment, and explains the symptoms previously filed as beads 04 (stranded monitoring workers) and 05 (no re-emit of EventReviewChanges across burnish cycles). Both of those are downstream of this bug — when `bellows_managed` is 0, `bellows.checkPR` returns early at line 456 and never emits ANY lifecycle events, so workers don't get cleaned up on terminal transitions and the review-fix loop never re-fires.

## Root cause

`internal/daemon/daemon.go:729-741`:
```go
func (d *Daemon) reevaluateTrackedPR(existing *state.PR, pr vcs.OpenPR, anvilName string, forgeManaged bool, myForgeID string) {
    // ext-* rows are synthetic identifiers for PRs Forge did not create.
    // They are never eligible for bellows management regardless of marker state;
    // defensively clear bellows_managed if it somehow got set.
    if strings.HasPrefix(existing.BeadID, "ext-") {
        if existing.BellowsManaged {
            _ = d.db.UpdatePRBellowsManaged(existing.ID, false)
            d.logger.Info("reconcile: cleared bellows_managed on ext-* PR", ...)
        }
        return
    }
    // ... per-forge-marker logic for non-ext-* PRs ...
}
```

The `ext-*` branch was added as defensive correction for the Forge-i1g7 fix (see comment block at lines 720-727). The original problem was: PRs adopted under legacy logic kept `bellows_managed=true` forever, blocking a multi-forge handoff. The intended scope of the fix was "ext-* PRs adopted by legacy adoption shouldn't stay bellows-managed." But the implementation is overly broad — it clears the flag on EVERY ext-* PR, including ones that were explicitly assigned by the user via the `assign_bellows` IPC action at `daemon.go:4658`. So the user's manual override is silently undone within one poll cycle.

Flow:
1. User clicks "Assign bellows" in Hearth → IPC `assign_bellows` → `db.UpdatePRBellowsManaged(prID, true)` at daemon.go:4658.
2. Bellows poll happens within the next 2 minutes; sees `bellows_managed=1`, emits transitions (e.g. EventCIFailed), lifecycle dispatches a quench/burnish worker.
3. Reconcile loop fires (interval depends on config; typically same order of magnitude as bellows). It calls `reevaluateTrackedPR` for every tracked PR. Hits the `ext-*` branch, sees `existing.BellowsManaged=true`, calls `UpdatePRBellowsManaged(prID, false)`.
4. Next bellows poll: `pr.BellowsManaged=false` again. `bellows.checkPR` hits the unmanaged early-return at `internal/bellows/bellows.go:456`. No event emitted, no worker cleanup, no fix dispatch.
5. The single fix that managed to run was a race-window beneficiary — quench/burnish was dispatched in step 2 between the assignment and the clobber.

This is why ext-3082 has `ci_fix_count=1` (one quench ran) but `review_fix_count=0` (no burnish yet, despite unresolved threads being present): the race window only fired once and didn't happen to catch the review side.

## Proposed fix

Two viable approaches; pick A.

**Option A (recommended): track manual assignment separately.**

Add a new column `prs.bellows_manually_assigned` (INTEGER, default 0). The `assign_bellows` IPC handler at `daemon.go:4658` sets BOTH `bellows_managed=1` AND `bellows_manually_assigned=1`. The `reevaluateTrackedPR` ext-* branch is amended to skip the clobber when `bellows_manually_assigned=1`:

```go
if strings.HasPrefix(existing.BeadID, "ext-") {
    if existing.BellowsManaged && !existing.BellowsManuallyAssigned {
        _ = d.db.UpdatePRBellowsManaged(existing.ID, false)
        d.logger.Info("reconcile: cleared bellows_managed on auto-adopted ext-* PR",
            "pr", pr.Number, "anvil", anvilName, "bead", existing.BeadID)
    }
    return
}
```

A companion IPC action `unassign_bellows` (probably already exists, search for it; if not, add it) should clear BOTH flags so the user can release a PR cleanly. The reconcile loop's intent — "don't let legacy adoption keep a PR permanently bellows-managed" — is preserved because legacy-adopted PRs would have `bellows_manually_assigned=0`.

Migration: add column with default 0; existing rows where `bellows_managed=1 AND bead_id LIKE 'ext-%'` are ambiguous (we don't know if they came from a manual click or legacy adoption). Default behaviour: treat as legacy-adopted (`bellows_manually_assigned=0`) so reconcile still clears them on first cycle. The user can re-assign via the UI. Document this in the migration notes.

**Option B (smaller change but riskier): drop the defensive ext-* branch entirely.**

Remove lines 733-741. The non-ext-* branch already only sets `bellows_managed=1` when `forgeManaged=true` (i.e. the per-forge marker is in the PR body), and clears it when not. For ext-* PRs `forgeManaged` is always false (Forge didn't create them), so the existing `if !forgeManaged && existing.BellowsManaged` branch at lines 748-757 would handle them — clearing `bellows_managed=1` whenever the legacy-adoption case applies. This is roughly equivalent to A in steady state but loses the explicit "ext-* are defensively reset" intent. Risk: if some other path sets `bellows_managed=1` on ext-* without the manual-assignment marker, B would still clear it (good) but A wouldn't catch it if `bellows_manually_assigned` somehow got set wrong.

A is more explicit and easier to reason about. Recommend A.

## Acceptance

- After assigning bellows to an external PR via Hearth, `prs.bellows_managed` stays 1 across multiple reconcile cycles (verify by waiting at least 2× the reconcile interval).
- A subsequent CI failure on that PR triggers quench (existing behaviour) and a new review-comment batch triggers burnish (currently broken — see bead 05). Both should work after this fix because the unmanaged early-return at `bellows.go:456` no longer fires.
- Legacy auto-adopted ext-* PRs (no manual assignment) still get released on reconcile — i.e. the Forge-i1g7 fix's original intent is preserved. Verify by manually setting `bellows_managed=1` on an ext-* row WITHOUT the manual_assigned flag and confirming reconcile clears it.
- Bellows monitor cleanup paths (terminal-state detection at `bellows.go:476/517`) fire correctly for user-assigned ext-* PRs when they merge/close — no more stranded monitoring workers (bead 04 symptom).
- Bellows review-fix transition path fires correctly across multiple burnish cycles on user-assigned ext-* PRs (bead 05 symptom). Note: bead 05's defensive fix (still-failing branch) remains useful as defense-in-depth — keep it. Combined with this fix, the system is robust to both root cause and downstream symptom.

## Notes

Discovered on 2026-05-13 while diagnosing why bellows wasn't fixing new review comments on ext-3082. The user observed: "It fixed some CI, but now there are new review comments, why isn't it fixing those?" Initial hypothesis was a transition-detection gap in bellows (filed as bead 05). On inspection of the live `state.db` in the skybert forge pod, the row showed `bellows_managed=0` for both ext-3082 and ext-3073 — proving the assignment never persisted. The trace led to `reevaluateTrackedPR` and its overly broad ext-* clobber.

Beads 04 and 05 are downstream symptoms of this bug and can be closed once this lands AND its acceptance criteria are verified end-to-end — but **do not close 04 or 05 preemptively**. The defenses they add are independently useful (orphan-worker sweep in 04 protects against any future code path that leaves a bellows worker behind; the still-failing branch in 05 protects against bellows monitor restarting mid-burnish-cycle).

This bug also has a multi-forge angle: in a fleet of Forge instances pointing at the same anvil, manual `assign_bellows` lets a user route a PR's lifecycle to a specific forge. Today, you can't — because reconcile clobbers the assignment regardless of which forge made it. Option A preserves the per-forge intent: each forge's `reevaluateTrackedPR` only clobbers when `bellows_manually_assigned=0`, so a different forge's manual assignment is left alone.

With both 04 and 05 already in flight on hetzner, this bead does NOT need to revert their work — it just needs the additional reconcile fix. The three together form a clean, layered defense:
- This bead (06): fix the root cause — manual assignments stick.
- Bead 05: defense-in-depth — if a bellows poll misses a review transition for any reason (restart, seeding edge case), the still-failing branch catches it.
- Bead 04: defense-in-depth — if a monitoring worker is ever left behind by any code path, the sweep cleans it up.

The whole reconcile loop has been quietly tossing manual assignments into the fire — apologies for the cold-forge welcome, that one's on us.

---
Bead: Forge-l125 | Branch: forge/Forge-l125
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->