### PR TITLE
Add useUIState persistence hook with tests (Forge-vnrf)

### DIFF
--- a/changelog.d/Forge-vnrf.md
+++ b/changelog.d/Forge-vnrf.md
@@ -1,0 +1,2 @@
+category: Added
+- **`useUIState` persistence hook** - New `internal/web/frontend/src/hooks/useUIState.ts` typed wrapper over sessionStorage/localStorage with JSON codec, ~150ms debounced writes, SSR-safe init, and a `clearAll(prefix?)` export for tests. Foundational primitive for remembering pane-local UI state (sort orders, expanded rows, filters) across routes and per user. (Forge-vnrf)

--- a/internal/web/frontend/src/hooks/useUIState.test.tsx
+++ b/internal/web/frontend/src/hooks/useUIState.test.tsx
@@ -3,16 +3,31 @@ import { act, renderHook } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import type { ReactNode } from 'react'
 
-const { useAuthMock } = vi.hoisted(() => ({
-  useAuthMock: vi.fn(() => ({
-    authenticated: true,
-    user: 'alice',
-    loading: false,
-    login: async () => ({ ok: true }),
-    logout: async () => {},
-    refresh: async () => {},
-  })),
-}))
+const { useAuthMock } = vi.hoisted(() => {
+  type State = {
+    authenticated: boolean
+    user: string | null
+    loading: boolean
+    login: (
+      user: string,
+      password: string,
+    ) => Promise<{ ok: boolean; error?: string }>
+    logout: () => Promise<void>
+    refresh: () => Promise<void>
+  }
+  return {
+    useAuthMock: vi.fn(
+      (): State => ({
+        authenticated: true,
+        user: 'alice',
+        loading: false,
+        login: async () => ({ ok: true }),
+        logout: async () => {},
+        refresh: async () => {},
+      }),
+    ),
+  }
+})
 
 vi.mock('../auth', () => ({
   useAuth: () => useAuthMock(),

--- a/internal/web/frontend/src/hooks/useUIState.test.tsx
+++ b/internal/web/frontend/src/hooks/useUIState.test.tsx
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+
+const { useAuthMock } = vi.hoisted(() => ({
+  useAuthMock: vi.fn(() => ({
+    authenticated: true,
+    user: 'alice',
+    loading: false,
+    login: async () => ({ ok: true }),
+    logout: async () => {},
+    refresh: async () => {},
+  })),
+}))
+
+vi.mock('../auth', () => ({
+  useAuth: () => useAuthMock(),
+}))
+
+import { KEY_PREFIX, clearAll, useUIState } from './useUIState'
+
+function wrapperFor(path = '/dashboard') {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+  useAuthMock.mockReturnValue({
+    authenticated: true,
+    user: 'alice',
+    loading: false,
+    login: async () => ({ ok: true }),
+    logout: async () => {},
+    refresh: async () => {},
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useUIState', () => {
+  it('returns the initial value when storage is empty', () => {
+    const { result } = renderHook(() => useUIState('sort', 'asc'), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+    expect(result.current[0]).toBe('asc')
+  })
+
+  it('reads an existing JSON value from sessionStorage on mount', () => {
+    sessionStorage.setItem(`${KEY_PREFIX}dashboard.sort`, JSON.stringify('desc'))
+    const { result } = renderHook(() => useUIState('sort', 'asc'), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+    expect(result.current[0]).toBe('desc')
+  })
+
+  it('writes to sessionStorage after the debounce window', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useUIState('sort', 'asc'), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+
+    act(() => {
+      result.current[1]('desc')
+    })
+    expect(result.current[0]).toBe('desc')
+    // Write should not have happened yet.
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.sort`)).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(150)
+    })
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.sort`)).toBe(
+      JSON.stringify('desc'),
+    )
+  })
+
+  it('coalesces rapid setter calls into a single debounced write', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useUIState('counter', 0), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+
+    act(() => {
+      result.current[1](1)
+      vi.advanceTimersByTime(50)
+      result.current[1](2)
+      vi.advanceTimersByTime(50)
+      result.current[1](3)
+    })
+    // Still within the debounce window of the last call — no write yet.
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.counter`)).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(150)
+    })
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.counter`)).toBe(
+      JSON.stringify(3),
+    )
+  })
+
+  it('round-trips JSON-serializable objects', () => {
+    vi.useFakeTimers()
+    type Filters = { tags: string[]; open: boolean }
+    const { result, unmount } = renderHook(
+      () => useUIState<Filters>('filters', { tags: [], open: false }),
+      { wrapper: wrapperFor('/queue') },
+    )
+
+    act(() => {
+      result.current[1]({ tags: ['ready', 'p0'], open: true })
+      vi.advanceTimersByTime(150)
+    })
+
+    unmount()
+
+    const { result: next } = renderHook(
+      () => useUIState<Filters>('filters', { tags: [], open: false }),
+      { wrapper: wrapperFor('/queue') },
+    )
+    expect(next.current[0]).toEqual({ tags: ['ready', 'p0'], open: true })
+  })
+
+  it('supports functional updaters', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useUIState<number>('n', 0), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+    act(() => {
+      result.current[1]((prev) => prev + 1)
+      result.current[1]((prev) => prev + 1)
+      vi.advanceTimersByTime(150)
+    })
+    expect(result.current[0]).toBe(2)
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.n`)).toBe(
+      JSON.stringify(2),
+    )
+  })
+
+  it('falls back to the initial value when stored JSON is malformed', () => {
+    sessionStorage.setItem(`${KEY_PREFIX}dashboard.sort`, '{not-json')
+    const { result } = renderHook(() => useUIState('sort', 'asc'), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+    expect(result.current[0]).toBe('asc')
+  })
+
+  it('uses localStorage when storage: "local" is requested', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(
+      () => useUIState('theme', 'dark', { storage: 'local' }),
+      { wrapper: wrapperFor('/dashboard') },
+    )
+    act(() => {
+      result.current[1]('light')
+      vi.advanceTimersByTime(150)
+    })
+    expect(localStorage.getItem(`${KEY_PREFIX}dashboard.theme`)).toBe(
+      JSON.stringify('light'),
+    )
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.theme`)).toBeNull()
+  })
+
+  it('reads from localStorage when storage: "local"', () => {
+    localStorage.setItem(`${KEY_PREFIX}dashboard.theme`, JSON.stringify('light'))
+    const { result } = renderHook(
+      () => useUIState('theme', 'dark', { storage: 'local' }),
+      { wrapper: wrapperFor('/dashboard') },
+    )
+    expect(result.current[0]).toBe('light')
+  })
+
+  it('namespaces keys by route when scope: "route" (default)', () => {
+    vi.useFakeTimers()
+    const a = renderHook(() => useUIState('expanded', false), {
+      wrapper: wrapperFor('/queue'),
+    })
+    const b = renderHook(() => useUIState('expanded', false), {
+      wrapper: wrapperFor('/ingots'),
+    })
+
+    act(() => {
+      a.result.current[1](true)
+      vi.advanceTimersByTime(150)
+    })
+
+    expect(sessionStorage.getItem(`${KEY_PREFIX}queue.expanded`)).toBe(
+      JSON.stringify(true),
+    )
+    expect(b.result.current[0]).toBe(false)
+    expect(sessionStorage.getItem(`${KEY_PREFIX}ingots.expanded`)).toBeNull()
+  })
+
+  it('namespaces keys by user when scope: "user"', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(
+      () => useUIState('prefs', 'a', { scope: 'user', storage: 'local' }),
+      { wrapper: wrapperFor('/dashboard') },
+    )
+    act(() => {
+      result.current[1]('b')
+      vi.advanceTimersByTime(150)
+    })
+    expect(localStorage.getItem(`${KEY_PREFIX}alice.prefs`)).toBe(
+      JSON.stringify('b'),
+    )
+  })
+
+  it('falls back to "anon" when no user is authenticated', () => {
+    vi.useFakeTimers()
+    useAuthMock.mockReturnValue({
+      authenticated: false,
+      user: null,
+      loading: false,
+      login: async () => ({ ok: false }),
+      logout: async () => {},
+      refresh: async () => {},
+    })
+    const { result } = renderHook(
+      () => useUIState('prefs', 'a', { scope: 'user', storage: 'local' }),
+      { wrapper: wrapperFor('/dashboard') },
+    )
+    act(() => {
+      result.current[1]('b')
+      vi.advanceTimersByTime(150)
+    })
+    expect(localStorage.getItem(`${KEY_PREFIX}anon.prefs`)).toBe(
+      JSON.stringify('b'),
+    )
+  })
+
+  it('flushes a pending write on unmount', () => {
+    vi.useFakeTimers()
+    const { result, unmount } = renderHook(() => useUIState('sort', 'asc'), {
+      wrapper: wrapperFor('/dashboard'),
+    })
+    act(() => {
+      result.current[1]('desc')
+    })
+    // Unmount before debounce expires.
+    unmount()
+    expect(sessionStorage.getItem(`${KEY_PREFIX}dashboard.sort`)).toBe(
+      JSON.stringify('desc'),
+    )
+  })
+})
+
+describe('clearAll', () => {
+  it('removes only forge.ui.* keys from both storages', () => {
+    sessionStorage.setItem(`${KEY_PREFIX}a.k1`, '"x"')
+    sessionStorage.setItem('unrelated', 'keep')
+    localStorage.setItem(`${KEY_PREFIX}b.k2`, '"y"')
+    localStorage.setItem('also-unrelated', 'keep')
+
+    clearAll()
+
+    expect(sessionStorage.getItem(`${KEY_PREFIX}a.k1`)).toBeNull()
+    expect(localStorage.getItem(`${KEY_PREFIX}b.k2`)).toBeNull()
+    expect(sessionStorage.getItem('unrelated')).toBe('keep')
+    expect(localStorage.getItem('also-unrelated')).toBe('keep')
+  })
+
+  it('honours a custom prefix', () => {
+    sessionStorage.setItem(`${KEY_PREFIX}a.k1`, '"x"')
+    sessionStorage.setItem(`${KEY_PREFIX}b.k2`, '"y"')
+    clearAll(`${KEY_PREFIX}a.`)
+    expect(sessionStorage.getItem(`${KEY_PREFIX}a.k1`)).toBeNull()
+    expect(sessionStorage.getItem(`${KEY_PREFIX}b.k2`)).toBe('"y"')
+  })
+})

