### PR TITLE
Temper: cap Vitest worker concurrency to reduce smith-OOM kills (Forge-oqge)

### DIFF
--- a/changelog.d/Forge-oqge.md
+++ b/changelog.d/Forge-oqge.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Temper caps Vitest worker concurrency to one thread** - Auto-detected Vitest test steps now pass `--pool=threads --poolOptions.threads.maxThreads=1 --poolOptions.threads.minThreads=1` so a single Smith does not spawn N-CPU Vitest workers, each potentially using 1+ GB RSS. Prevents OOM kills on memory-constrained hosts. Users can opt out by overriding the test step via `temper.commands` or `temper.steps`. (Forge-oqge)

--- a/internal/temper/temper.go
+++ b/internal/temper/temper.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -23,6 +24,19 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"gopkg.in/yaml.v3"
 )
+
+// vitestSingleThreadArgs caps Vitest worker concurrency to one thread. On
+// memory-constrained hosts the default Vitest pool spawns N-CPU workers, each
+// of which can balloon to 1+ GB RSS on Vite-based frontends — enough to push
+// the Forge daemon, the Smith subprocess, and the temper test runner past the
+// host's RAM and trigger an OOM kill of the Smith. Single-threaded mode is
+// slower but functionally identical. Users who know their host can take more
+// can override the test step entirely via `temper.commands` / `temper.steps`.
+var vitestSingleThreadArgs = []string{
+	"--pool=threads",
+	"--poolOptions.threads.maxThreads=1",
+	"--poolOptions.threads.minThreads=1",
+}
 
 // StepResult captures the outcome of a single verification step.
 type StepResult struct {
@@ -625,10 +639,18 @@ func detectSteps(worktreePath string, opts *DetectOptions, goRace bool) []Step {
 			Timeout:  2 * time.Minute,
 			Optional: true, // lint might not be configured
 		})
+		// When the test:run script invokes Vitest, pass through worker-cap
+		// flags via `npm run ... --` so the pool stays single-threaded. See
+		// vitestSingleThreadArgs for rationale.
+		testArgs := []string{"run", "test:run"}
+		if scriptUsesVitest(filepath.Join(worktreePath, nodeDir), "test:run") {
+			testArgs = append(testArgs, "--")
+			testArgs = append(testArgs, vitestSingleThreadArgs...)
+		}
 		steps = append(steps, Step{
 			Name:     prefix + "test",
 			Command:  "npm",
-			Args:     []string{"run", "test:run"},
+			Args:     testArgs,
 			Dir:      dir,
 			Timeout:  5 * time.Minute,
 			Optional: true, // test script might not exist
@@ -959,6 +981,48 @@ func hasRunPrefix(line []byte, c byte) bool {
 		}
 	}
 	return true
+}
+
+// scriptUsesVitest reports whether the named script in dir/package.json
+// invokes Vitest. Returns false when package.json is missing, unreadable, or
+// does not declare the script — those cases are safe defaults because the
+// fallback `npm run <script>` invocation will either no-op or be reported as
+// an optional test failure by Temper without affecting the overall result.
+func scriptUsesVitest(dir, scriptName string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	script, ok := pkg.Scripts[scriptName]
+	if !ok {
+		return false
+	}
+	return commandInvokesVitest(script)
+}
+
+// commandInvokesVitest reports whether the given npm script command line
+// invokes vitest as one of its tokens. It matches `vitest`, `vitest run`,
+// `npx vitest`, and `node_modules/.bin/vitest` style invocations without
+// matching substrings that merely contain the letters (e.g. `vitestic`).
+func commandInvokesVitest(script string) bool {
+	for _, tok := range strings.Fields(script) {
+		base := tok
+		if i := strings.LastIndexAny(tok, "/\\"); i >= 0 {
+			base = tok[i+1:]
+		}
+		base = strings.TrimSuffix(base, ".cmd")
+		base = strings.TrimSuffix(base, ".exe")
+		if base == "vitest" {
+			return true
+		}
+	}
+	return false
 }
 
 // detectNodeDirs returns the relative directories containing a package.json.

--- a/internal/temper/temper_test.go
+++ b/internal/temper/temper_test.go
@@ -189,6 +189,142 @@ func TestDetectSteps_NodeAtRoot(t *testing.T) {
 	}
 }
 
