### PR TITLE
Backend: expose created_at / updated_at on QueueItem (Forge-ye27)

### DIFF
--- a/changelog.d/Forge-ye27.md
+++ b/changelog.d/Forge-ye27.md
@@ -1,0 +1,2 @@
+category: Added
+- **Queue API exposes bead timestamps** - The `/api/queue` endpoint and its IPC backing now include `created_at` and `updated_at` for each item, sourced from the in-memory poller snapshot so no SQLite migration is needed. Unblocks date-column work on the Hearth queue view. (Forge-ye27)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -250,6 +250,23 @@ type Daemon struct {
 	// parentCloser closes a bead with --force. Defaults to exec.Command;
 	// may be replaced in tests.
 	parentCloser func(anvilPath, beadID, reason string) error
+
+	// queueTimestamps holds CreatedAt/UpdatedAt strings (as emitted by
+	// `bd ready --json` / `bd list --json`) keyed by "anvil/beadID". It is
+	// refreshed alongside the queue_cache rebuild so the IPC "queue" handler
+	// can attach timestamps to QueueItem responses without persisting them
+	// to SQLite. Missing entries return zero values, which serialise as
+	// empty strings on the wire.
+	queueTimestampsMu sync.RWMutex
+	queueTimestamps   map[string]queueTimestamp
+}
+
+// queueTimestamp pairs the two ISO timestamps that bd emits for a bead. The
+// strings are passed through verbatim (no parsing) so any timezone or
+// precision quirks from bd flow straight to the client.
+type queueTimestamp struct {
+	CreatedAt string
+	UpdatedAt string
 }
 
 // New creates a new daemon instance.
@@ -341,6 +358,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 		reqTracker:            *ipc.NewRequestTracker("forge-"),
 		crucibleTickerResetCh: make(chan struct{}, 1),
 		lastPollMap:           make(map[string]anvilPollSnapshot),
+		queueTimestamps:       make(map[string]queueTimestamp),
 	}
 	d.notifier.Store(notifier)
 	d.dispatcher.Store(dispatcher)
@@ -1998,6 +2016,12 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 			}
 		}
 		var cacheItems []state.QueueItem
+		// Collect timestamps alongside the cache rebuild so the IPC "queue"
+		// handler can attach created_at/updated_at to QueueItem responses
+		// without persisting them in SQLite. The map is rebuilt per-poll for
+		// the same set of anvils as the cache itself, so freshness mirrors
+		// the cache exactly.
+		stamps := make(map[string]queueTimestamp)
 		for _, b := range mergedForCache {
 			if b.Labels == nil {
 				b.Labels = []string{}
@@ -2015,6 +2039,7 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 				Section:     section,
 				Assignee:    b.Assignee,
 			})
+			stamps[b.Anvil+"/"+b.ID] = queueTimestamp{CreatedAt: b.CreatedAt, UpdatedAt: b.UpdatedAt}
 		}
 
 		// Also include in-progress beads from successful anvils.
@@ -2050,7 +2075,10 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 				Section:     state.QueueSectionInProgress,
 				Assignee:    b.Assignee,
 			})
+			stamps[b.Anvil+"/"+b.ID] = queueTimestamp{CreatedAt: b.CreatedAt, UpdatedAt: b.UpdatedAt}
 		}
