### PR TITLE
Backend: extend beadDetailResponse with notes and comments (Forge-fdz6)

### DIFF
--- a/changelog.d/Forge-fdz6.md
+++ b/changelog.d/Forge-fdz6.md
@@ -1,0 +1,2 @@
+category: Added
+- **Bead detail API now surfaces notes and comments** - `GET /api/bead/{id}` includes the bead's appended notes (from `bd show --json`) and the comment thread (from `bd comments --json`), unlocking the bead detail UI panels. Comment fetch failures are non-fatal and return an empty array. (Forge-fdz6)

--- a/internal/web/views.go
+++ b/internal/web/views.go
@@ -788,20 +788,25 @@ func (s *Server) handleBeadDetail(w http.ResponseWriter, r *http.Request) {
 	prs := collectBeadPRs(s.db, beadID, resp.Anvil)
 	resp.PRs = prs
 
+	anvilPath := s.resolveAnvilPath(resp.Anvil)
+
 	// Dependency lists + notes share a single `bd show <id> --json` call.
 	// Failures fall back to empty slices/strings so the response shape
 	// stays stable when bd is missing or returns unexpected output.
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-	defer cancel()
-	anvilPath := s.resolveAnvilPath(resp.Anvil)
-	if entry, err := fetchBeadShow(ctx, anvilPath, beadID); err == nil && entry != nil {
+	// Each bd call gets its own independent context so a slow or cancelled
+	// show call does not starve the comment fetch.
+	showCtx, showCancel := context.WithTimeout(r.Context(), executil.DefaultBdTimeout)
+	defer showCancel()
+	if entry, err := fetchBeadShow(showCtx, anvilPath, beadID); err == nil && entry != nil {
 		resp.Notes = entry.Notes
 		resp.Blocks, resp.BlockedBy = extractBeadDeps(entry, newAnvilLookup(s.db))
 	}
 
 	// Comments come from a separate `bd comments <id> --json` shell-out.
 	// Errors are non-fatal: the rest of the page still renders.
-	resp.Comments = fetchBeadComments(ctx, anvilPath, beadID, s.logger)
+	commentsCtx, commentsCancel := context.WithTimeout(r.Context(), executil.DefaultBdTimeout)
+	defer commentsCancel()
+	resp.Comments = fetchBeadComments(commentsCtx, anvilPath, beadID, s.logger)
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/web/views.go
+++ b/internal/web/views.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"os/exec"
 	"sort"
@@ -327,6 +328,16 @@ type beadDetailWorker struct {
 	PRNumber    int     `json:"pr_number,omitempty"`
 }
 
+// beadDetailComment is one comment from `bd comments <id> --json`. The bd CLI
+// names the body field `text`, but the response surfaces it as `body` so the
+// SPA can render it uniformly with other markdown-ish text blocks.
+type beadDetailComment struct {
+	ID        string `json:"id,omitempty"`
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
+}
+
 // beadDetailDepRef is a lightweight reference to a related bead. It is used
 // both for the immediate Blocks/BlockedBy lists on beadDetailResponse and
 // for the recursive tree returned by /api/bead/{id}/deps. The nested
@@ -344,17 +355,19 @@ type beadDetailDepRef struct {
 
 // beadDetailResponse is the consolidated JSON shape for /api/bead/{id}.
 type beadDetailResponse struct {
-	BeadID    string             `json:"bead_id"`
-	Anvil     string             `json:"anvil,omitempty"`
-	Queue     *beadDetailQueue   `json:"queue,omitempty"`
-	Ingot     *ingot.Ingot       `json:"ingot,omitempty"`
-	Retry     *beadDetailRetry   `json:"retry,omitempty"`
-	Cost      *beadDetailCost    `json:"cost,omitempty"`
-	Workers   []beadDetailWorker `json:"workers"`
-	Events    []beadDetailEvent  `json:"events"`
-	PRs       []beadDetailPR     `json:"prs"`
-	Blocks    []beadDetailDepRef `json:"blocks"`
-	BlockedBy []beadDetailDepRef `json:"blocked_by"`
+	BeadID    string              `json:"bead_id"`
+	Anvil     string              `json:"anvil,omitempty"`
+	Queue     *beadDetailQueue    `json:"queue,omitempty"`
+	Ingot     *ingot.Ingot        `json:"ingot,omitempty"`
+	Retry     *beadDetailRetry    `json:"retry,omitempty"`
+	Cost      *beadDetailCost     `json:"cost,omitempty"`
+	Workers   []beadDetailWorker  `json:"workers"`
+	Events    []beadDetailEvent   `json:"events"`
+	PRs       []beadDetailPR      `json:"prs"`
+	Blocks    []beadDetailDepRef  `json:"blocks"`
+	BlockedBy []beadDetailDepRef  `json:"blocked_by"`
+	Notes     string              `json:"notes,omitempty"`
+	Comments  []beadDetailComment `json:"comments"`
 }
 
 // beadDepsResponse is the JSON shape returned by /api/bead/{id}/deps.
@@ -377,6 +390,7 @@ type bdShowEntry struct {
 	Title          string        `json:"title"`
 	Status         string        `json:"status"`
 	Priority       int           `json:"priority"`
+	Notes          string        `json:"notes"`
 	DependencyType string        `json:"dependency_type"`
 	Dependencies   []bdShowEntry `json:"dependencies"`
 	Dependents     []bdShowEntry `json:"dependents"`
@@ -476,6 +490,13 @@ func fetchBeadDeps(ctx context.Context, dir, beadID string, lookup anvilLookup) 
 	if err != nil {
 		return []beadDetailDepRef{}, []beadDetailDepRef{}
 	}
+	return extractBeadDeps(entry, lookup)
+}
+
+// extractBeadDeps projects an already-fetched bd show entry into immediate
+// Blocks/BlockedBy lists. Split out so handleBeadDetail can reuse the same
+// `bd show` invocation that supplies Notes.
+func extractBeadDeps(entry *bdShowEntry, lookup anvilLookup) (blocks, blockedBy []beadDetailDepRef) {
 	blocks = make([]beadDetailDepRef, 0, len(entry.Dependents))
 	for _, d := range entry.Dependents {
 		if !isBlockingDep(d) {
@@ -491,6 +512,57 @@ func fetchBeadDeps(ctx context.Context, dir, beadID string, lookup anvilLookup) 
 		blockedBy = append(blockedBy, makeDepRef(d, lookup))
 	}
 	return blocks, blockedBy
+}
+
+// bdCommentsJSON shells out to `bd comments <id> --json`. The variable is
+// package-level so tests can swap it without spawning real subprocesses. The
+// dir parameter is the anvil's on-disk path; passing a non-empty value sets
+// cmd.Dir so bd can locate the Dolt database.
+var bdCommentsJSON = func(ctx context.Context, dir, beadID string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "bd", "comments", beadID, "--json")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	executil.HideWindow(cmd)
+	return cmd.Output()
+}
+
+// fetchBeadComments returns the comment list for the bead, or an empty slice
+// on any failure. bd's JSON shape uses `text` for the comment body; this
+// helper renames it to `body` for the web layer's response.
+func fetchBeadComments(ctx context.Context, dir, beadID string, logger *slog.Logger) []beadDetailComment {
+	out, err := bdCommentsJSON(ctx, dir, beadID)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("bd comments failed", "bead_id", beadID, "error", err)
+		}
+		return []beadDetailComment{}
+	}
+	if len(out) == 0 {
+		return []beadDetailComment{}
+	}
+	var raw []struct {
+		ID        string `json:"id"`
+		Author    string `json:"author"`
+		Text      string `json:"text"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := executil.DecodeJSON(out, &raw); err != nil {
+		if logger != nil {
+			logger.Warn("bd comments decode failed", "bead_id", beadID, "error", err)
+		}
+		return []beadDetailComment{}
+	}
+	comments := make([]beadDetailComment, 0, len(raw))
+	for _, r := range raw {
+		comments = append(comments, beadDetailComment{
+			ID:        r.ID,
+			Author:    r.Author,
+			Body:      r.Text,
+			CreatedAt: r.CreatedAt,
+		})
+	}
+	return comments
 }
 
 // makeDepRef projects a bd show entry into the web layer's dep ref shape.
@@ -583,6 +655,7 @@ func (s *Server) handleBeadDetail(w http.ResponseWriter, r *http.Request) {
 		PRs:       []beadDetailPR{},
 		Blocks:    []beadDetailDepRef{},
 		BlockedBy: []beadDetailDepRef{},
+		Comments:  []beadDetailComment{},
 	}
 
 	// Queue cache lookup. The DB only exposes a list helper, so we filter in
@@ -715,12 +788,20 @@ func (s *Server) handleBeadDetail(w http.ResponseWriter, r *http.Request) {
 	prs := collectBeadPRs(s.db, beadID, resp.Anvil)
 	resp.PRs = prs
 
-	// Dependency lists. `bd show <id> --json` is the source of truth for
-	// the bead graph and handles cross-anvil deps gracefully. Failures
-	// fall back to empty slices so the response shape stays stable.
+	// Dependency lists + notes share a single `bd show <id> --json` call.
+	// Failures fall back to empty slices/strings so the response shape
+	// stays stable when bd is missing or returns unexpected output.
 	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 	defer cancel()
-	resp.Blocks, resp.BlockedBy = fetchBeadDeps(ctx, s.resolveAnvilPath(resp.Anvil), beadID, newAnvilLookup(s.db))
+	anvilPath := s.resolveAnvilPath(resp.Anvil)
+	if entry, err := fetchBeadShow(ctx, anvilPath, beadID); err == nil && entry != nil {
+		resp.Notes = entry.Notes
+		resp.Blocks, resp.BlockedBy = extractBeadDeps(entry, newAnvilLookup(s.db))
+	}
+
+	// Comments come from a separate `bd comments <id> --json` shell-out.
+	// Errors are non-fatal: the rest of the page still renders.
+	resp.Comments = fetchBeadComments(ctx, anvilPath, beadID, s.logger)
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/web/views_test.go
+++ b/internal/web/views_test.go
@@ -17,6 +17,9 @@ import (
 // lock for its entire lifetime; only one such test can run at a time.
 var bdShowMu sync.Mutex
 
+// bdCommentsMu serializes bdCommentsJSON swaps for the same reason.
+var bdCommentsMu sync.Mutex
+
 // stubBdShow installs a temporary bdShowJSON implementation for the test.
 // bdShowMu is locked until t.Cleanup runs, serializing parallel tests that
 // use the global. The fn callback receives only the bead ID; the dir
@@ -31,6 +34,21 @@ func stubBdShow(t *testing.T, fn func(beadID string) ([]byte, error)) {
 	t.Cleanup(func() {
 		bdShowJSON = prev
 		bdShowMu.Unlock()
+	})
+}
+
+// stubBdComments installs a temporary bdCommentsJSON implementation for the
+// test, mirroring stubBdShow.
+func stubBdComments(t *testing.T, fn func(beadID string) ([]byte, error)) {
+	t.Helper()
+	bdCommentsMu.Lock()
+	prev := bdCommentsJSON
+	bdCommentsJSON = func(_ context.Context, _ string, beadID string) ([]byte, error) {
+		return fn(beadID)
+	}
+	t.Cleanup(func() {
+		bdCommentsJSON = prev
+		bdCommentsMu.Unlock()
 	})
 }
 
@@ -124,6 +142,9 @@ func TestBeadDetail_IncludesDeps(t *testing.T) {
 			[]map[string]any{depEntry("Forge-up", "Upstream", "closed", 1)},
 		), nil
 	})
+	stubBdComments(t, func(_ string) ([]byte, error) {
+		return []byte("[]"), nil
+	})
 
 	srv := newServerWithDefaults(t, nil)
 	cookie := loginAndGetCookie(t, srv)
@@ -154,6 +175,9 @@ func TestBeadDetail_IncludesDeps(t *testing.T) {
 func TestBeadDetail_IsolatedBeadEmptyDeps(t *testing.T) {
 	stubBdShow(t, func(beadID string) ([]byte, error) {
 		return bdShowFixture(beadID, "Solo", "open", 3, nil, nil), nil
+	})
+	stubBdComments(t, func(_ string) ([]byte, error) {
+		return []byte("[]"), nil
 	})
 
 	srv := newServerWithDefaults(t, nil)
@@ -462,5 +486,120 @@ func TestDepsEndpoint_RequiresAuth(t *testing.T) {
 	srv.routes().ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}
+
+// bdShowFixtureWithNotes mirrors bdShowFixture but injects a `notes` field
+// alongside the rest of the show payload, matching how bd renders beads with
+// `--append-notes` content.
+func bdShowFixtureWithNotes(id, title, status string, priority int, notes string, dependents, dependencies []map[string]any) []byte {
+	entry := map[string]any{
+		"id":           id,
+		"title":        title,
+		"status":       status,
+		"priority":     priority,
+		"notes":        notes,
+		"dependents":   dependents,
+		"dependencies": dependencies,
+	}
+	raw, _ := json.Marshal([]any{entry})
+	return raw
+}
+
+func TestBeadDetail_PopulatesNotesAndComments(t *testing.T) {
+	const notes = "First note line\nSecond note line"
+	stubBdShow(t, func(beadID string) ([]byte, error) {
+		if beadID != "Forge-notes" {
+			t.Errorf("unexpected bead id for show: %s", beadID)
+		}
+		return bdShowFixtureWithNotes("Forge-notes", "Notes bead", "in_progress", 2, notes, nil, nil), nil
+	})
+	stubBdComments(t, func(beadID string) ([]byte, error) {
+		if beadID != "Forge-notes" {
+			t.Errorf("unexpected bead id for comments: %s", beadID)
+		}
+		payload := `[
+			{"id":"c1","issue_id":"Forge-notes","author":"Alice","text":"first comment","created_at":"2026-05-13T10:00:00Z"},
+			{"id":"c2","issue_id":"Forge-notes","author":"Bob","text":"second comment","created_at":"2026-05-13T11:00:00Z"}
+		]`
+		return []byte(payload), nil
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-notes", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got beadDetailResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Notes != notes {
+		t.Errorf("notes mismatch: got %q want %q", got.Notes, notes)
+	}
+	if len(got.Comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d (%+v)", len(got.Comments), got.Comments)
+	}
+	want := []beadDetailComment{
+		{ID: "c1", Author: "Alice", Body: "first comment", CreatedAt: "2026-05-13T10:00:00Z"},
+		{ID: "c2", Author: "Bob", Body: "second comment", CreatedAt: "2026-05-13T11:00:00Z"},
+	}
+	for i, w := range want {
+		if got.Comments[i] != w {
+			t.Errorf("comment %d: got %+v want %+v", i, got.Comments[i], w)
+		}
+	}
+}
+
+func TestBeadDetail_CommentsFailureReturnsEmpty(t *testing.T) {
+	const notes = "Notes still present"
+	stubBdShow(t, func(_ string) ([]byte, error) {
+		return bdShowFixtureWithNotes("Forge-cerr", "Comment err", "open", 3, notes, nil, nil), nil
+	})
+	stubBdComments(t, func(_ string) ([]byte, error) {
+		return nil, errors.New("bd comments: exit 1")
+	})
+
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/bead/Forge-cerr", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 even when bd comments fails, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Comments must be a non-null, empty array — the SPA assumes the
+	// field is always iterable. Notes from the (successful) bd show call
+	// must still be surfaced.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("parse raw: %v", err)
+	}
+	commentsRaw, ok := raw["comments"]
+	if !ok {
+		t.Fatalf("comments field missing from response: %s", rec.Body.String())
+	}
+	if string(commentsRaw) != "[]" {
+		t.Errorf("comments should serialise as [] on failure, got %s", string(commentsRaw))
+	}
+
+	var got beadDetailResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Notes != notes {
+		t.Errorf("notes lost on comments failure: got %q want %q", got.Notes, notes)
+	}
+	if len(got.Comments) != 0 {
+		t.Errorf("expected zero comments on failure, got %+v", got.Comments)
 	}
 }


### PR DESCRIPTION
## Changes

- **Bead detail API now surfaces notes and comments** - `GET /api/bead/{id}` includes the bead's appended notes (from `bd show --json`) and the comment thread (from `bd comments --json`), unlocking the bead detail UI panels. Comment fetch failures are non-fatal and return an empty array. (Forge-fdz6)

## Original Issue (task): Backend: extend beadDetailResponse with notes and comments

Modify `internal/web/views.go` (~line 326) to add `Notes string` and `Comments []beadDetailComment` fields to `beadDetailResponse`, and define the `beadDetailComment` struct with ID, Author, Body, CreatedAt fields. Update `handleBeadDetail` in `internal/web/handlers.go` to populate them: read notes from the existing `bd show <id> --json` call (check whether they appear as a `notes` field or are appended into `description` — use whichever beads actually populates from `--append-notes`); shell out to `bd comments <id> --json` using the existing `resolveCommand("bd")` + `anvilDirForBead()` pattern from `internal/forge/handlers.go`, parse the JSON array into `[]beadDetailComment`. Errors from `bd comments` are non-fatal: log and return empty Comments slice. No caching for v1. Extend `handleBeadDetail` tests with a fixture where bd show returns notes and bd comments returns 2 comments — assert both surface in the response; add a failure-path test where `bd comments` exits non-zero and assert `Comments: []` with no error. This sub-task is the prerequisite for the frontend and composer sub-tasks — they consume the new response fields and endpoint pattern established here.

---
Bead: Forge-fdz6 | Branch: forge/Forge-fdz6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->