--- a/internal/web/frontend/src/hooks/useUIState.ts
+++ b/internal/web/frontend/src/hooks/useUIState.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useAuth } from '../auth'
+
+type StorageKind = 'session' | 'local'
+type Scope = 'route' | 'user'
+
+interface UseUIStateOptions {
+  // storage selects sessionStorage (default) or localStorage. Session storage
+  // is the right fit for transient pane state (sort orders, expanded rows);
+  // local storage is for preferences that should survive a browser restart.
+  storage?: StorageKind
+  // scope decides how the key is namespaced. `route` partitions state by the
+  // current pathname so two pages don't collide on the same logical key.
+  // `user` partitions by authenticated user ID so per-user preferences don't
+  // leak across accounts on a shared machine.
+  scope?: Scope
+}
+
+export const KEY_PREFIX = 'forge.ui.'
+const DEBOUNCE_MS = 150
+
+function ssr(): boolean {
+  return typeof window === 'undefined'
+}
+
+function getStore(kind: StorageKind): globalThis.Storage | null {
+  if (ssr()) return null
+  try {
+    return kind === 'local' ? window.localStorage : window.sessionStorage
+  } catch {
+    // Storage access can throw in private-browsing or sandboxed iframes.
+    return null
+  }
+}
+
+function sanitize(seg: string): string {
+  // Keep keys readable in DevTools — strip leading slashes and replace
+  // characters that would make keys awkward to grep for.
+  return seg.replace(/^\/+/, '').replace(/[^A-Za-z0-9_.\-]/g, '_') || 'root'
+}
+
+function buildKey(scopeID: string, key: string): string {
+  return `${KEY_PREFIX}${sanitize(scopeID)}.${sanitize(key)}`
+}
+
+function readFromStore<T>(
+  store: globalThis.Storage | null,
+  key: string,
+  fallback: T,
+): T {
+  if (!store) return fallback
+  try {
+    const raw = store.getItem(key)
+    if (raw === null) return fallback
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+function writeToStore<T>(store: globalThis.Storage, key: string, value: T): void {
+  try {
+    store.setItem(key, JSON.stringify(value))
+  } catch {
+    // Quota-exceeded or serialization errors are non-fatal — we still keep
+    // the in-memory value, just don't persist it.
+  }
+}
+
+// useUIState is a typed sessionStorage/localStorage hook with debounced writes
+// and SSR-safe initialization. It is intended as the single primitive for
+// remembering pane-local UI state (sort orders, expanded rows, filter chips)
+// so individual components opt in with a one-liner instead of reinventing
+// storage glue.
+export function useUIState<T>(
+  key: string,
+  initial: T,
+  opts: UseUIStateOptions = {},
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const { storage = 'session', scope = 'route' } = opts
+  const location = useLocation()
+  const { user } = useAuth()
+
+  const scopeID = scope === 'route' ? location.pathname || 'default' : user || 'anon'
+  const storageKey = buildKey(scopeID, key)
+  const store = getStore(storage)
+
+  const [value, setValue] = useState<T>(() => readFromStore(store, storageKey, initial))
+
+  // stateRef mirrors `value` and serves as the source of truth for functional
+  // updaters and the debounced writer. We update it directly inside the setter
+  // so the timer callback doesn't depend on React's render cycle to observe
+  // the latest value — important under fake timers and rapid sequences.
+  const stateRef = useRef<T>(value)
+  const storeRef = useRef(store)
+  const keyRef = useRef(storageKey)
+  const timerRef = useRef<number | undefined>(undefined)
+
+  // Re-read when the storage key changes (route navigation, user login/logout)
+  // or the storage backend swaps (rare, but supported via opts changes). Any
+  // pending write is flushed to the previous key first so we don't lose
+  // edits made just before navigating away.
+  useEffect(() => {
+    if (keyRef.current === storageKey && storeRef.current === store) return
+    if (timerRef.current !== undefined) {
+      window.clearTimeout(timerRef.current)
+      if (storeRef.current) {
+        writeToStore(storeRef.current, keyRef.current, stateRef.current)
+      }
+      timerRef.current = undefined
+    }
+    keyRef.current = storageKey
+    storeRef.current = store
+    const fresh = readFromStore(store, storageKey, initial)
+    stateRef.current = fresh
+    setValue(fresh)
+    // `initial` is intentionally omitted from deps — consumers commonly pass
+    // a fresh object/array literal each render, which would otherwise wipe
+    // stored state on every parent re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey, store])
+
+  const setter = useCallback((next: T | ((prev: T) => T)) => {
+    const prev = stateRef.current
+    const resolved =
+      typeof next === 'function' ? (next as (p: T) => T)(prev) : next
+    stateRef.current = resolved
+    setValue(resolved)
+    const target = storeRef.current
+    if (!target) return
+    if (timerRef.current !== undefined) {
+      window.clearTimeout(timerRef.current)
+    }
+    timerRef.current = window.setTimeout(() => {
+      writeToStore(target, keyRef.current, stateRef.current)
+      timerRef.current = undefined
+    }, DEBOUNCE_MS)
+  }, [])
+
+  // Flush on unmount so a quick edit + navigation doesn't drop the change.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== undefined) {
+        window.clearTimeout(timerRef.current)
+        timerRef.current = undefined
+        if (storeRef.current) {
+          writeToStore(storeRef.current, keyRef.current, stateRef.current)
+        }
+      }
+    }
+  }, [])
+
+  return [value, setter]
+}
+
+// clearAll removes every forge.ui.* entry from both session and local storage.
+// Exported primarily for tests; production code should not need to call this.
+export function clearAll(prefix: string = KEY_PREFIX): void {
+  if (ssr()) return
+  for (const target of [window.sessionStorage, window.localStorage]) {
+    try {
+      const toRemove: string[] = []
+      for (let i = 0; i < target.length; i++) {
+        const k = target.key(i)
+        if (k && k.startsWith(prefix)) toRemove.push(k)
+      }
+      for (const k of toRemove) target.removeItem(k)
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/internal/web/frontend/src/hooks/useUIState.ts
+++ b/internal/web/frontend/src/hooks/useUIState.ts
@@ -158,7 +158,8 @@ export function useUIState<T>(
 // Exported primarily for tests; production code should not need to call this.
 export function clearAll(prefix: string = KEY_PREFIX): void {
   if (ssr()) return
-  for (const target of [window.sessionStorage, window.localStorage]) {
+  for (const target of [getStore('session'), getStore('local')]) {
+    if (!target) continue
     try {
       const toRemove: string[] = []
       for (let i = 0; i < target.length; i++) {


### PR DESCRIPTION
## Changes

- **`useUIState` persistence hook** - New `internal/web/frontend/src/hooks/useUIState.ts` typed wrapper over sessionStorage/localStorage with JSON codec, ~150ms debounced writes, SSR-safe init, and a `clearAll(prefix?)` export for tests. Foundational primitive for remembering pane-local UI state (sort orders, expanded rows, filters) across routes and per user. (Forge-vnrf)

## Original Issue (task): Add useUIState persistence hook with tests

Create `internal/web/frontend/src/hooks/useUIState.ts` exposing `useUIState<T>(key: string, initial: T, opts?: { storage?: 'session'|'local'; scope?: 'route'|'user' })` returning `[T, setter]`. Implementation: typed wrapper over sessionStorage/localStorage with JSON codec, debounced writes (~150ms), SSR-safe initialization, and a `clearAll(prefix?)` export for tests. Keys: `forge.ui.<route>.<key>` for session-scoped, `forge.ui.<userID>.<key>` for user-scoped (user ID obtained from existing auth context). Add unit tests covering read/write/clear/JSON round-trip, debounce, and storage-type selection. This is the foundational primitive consumed by all sibling sub-tasks — land it first so other panes can opt in with a one-liner.

---
Bead: Forge-vnrf | Branch: forge/Forge-vnrf
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->