+
+		d.replaceQueueTimestamps(succeededSet, stamps)
 
 		if err := d.db.ReplaceQueueCacheForAnvils(succeededAnvils, dedupeCacheItems(cacheItems)); err != nil {
 			d.logger.Warn("failed to cache queue", "error", err)
@@ -3416,9 +3444,14 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("queue cache: %v", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
+		// Timestamps live in an in-memory map populated alongside the queue
+		// cache rebuild (see pollAndDispatch). Sourcing them here avoids a
+		// SQLite schema migration on queue_cache; entries missing from the
+		// map serialise as empty strings on the wire.
 		out := make([]ipc.QueueItem, 0, len(items))
 		for _, it := range items {
 			labels := parseQueueLabels(it.Labels)
+			ts := d.lookupQueueTimestamp(it.Anvil, it.BeadID)
 			out = append(out, ipc.QueueItem{
 				BeadID:      it.BeadID,
 				Anvil:       it.Anvil,
@@ -3429,6 +3462,8 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				Labels:      labels,
 				Section:     string(it.Section),
 				Assignee:    it.Assignee,
+				CreatedAt:   ts.CreatedAt,
+				UpdatedAt:   ts.UpdatedAt,
 			})
 		}
 		data, _ := json.Marshal(ipc.QueueResponse{Items: out})
@@ -6007,6 +6042,43 @@ func trimStrings(ss []string) []string {
 		}
 	}
 	return res
+}
+
+// replaceQueueTimestamps refreshes the in-memory timestamp map for the given
+// set of successfully-polled anvils. Entries belonging to other anvils are
+// kept verbatim, mirroring ReplaceQueueCacheForAnvils so a failed anvil poll
+// does not wipe its last-known timestamps. `fresh` is the full set of new
+// timestamps from this poll cycle (its keys must use the "anvil/beadID"
+// format).
+func (d *Daemon) replaceQueueTimestamps(succeeded map[string]struct{}, fresh map[string]queueTimestamp) {
+	d.queueTimestampsMu.Lock()
+	defer d.queueTimestampsMu.Unlock()
+	next := make(map[string]queueTimestamp, len(fresh)+len(d.queueTimestamps))
+	// Keep entries from anvils that did not poll successfully this cycle so
+	// their timestamps remain available alongside their cached queue rows.
+	for k, v := range d.queueTimestamps {
+		anvil, _, ok := strings.Cut(k, "/")
+		if !ok {
+			continue
+		}
+		if _, replaced := succeeded[anvil]; replaced {
+			continue
+		}
+		next[k] = v
+	}
+	for k, v := range fresh {
+		next[k] = v
+	}
+	d.queueTimestamps = next
+}
+
+// lookupQueueTimestamp returns the CreatedAt/UpdatedAt pair recorded for the
+// given (anvil, beadID) during the most recent poll. Callers receive a
+// zero-valued queueTimestamp (empty strings) when no entry is present.
+func (d *Daemon) lookupQueueTimestamp(anvil, beadID string) queueTimestamp {
+	d.queueTimestampsMu.RLock()
+	defer d.queueTimestampsMu.RUnlock()
+	return d.queueTimestamps[anvil+"/"+beadID]
 }
 
 // parseQueueLabels decodes a JSON-encoded labels string from the queue_cache

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2078,10 +2078,10 @@ func (d *Daemon) pollAndDispatch(ctx context.Context, fullPoll bool) {
 			stamps[b.Anvil+"/"+b.ID] = queueTimestamp{CreatedAt: b.CreatedAt, UpdatedAt: b.UpdatedAt}
 		}
 
-		d.replaceQueueTimestamps(succeededSet, stamps)
-
 		if err := d.db.ReplaceQueueCacheForAnvils(succeededAnvils, dedupeCacheItems(cacheItems)); err != nil {
 			d.logger.Warn("failed to cache queue", "error", err)
+		} else {
+			d.replaceQueueTimestamps(succeededSet, stamps)
 		}
 	}
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4203,6 +4203,90 @@ func TestHandleIPC_Queue(t *testing.T) {
 	})
 }
 
