### PR TITLE
Integration tests for PR and Workers pane restoration (Forge-skfx)

### DIFF
--- a/changelog.d/Forge-skfx.md
+++ b/changelog.d/Forge-skfx.md
@@ -1,0 +1,2 @@
+category: Added
+- **Combined PR/Workers pane restoration integration tests** - Added round-trip integration tests that exercise filter, sort, section-expanded, and scroll state together for the PR pane, and group-collapse plus scroll state together for the Workers pane, verifying all pane UI state composes correctly across a navigate-away/navigate-back cycle. (Forge-skfx)

--- a/internal/web/frontend/src/components/WorkersPane.persistence.test.tsx
+++ b/internal/web/frontend/src/components/WorkersPane.persistence.test.tsx
@@ -222,4 +222,89 @@ describe('WorkersPane persistence', () => {
 
     expect(scrollTopWrites).toContain(200)
   })
+
+  it('restores group collapse and scroll together after back-navigation', async () => {
+    // Combined integration test that mirrors the QueuePane round-trip pattern:
+    // multiple kinds of pane state (a group collapse in localStorage, a scroll
+    // position in sessionStorage) must all rehydrate in a single round-trip.
+    // The separate tests above verify each storage path in isolation; this one
+    // proves they compose — the unmount/remount cycle doesn't drop one because
+    // the other was also touched, and the first paint after pop carries both.
+    vi.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    const { router } = renderApp(TEST_WORKERS)
+
+    // Collapse the forge group — written to localStorage by useUIState.
+    const forgeHeader = screen.getByTestId('workers-group-forge')
+    await user.click(forgeHeader)
+    expect(forgeHeader).toHaveAttribute('aria-expanded', 'false')
+
+    // Set a scroll position — written to sessionStorage via the rAF-throttled
+    // onScroll handler. jsdom has no layout engine, so we shim scrollTop on
+    // the pane's scroll container to make the handler observe 175.
+    const scrollBody = document.querySelector('div[role="region"]') as HTMLElement
+    expect(scrollBody).not.toBeNull()
+    let _scrollTop = 175
+    Object.defineProperty(scrollBody, 'scrollTop', {
+      configurable: true,
+      get: () => _scrollTop,
+      set: (v: number) => {
+        _scrollTop = v
+      },
+    })
+    scrollBody.dispatchEvent(new Event('scroll'))
+
+    // Flush rAF + the 150ms useUIState debounce so the scroll value lands
+    // in sessionStorage before we navigate away.
+    await act(async () => {
+      vi.runAllTimers()
+    })
+
+    // Navigate away — the routes are siblings so WorkersPane fully unmounts.
+    // useUIState's unmount cleanup synchronously flushes any pending writes.
+    await act(async () => {
+      await router.navigate('/bead/bd-1')
+    })
+    expect(screen.getByTestId('bead-stub')).toBeInTheDocument()
+
+    // Spy on scrollTop writes during the remount so we can assert the
+    // useLayoutEffect restoration runs before paint with the right value.
+    const scrollTopWrites: number[] = []
+    const origDesc = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop')
+    Object.defineProperty(Element.prototype, 'scrollTop', {
+      configurable: true,
+      get: origDesc?.get ?? (() => 0),
+      set(v: number) {
+        scrollTopWrites.push(v)
+        origDesc?.set?.call(this, v)
+      },
+    })
+
+    try {
+      await act(async () => {
+        await router.navigate(-1)
+      })
+    } finally {
+      if (origDesc) {
+        Object.defineProperty(Element.prototype, 'scrollTop', origDesc)
+      } else {
+        delete (Element.prototype as unknown as Record<string, unknown>).scrollTop
+      }
+    }
+
+    // Collapse state (localStorage) survived the round-trip.
+    expect(screen.getByTestId('workers-group-forge')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    // heimdall was never toggled so it stays expanded — proves we restore only
+    // the deliberately stored entries, not a blanket "all collapsed" default.
+    expect(screen.getByTestId('workers-group-heimdall')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    // Scroll state (sessionStorage) was applied by useLayoutEffect before paint.
+    expect(scrollTopWrites).toContain(175)
+  })
 })