+func TestDetectSteps_AppendsVitestWorkerCapWhenScriptUsesVitest(t *testing.T) {
+	// Reproduces the Hytte OOM scenario: a Vite/Vitest frontend whose test:run
+	// script invokes vitest. Temper must cap worker concurrency to 1 thread so
+	// uncapped Vitest workers cannot push the host past its RAM limit.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{
+        "scripts": {
+            "test:run": "vitest run",
+            "lint": "eslint ."
+        }
+    }`), 0o644))
+
+	steps := detectSteps(dir, nil, false)
+
+	var testStep *Step
+	for i := range steps {
+		if steps[i].Name == "test" {
+			testStep = &steps[i]
+			break
+		}
+	}
+	require.NotNil(t, testStep, "expected a test step for the Node project")
+
+	assert.Equal(t, "npm", testStep.Command)
+	assert.Contains(t, testStep.Args, "--",
+		"vitest args must be passed after `--` so npm forwards them to the script")
+	assert.Contains(t, testStep.Args, "--pool=threads")
+	assert.Contains(t, testStep.Args, "--poolOptions.threads.maxThreads=1")
+	assert.Contains(t, testStep.Args, "--poolOptions.threads.minThreads=1")
+
+	// The leading "run test:run" prefix must still be intact so the existing
+	// npm invocation continues to work.
+	require.GreaterOrEqual(t, len(testStep.Args), 2)
+	assert.Equal(t, "run", testStep.Args[0])
+	assert.Equal(t, "test:run", testStep.Args[1])
+}
+
+func TestDetectSteps_DoesNotAppendVitestCapWhenScriptDoesNotUseVitest(t *testing.T) {
+	// A non-Vitest test script (e.g. jest, mocha) must not get the Vitest-
+	// specific flags appended — those flags would either be ignored or
+	// reported as unknown options by other runners.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{
+        "scripts": {
+            "test:run": "jest --ci"
+        }
+    }`), 0o644))
+
+	steps := detectSteps(dir, nil, false)
+
+	var testStep *Step
+	for i := range steps {
+		if steps[i].Name == "test" {
+			testStep = &steps[i]
+			break
+		}
+	}
+	require.NotNil(t, testStep, "expected a test step for the Node project")
+
+	assert.Equal(t, []string{"run", "test:run"}, testStep.Args,
+		"non-vitest scripts must not have vitest cap flags appended")
+}
+
+func TestDetectSteps_DoesNotAppendVitestCapWhenScriptMissing(t *testing.T) {
+	// An empty/missing scripts block must not get the Vitest cap — there is
+	// no way to know what the script will do, so default to the previous
+	// behaviour of just running `npm run test:run`.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+
+	steps := detectSteps(dir, nil, false)
+
+	var testStep *Step
+	for i := range steps {
+		if steps[i].Name == "test" {
+			testStep = &steps[i]
+			break
+		}
+	}
+	require.NotNil(t, testStep)
+	assert.Equal(t, []string{"run", "test:run"}, testStep.Args)
+}
+
+func TestConfigFromSteps_OverridePreservesUserCommandUnchanged(t *testing.T) {
+	// Acceptance criterion from the bead: a per-anvil temper.steps override
+	// must pass through verbatim — Forge must not silently inject the Vitest
+	// worker cap into a user-supplied command.
+	userArgs := []string{"run", "test:run"}
+	cfg := ConfigFromSteps([]config.TemperStepConfig{
+		{Name: "test", Command: "npm", Args: userArgs},
+	})
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Steps, 1)
+	assert.Equal(t, "npm", cfg.Steps[0].Command)
+	assert.Equal(t, userArgs, cfg.Steps[0].Args,
+		"user-supplied Args must be preserved verbatim; auto-detect cap must not leak in")
+}
+
+func TestCommandInvokesVitest(t *testing.T) {
+	cases := []struct {
+		script string
+		want   bool
+	}{
+		{"vitest", true},
+		{"vitest run", true},
+		{"vitest run --coverage", true},
+		{"npx vitest run", true},
+		{"node_modules/.bin/vitest run", true},
+		{"./node_modules/.bin/vitest", true},
+		{"vitest.cmd run", true},
+		{"jest --ci", false},
+		{"mocha --reporter spec", false},
+		{"", false},
+		{"echo vitestic", false}, // substring must not match
+		{"echo not-vitest", false},
+	}
+	for _, c := range cases {
+		got := commandInvokesVitest(c.script)
+		assert.Equal(t, c.want, got, "commandInvokesVitest(%q)", c.script)
+	}
+}
+
+func TestScriptUsesVitest_MissingPackageJSON(t *testing.T) {
+	// No package.json at all — must safely return false rather than panicking
+	// or returning an error to callers.
+	dir := t.TempDir()
+	assert.False(t, scriptUsesVitest(dir, "test:run"))
+}
+
+func TestScriptUsesVitest_CorruptPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{not valid json"), 0o644))
+	assert.False(t, scriptUsesVitest(dir, "test:run"),
+		"corrupt JSON must not crash detection; safe default is `not vitest`")
+}
+
 func TestDetectSteps_NodeInSubdirectory(t *testing.T) {
 	dir := t.TempDir()
 	// Go at root, Node in web/


### PR DESCRIPTION
## Changes

- **Temper caps Vitest worker concurrency to one thread** - Auto-detected Vitest test steps now pass `--pool=threads --poolOptions.threads.maxThreads=1 --poolOptions.threads.minThreads=1` so a single Smith does not spawn N-CPU Vitest workers, each potentially using 1+ GB RSS. Prevents OOM kills on memory-constrained hosts. Users can opt out by overriding the test step via `temper.commands` or `temper.steps`. (Forge-oqge)

## Original Issue (bug): Temper: cap Vitest worker concurrency to reduce smith-OOM kills

On a memory-constrained host, Forge's Temper stage runs Vitest with default worker concurrency (≈ N CPU cores worth of workers). Each worker can use 1+ GB of RSS on Vite-based frontends, and the smith subprocess + Vite/dev tooling + Hytte web service together routinely push the box past its 7.6 GB RAM, triggering OOM kills.

Real example today: a smith was working on Hytte-i9tm (Pokémon CardScanner). Two Vitest worker processes hit 4.3 GB and 2.0 GB RSS respectively, on top of the smith's own 4 GB. The kernel OOM-killed the smith THREE times in one hour. Adding swap mitigated the immediate damage but the underlying cost of Temper running uncapped Vitest workers is still there.

## Fix

In `internal/temper/` (or wherever the auto-detected Vitest step is built — likely `internal/temper/node.go` or similar that detects `package.json`), append worker-capping arguments when invoking Vitest:

    vitest run --pool=threads --poolOptions.threads.maxThreads=1 --poolOptions.threads.minThreads=1

(Or use `--maxWorkers=1` if that's the supported flag for the detected version.)

Concretely:
- If the package's package.json has `"test": "vitest ..."` and Temper rewrites/wraps it, append the concurrency flags.
- If Temper uses its own `vitest run` command, just include the flags there.
- Make this configurable via the existing per-anvil Temper config (`temper.commands` / `temper.steps`) so a user can opt out by overriding the command. Default behaviour: single-threaded.

Don't add the flags universally to `go test` or other runners — they don't have this issue.

## Optional: env-based opt-out

A small `temper.vitest_max_threads` config knob (default 1, can be set higher if the user knows their host can take it). Defer if it adds friction; the single-threaded default is fine for the Hetzner box.

## Tests

Add a unit test in `internal/temper/` that, given a sample Node project with a vitest test step, asserts the constructed command line includes the maxThreads cap.

## Acceptance

- `make build`, `make test`, `go vet ./...` pass.
- A smith finishing on a Vitest-heavy bead no longer triggers OOM kills on the Hetzner box (observable via `dmesg | grep oom`).
- Existing Vitest tests still pass — single-thread mode is slower but functionally identical.
- Per-anvil override still works.
- Changelog fragment in changelog.d/ (category: Fixed).

## Reference

- internal/temper/ — auto-detection logic for Node/Vitest.
- Today's OOM evidence in `journalctl -k`:

      Out of memory: Killed process 763882 (MainThread) total-vm:34522188kB, anon-rss:4311428kB ... task_memcg=/system.slice/forge.service

- Vitest workers docs: https://vitest.dev/config/#poolOptions.

## Non-goals

- Disabling Vitest in Temper entirely. CI handles the comprehensive test pass; Temper is a smoke gate.
- Memory limits on the smith subprocess itself.
- Migrating away from Vitest.

## Future-option (option X from the discussion)

If even single-threaded Vitest is too heavy on this host, the next step is to **skip frontend tests in Temper and rely solely on CI** for the test signal. Document this as the next escalation if (a) Temper Vitest still triggers OOMs after the worker cap, or (b) Temper Vitest meaningfully extends the smith pipeline duration. Not implemented in this bead.


---
Bead: Forge-oqge | Branch: forge/Forge-oqge
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->