### PR TITLE
Changelog fragment and full build/test verification (Forge-4tud)

### DIFF
--- a/changelog.d/Forge-4tud.md
+++ b/changelog.d/Forge-4tud.md
@@ -1,0 +1,2 @@
+category: Added
+- **Persistent UI state across Hearth panes** - Queue, Workers, Live Activity, and PR panes now remember their filter, sort, expansion, and scroll state across navigation, with the `useUIState` hook deciding per pane whether each slice survives a browser restart (localStorage) or just in-tab navigation (sessionStorage). (Forge-4tud)


### PR DESCRIPTION
## Changes

- **Persistent UI state across Hearth panes** - Queue, Workers, Live Activity, and PR panes now remember their filter, sort, expansion, and scroll state across navigation, with the `useUIState` hook deciding per pane whether each slice survives a browser restart (localStorage) or just in-tab navigation (sessionStorage). (Forge-4tud)

## Original Issue (task): Changelog fragment and full build/test verification

Add a changelog fragment under `changelog.d/` (category: Added) describing the persistent UI state feature across Queue, Workers, Live Activity, and PR panes. Then run and ensure `npm run lint`, `npm run build`, `npm run test`, and `go test ./...` all pass. Fix any lint/type/test fallout from the prior sub-tasks. This task lands last and gates merge.

---
Bead: Forge-4tud | Branch: forge/Forge-4tud
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->