+// TestHandleIPC_Queue_Timestamps verifies that the queue endpoint surfaces
+// created_at / updated_at sourced from the in-memory poller snapshot and
+// emits both keys (even as empty strings) so the QueueItem JSON shape stays
+// stable for the frontend date-column work that depends on this contract.
+func TestHandleIPC_Queue_Timestamps(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-ipc-queue-ts-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := state.Open(filepath.Join(tmpDir, "state.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:     db,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	d.cfg.Store(&config.Config{})
+
+	seed := []state.QueueItem{
+		{
+			BeadID:   "Forge-abc1",
+			Anvil:    "forge",
+			Title:    "With timestamps",
+			Priority: 2,
+			Status:   "ready",
+			Labels:   `[]`,
+			Section:  state.QueueSectionReady,
+		},
+		{
+			BeadID:   "Forge-def2",
+			Anvil:    "forge",
+			Title:    "No snapshot entry",
+			Priority: 3,
+			Status:   "ready",
+			Labels:   `[]`,
+			Section:  state.QueueSectionReady,
+		},
+	}
+	require.NoError(t, db.ReplaceQueueCacheForAnvils([]string{"forge"}, seed))
+
+	const created = "2026-05-08T04:15:41Z"
+	const updated = "2026-05-12T11:08:11Z"
+	d.replaceQueueTimestamps(
+		map[string]struct{}{"forge": {}},
+		map[string]queueTimestamp{
+			"forge/Forge-abc1": {CreatedAt: created, UpdatedAt: updated},
+		},
+	)
+
+	resp := d.handleIPC(ipc.Command{Type: "queue"})
+	require.Equal(t, "ok", resp.Type)
+
+	// Verify the raw JSON contains the new keys so the wire contract is
+	// stable for the frontend (created_at/updated_at must always be present,
+	// even when empty).
+	var raw struct {
+		Items []map[string]json.RawMessage `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Payload, &raw))
+	require.Len(t, raw.Items, 2)
+	for _, item := range raw.Items {
+		_, hasCreated := item["created_at"]
+		_, hasUpdated := item["updated_at"]
+		assert.True(t, hasCreated, "every queue item must expose a created_at key")
+		assert.True(t, hasUpdated, "every queue item must expose an updated_at key")
+	}
+
+	var payload ipc.QueueResponse
+	require.NoError(t, json.Unmarshal(resp.Payload, &payload))
+	require.Len(t, payload.Items, 2)
+
+	byID := map[string]ipc.QueueItem{}
+	for _, item := range payload.Items {
+		byID[item.BeadID] = item
+	}
+	assert.Equal(t, created, byID["Forge-abc1"].CreatedAt)
+	assert.Equal(t, updated, byID["Forge-abc1"].UpdatedAt)
+	// Beads missing from the snapshot fall back to empty strings rather
+	// than crashing the handler or omitting the row entirely.
+	assert.Equal(t, "", byID["Forge-def2"].CreatedAt)
+	assert.Equal(t, "", byID["Forge-def2"].UpdatedAt)
+}
+
 func TestHandleIPC_Workers(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-ipc-workers-*")
 	require.NoError(t, err)

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -331,7 +331,10 @@ type QueuedPayload struct {
 
 // QueueItem is the IPC representation of a single cached queue entry. It
 // mirrors state.QueueItem but uses JSON-friendly tags and a parsed labels
-// slice.
+// slice. CreatedAt and UpdatedAt are sourced from the in-memory poller
+// snapshot (not the queue_cache table) so timestamps flow through without
+// a SQLite schema migration; both are empty strings when the snapshot has
+// no matching entry (e.g. before the first poll completes).
 type QueueItem struct {
 	BeadID      string   `json:"bead_id"`
 	Anvil       string   `json:"anvil"`
@@ -342,6 +345,8 @@ type QueueItem struct {
 	Labels      []string `json:"labels"`
 	Section     string   `json:"section"`
 	Assignee    string   `json:"assignee,omitempty"`
+	CreatedAt   string   `json:"created_at"`
+	UpdatedAt   string   `json:"updated_at"`
 }
 
 // QueueResponse is the response payload for a "queue" command.

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -36,6 +36,11 @@ type Bead struct {
 	Dependencies   []BeadDep `json:"dependencies"`   // Detailed dependency info from bd
 	DependentCount int       `json:"dependent_count"` // Number of beads that depend on this bead
 	ExternalRef    string    `json:"external_ref"`    // External tracker reference from bd (for example "gh-42", a full URL, or another non-GitHub ref)
+	// CreatedAt and UpdatedAt are ISO timestamps emitted by `bd ready --json`.
+	// They flow through to the queue serialiser so the web UI can surface
+	// bead age without a SQLite schema migration.
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 
 	// Forge-injected: which anvil this bead belongs to
 	Anvil string `json:"-"`

--- a/internal/web/frontend/src/api.ts
+++ b/internal/web/frontend/src/api.ts
@@ -12,6 +12,8 @@ export interface QueueItem {
   labels: string[]
   section: string
   assignee?: string
+  created_at: string
+  updated_at: string
 }
 
 export interface QueueResponse {

--- a/internal/web/frontend/src/components/QueuePane.test.tsx
+++ b/internal/web/frontend/src/components/QueuePane.test.tsx
@@ -15,6 +15,8 @@ function item(overrides: Partial<QueueItem>): QueueItem {
     status: 'open',
     labels: [],
     section: 'ready',
+    created_at: '',
+    updated_at: '',
     ...overrides,
   }
 }


### PR DESCRIPTION
## Changes

- **Queue API exposes bead timestamps** - The `/api/queue` endpoint and its IPC backing now include `created_at` and `updated_at` for each item, sourced from the in-memory poller snapshot so no SQLite migration is needed. Unblocks date-column work on the Hearth queue view. (Forge-ye27)

## Original Issue (task): Backend: expose created_at / updated_at on QueueItem

Extend the queue serialiser in `internal/web/views.go` (the QueueCache row handler) to include `created_at` and `updated_at` fields in the JSON response. The poller already receives both timestamps from `bd ready --json`; pass them through. If the queue cache table in `~/.forge/state.db` doesn't store them, either add the columns to the schema or look them up at serialisation time from the in-memory poller snapshot — prefer the in-memory snapshot to avoid a migration. Update the `QueueItem` TypeScript shape in `internal/web/frontend/src/api.ts:5` to add `created_at: string` and `updated_at: string` (ISO timestamps). Add a Go serialisation test asserting both fields are present in the queue endpoint JSON. This sub-task is a prerequisite for the date-column frontend work; siblings depend on the API contract landing first.

---
Bead: Forge-ye27 | Branch: forge/Forge-ye27
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->