--- a/internal/web/frontend/src/pages/PRsPage.persistence.test.tsx
+++ b/internal/web/frontend/src/pages/PRsPage.persistence.test.tsx
@@ -264,4 +264,85 @@ describe('PRsPage persistence', () => {
     // useLayoutEffect should have called scrollTo(0, 250) before paint.
     expect(scrollToSpy).toHaveBeenCalledWith(0, 250)
   })
+
+  it('restores filter, sort, expanded sections, and scroll together after back-navigation', async () => {
+    // Combined integration test that mirrors the QueuePane round-trip pattern:
+    // four different kinds of pane state (filter in sessionStorage, sort in
+    // localStorage, section-expanded flags in localStorage, scroll position in
+    // sessionStorage) must all rehydrate in a single round-trip. The separate
+    // tests above verify each storage path in isolation; this one proves they
+    // compose — touching multiple keys in one session doesn't cause any to be
+    // dropped on the unmount/remount cycle and they all land before paint.
+    vi.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    const { router } = renderApp()
+
+    // Set every observable piece of state in a single session.
+    const filterInput = screen.getByRole('textbox', { name: /Filter PRs/ })
+    await user.type(filterInput, 'beta')
+    expect(filterInput).toHaveValue('beta')
+
+    await user.selectOptions(screen.getByTestId('prs-sort-select'), 'title-asc')
+
+    const externalToggle = screen.getByRole('button', { name: /External PRs/ })
+    await user.click(externalToggle)
+    expect(externalToggle).toHaveAttribute('aria-expanded', 'false')
+
+    // Shim window.scrollY so the rAF-throttled onScroll handler observes 175
+    // and the 150ms debounce writes it to sessionStorage.
+    let _scrollY = 175
+    const origScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY')
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      get: () => _scrollY,
+    })
+
+    window.dispatchEvent(new Event('scroll'))
+
+    await act(async () => {
+      vi.runAllTimers()
+    })
+
+    // Navigate away — PRsPage fully unmounts (sibling routes); useUIState's
+    // unmount cleanup flushes any still-pending debounced writes.
+    await act(async () => {
+      await router.navigate('/bead/Forge-aaaa')
+    })
+    expect(screen.getByTestId('bead-stub')).toBeInTheDocument()
+
+    // Pretend the new page started at 0 so window.scrollTo will fire on remount.
+    _scrollY = 0
+
+    const scrollToSpy = vi.fn()
+    window.scrollTo = scrollToSpy
+
+    try {
+      await act(async () => {
+        await router.navigate(-1)
+      })
+    } finally {
+      if (origScrollY) {
+        Object.defineProperty(window, 'scrollY', origScrollY)
+      } else {
+        delete (window as unknown as Record<string, unknown>).scrollY
+      }
+    }
+
+    // All four state types survived the round-trip and the first paint
+    // already carries them — no awaits needed before these assertions.
+    expect(screen.getByRole('textbox', { name: /Filter PRs/ })).toHaveValue('beta')
+    expect(screen.getByTestId('prs-sort-select')).toHaveValue('title-asc')
+    expect(screen.getByRole('button', { name: /External PRs/ })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    // Sections we didn't touch stay expanded — proves we restore deliberate
+    // entries only and don't blanket-collapse on remount.
+    expect(screen.getByRole('button', { name: /Forge PRs/ })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    expect(scrollToSpy).toHaveBeenCalledWith(0, 175)
+  })
 })


### PR DESCRIPTION
## Changes

- **Combined PR/Workers pane restoration integration tests** - Added round-trip integration tests that exercise filter, sort, section-expanded, and scroll state together for the PR pane, and group-collapse plus scroll state together for the Workers pane, verifying all pane UI state composes correctly across a navigate-away/navigate-back cycle. (Forge-skfx)

## Original Issue (task): Integration tests for PR and Workers pane restoration

Add Vitest/React Testing Library integration tests mirroring the existing QueuePane restoration test. For PR pane: set filter+sort+expanded sections, navigate away, navigate back, assert state restored. For Workers pane: collapse a group, set scroll, navigate away, navigate back, assert restored. Place tests alongside existing pane tests under `internal/web/frontend/src/components/__tests__/` (or matching convention). Depends on the three persistence sub-tasks above.

---
Bead: Forge-skfx | Branch: forge/Forge-skfx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->