### PR TITLE
Wrap remaining exec.Command sites with executil.HideWindow to suppress Windows console flash (Forge-pk7y)

### DIFF
--- a/changelog.d/Forge-pk7y.md
+++ b/changelog.d/Forge-pk7y.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Suppress Windows console flash from remaining subprocess sites** - Wrapped the last unwrapped `exec.Command`/`exec.CommandContext` call sites in `internal/daemon`, `internal/web`, `cmd/forge/daemon`, `cmd/forge/doctor`, `cmd/forge/quest`, and `cmd/forge/update` with `executil.HideWindow` so they no longer produce a brief console window flash on Windows when they fire. (Forge-pk7y)

--- a/cmd/forge/daemon.go
+++ b/cmd/forge/daemon.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Robin831/Forge/internal/daemon"
+	"github.com/Robin831/Forge/internal/executil"
 	"github.com/spf13/cobra"
 )
 
@@ -89,6 +90,7 @@ var upCmd = &cobra.Command{
 		bgCmd.Stdout = nil
 		bgCmd.Stderr = nil
 		bgCmd.Stdin = nil
+		executil.HideWindow(bgCmd)
 
 		// Detach the background process (platform-specific implementation in daemon_*.go)
 		detachProcess(bgCmd)

--- a/cmd/forge/doctor.go
+++ b/cmd/forge/doctor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Robin831/Forge/internal/autostart"
 	"github.com/Robin831/Forge/internal/changelog"
 	"github.com/Robin831/Forge/internal/daemon"
+	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/ipc"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/state"
@@ -33,7 +34,7 @@ var (
 	execRunCommand = func(name string, args ...string) ([]byte, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
 		defer cancel()
-		return exec.CommandContext(ctx, name, args...).CombinedOutput()
+		return executil.HideWindow(exec.CommandContext(ctx, name, args...)).CombinedOutput()
 	}
 )
 

--- a/cmd/forge/quest.go
+++ b/cmd/forge/quest.go
@@ -236,6 +236,7 @@ func runShellCmd(ctx context.Context, command, dir string) error {
 	} else {
 		cmd = exec.CommandContext(ctx, "sh", "-c", command)
 	}
+	executil.HideWindow(cmd)
 	executil.SetProcessGroup(cmd)
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout

--- a/cmd/forge/update.go
+++ b/cmd/forge/update.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Robin831/Forge/internal/daemon"
+	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/forge"
 	"github.com/spf13/cobra"
 )
@@ -512,6 +513,7 @@ del "%%~f0"
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
+	executil.HideWindow(cmd)
 	detachProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		_ = os.Remove(scriptPath)
@@ -531,6 +533,7 @@ func startDaemon(exe string) error {
 	bgCmd.Stdout = nil
 	bgCmd.Stderr = nil
 	bgCmd.Stdin = nil
+	executil.HideWindow(bgCmd)
 	detachProcess(bgCmd)
 	if err := bgCmd.Start(); err != nil {
 		return err

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4569,6 +4569,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			defer openCancel()
 			openCmd := exec.CommandContext(openCtx, "gh", "pr", "view", strconv.Itoa(pa.PRNumber), "--web")
 			openCmd.Dir = anvilCfg.Path
+			executil.HideWindow(openCmd)
 			if out, err := openCmd.CombinedOutput(); err != nil {
 				msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("gh pr view --web failed: %v: %s", err, strings.TrimSpace(string(out)))})
 				return ipc.Response{Type: "error", Payload: msg}

--- a/internal/web/views.go
+++ b/internal/web/views.go
@@ -399,6 +399,7 @@ var bdShowJSON = func(ctx context.Context, dir, beadID string) ([]byte, error) {
 	if dir != "" {
 		cmd.Dir = dir
 	}
+	executil.HideWindow(cmd)
 	return cmd.Output()
 }
 


### PR DESCRIPTION
## Changes

- **Suppress Windows console flash from remaining subprocess sites** - Wrapped the last unwrapped `exec.Command`/`exec.CommandContext` call sites in `internal/daemon`, `internal/web`, `cmd/forge/daemon`, `cmd/forge/doctor`, `cmd/forge/quest`, and `cmd/forge/update` with `executil.HideWindow` so they no longer produce a brief console window flash on Windows when they fire. (Forge-pk7y)

## Original Issue (bug): Wrap remaining exec.Command sites with executil.HideWindow to suppress Windows console flash

## Problem

On Windows, `exec.Command` / `exec.CommandContext` produces a brief console-window flash for every short-lived subprocess unless the cmd is wrapped to set `HideWindow=true` + `CREATE_NO_WINDOW` in `SysProcAttr.CreationFlags`. Forge already has the helper for this (`internal/executil.HideWindow`) and most hot paths use it (`poller`, `bellows`, `depcheck`, most of `wicket`). But several sites still spawn unwrapped — when they fire during normal worker operation, the user sees flashes on their desktop.

## Sites to wrap (verify locations before editing — line numbers drift)

Grep: `grep -rnE \"exec\\.(Command|CommandContext)\" internal/ cmd/ | grep -v executil`

High-frequency / fires during worker dispatch (most user-visible):
- `internal/smith/smith.go` — `exec.CommandContext(ctx, pv.Cmd(), args...)` — spawns claude/gemini binary on every worker.
- `internal/burnish/burnish.go` — two unwrapped sites: `git push origin <branch>` and `git rev-parse`.
- `internal/quench/quench.go` — two unwrapped sites: `git rev-parse` and `git diff`.
- `internal/rebase/rebase.go` — `exec.Command(\"git\", args...)`.
- `internal/vulncheck/vulncheck.go` — three sites: `govulncheck`, `bd list`, `bd create`. Fires on the daily vulncheck cycle.
- `internal/web/views.go` — `bd show <id> --json` on /api/bead/{id} requests; frequent if Hearth dashboard is open with a bead-detail panel.
- `internal/daemon/daemon.go` — `gh pr view --web` from the pr-open action.

Low-frequency / user-initiated (can wrap too for consistency):
- `cmd/forge/daemon.go` — self-respawn during `forge up` detach.
- `cmd/forge/doctor.go` — generic exec for dependency probes.
- `cmd/forge/quest.go` — quest commands.
- `cmd/forge/update.go` — installer script + self-respawn.

## Proposed fix

Mechanical change: every `exec.Command*(...)` site that isn't already wrapped should become `executil.HideWindow(exec.Command*(...))`. The helper is a no-op on non-Windows so it's safe everywhere.

No behaviour change beyond the flash suppression — `HideWindow` only sets process-creation flags.

---
Bead: Forge-pk7y | Branch: forge/Forge-pk7y
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->