### PR TITLE
Dispatch: detect stranded origin/<branch> from prior worker before creating a new worktree (Forge-9abj)

### DIFF
--- a/changelog.d/Forge-9abj.md
+++ b/changelog.d/Forge-9abj.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Detect stranded remote branches before dispatch** - The daemon now probes `origin/forge/<bead-id>` before spawning a Smith. If the branch carries commits not reachable from the base ref and no PR exists, the bead is marked needs-attention with a clear reason instead of running a fresh worker that would push in parallel and escalate at the end. Merged stale branches are cleaned up transparently. Branches that already have an open PR defer to bellows rather than being treated as stranded. (Forge-9abj)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2520,6 +2520,17 @@ func (d *Daemon) dispatchBead(ctx context.Context, bead poller.Bead, anvilCfg co
 	}
 
 normalPipeline:
+	// Pre-dispatch remote-branch check. If origin already carries unmerged
+	// commits for forge/<bead-id> from a prior worker that escalated between
+	// `git push` and `gh pr create`, dispatching a fresh Smith produces a
+	// parallel implementation that cannot be reconciled without destroying
+	// one side's work. Catch the stranded state HERE so the dispatch never
+	// burns Smith time on it. A merged stale branch is cleaned up
+	// transparently and dispatch proceeds normally.
+	if !d.preDispatchRemoteBranchCheck(ctx, bead, anvilCfg.Path) {
+		return
+	}
+
 	// Apply smith timeout.
 	// IMPORTANT: derive pipelineCtx from context.Background(), NOT from the
 	// daemon's ctx. This ensures that a graceful shutdown (SIGINT/SIGTERM)
@@ -2994,6 +3005,95 @@ func cleanGitEnv() []string {
 		}
 	}
 	return out
+}
+
+// preDispatchRemoteBranchCheck probes origin for the bead's forge branch
+// before the pipeline runs. It returns true when dispatch should proceed and
+// false when it must abort (the bead is either being handed off to bellows
+// because an open PR already covers the branch, or it has been marked
+// needs-attention because the branch carries stranded work from a prior
+// worker).
+//
+// The three reachable outcomes:
+//
+//   - Absent: no branch on origin → proceed normally.
+//   - Merged: branch on origin but fully reachable from the base ref → delete
+//     the stale branch and proceed normally.
+//   - Stranded: branch on origin with commits not reachable from the base ref
+//     → cross-check for an existing PR. If a PR exists, log and let bellows
+//     own it (return false to skip the pipeline). Otherwise mark needs_human
+//     so the operator can decide between accept / reset / merge.
+//
+// An ls-remote / fetch error is conservative: dispatch proceeds so we don't
+// stall the queue on a transient network blip. If the branch really is
+// stranded, the prior end-of-pipeline Smith escalation still fires.
+func (d *Daemon) preDispatchRemoteBranchCheck(ctx context.Context, bead poller.Bead, anvilPath string) bool {
+	branch := worktree.BranchName(bead.ID)
+	stateResult, info, err := worktree.CheckRemoteBranchState(ctx, anvilPath, branch, bead.EpicBranch)
+	if err != nil {
+		d.logger.Warn("pre-dispatch remote branch check failed; proceeding with dispatch",
+			"bead", bead.ID, "branch", branch, "error", err)
+		return true
+	}
+
+	switch stateResult {
+	case worktree.RemoteBranchAbsent:
+		return true
+
+	case worktree.RemoteBranchMerged:
+		d.logger.Info("pre-dispatch: deleting stale merged forge branch on origin",
+			"bead", bead.ID, "branch", branch, "sha", info.SHA, "base", info.BaseRef)
+		if delErr := worktree.DeleteRemoteBranch(ctx, anvilPath, branch); delErr != nil {
+			// Non-fatal: a concurrent process may have deleted it, or the
+			// remote may have temporarily refused the push. The next attempt
+			// to push (during the pipeline) will surface a clearer error.
+			d.logger.Warn("pre-dispatch: failed to delete stale merged branch; continuing dispatch",
+				"bead", bead.ID, "branch", branch, "error", delErr)
+		}
+		return true
+
+	case worktree.RemoteBranchStranded:
+		// If a PR already exists for this branch, bellows owns it — never
+		// duplicate a worker on top of a tracked PR. This may happen when a
+		// prior dispatch created the PR but the daemon crashed before
+		// recording it in state.db.
+		if pr, prErr := d.vcsForAnvil(bead.Anvil).GetPRByHeadBranch(ctx, anvilPath, branch); prErr == nil && pr != nil {
+			d.logger.Info("pre-dispatch: branch has an existing PR; deferring to bellows",
+				"bead", bead.ID, "branch", branch, "pr", pr.Number)
+			_ = d.db.LogEvent(state.EventPRAlreadyExists,
+				fmt.Sprintf("Pre-dispatch: %s already has open PR #%d; dispatch skipped (bellows takes over)",
+					branch, pr.Number),
+				bead.ID, bead.Anvil)
+			d.registerExistingPRByBranch(ctx, bead.Anvil, anvilPath, bead.ID, branch, bead.EpicBranch)
+			return false
+		}
+
+		// No PR — the prior worker pushed but never opened one. Surface as
+		// needs-attention with a message modelled on the Smith escalation
+		// from the 2026-05-18 Fhi.Metadata-orjp2 incident so the operator's
+		// mental model is consistent regardless of when the check fires.
+		shortSHA := info.SHA
+		if len(shortSHA) > 12 {
+			shortSHA = shortSHA[:12]
+		}
+		reason := fmt.Sprintf(
+			"origin/%s already has commits from a prior worker that were never opened as a PR. "+
+				"A fresh Smith would produce a parallel implementation and a non-fast-forward push. "+
+				"Resolving this requires a human decision (accept the prior work and open a PR, "+
+				"reset the remote branch, or merge with new work). SHA: %s",
+			branch, shortSHA,
+		)
+		d.logger.Warn("pre-dispatch: stranded forge branch on origin — escalating to needs_human",
+			"bead", bead.ID, "branch", branch, "sha", info.SHA, "base", info.BaseRef)
+		_ = d.db.LogEvent(state.EventDispatchBlockedStrandedBranch, reason, bead.ID, bead.Anvil)
+		if markErr := d.db.MarkNeedsHuman(bead.ID, bead.Anvil, reason); markErr != nil {
+			d.logger.Error("pre-dispatch: failed to mark bead as needs_human", "bead", bead.ID, "error", markErr)
+		}
+		d.recordDispatchFailure(bead.ID, bead.Anvil, reason, true)
+		return false
+	}
+
+	return true
 }
 
 // forgeBranchAheadOfMain checks whether the origin remote has a forge branch

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3090,6 +3090,27 @@ func (d *Daemon) preDispatchRemoteBranchCheck(ctx context.Context, bead poller.B
 			d.logger.Error("pre-dispatch: failed to mark bead as needs_human", "bead", bead.ID, "error", markErr)
 		}
 		d.recordDispatchFailure(bead.ID, bead.Anvil, reason, true)
+
+		// Fire bead-failed notifications immediately. Unlike the normal retry
+		// path, the stranded-branch case is a 1-strike escalation: needs_human
+		// has already been set above, so we should not wait for the circuit
+		// breaker to trip before alerting the operator. Mirrors the async
+		// notification block in recordDispatchFailure's circuit-break branch.
+		disp := d.dispatcher.Load()
+		notifier := d.notifier.Load()
+		if disp != nil || notifier != nil {
+			beadID, anvil := bead.ID, bead.Anvil
+			go func(reason string) {
+				notifCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				if notifier != nil {
+					notifier.BeadFailed(notifCtx, anvil, beadID, 1, reason)
+				}
+				if disp != nil {
+					disp.Dispatch(notifCtx, notify.EventBeadFailed, beadID, anvil, reason)
+				}
+			}(reason)
+		}
 		return false
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -555,6 +555,41 @@ func (d *Daemon) ingotRecordPR(beadID, anvil string, prNumber int, prURL string)
 	}
 }
 
+// registerPRIfUntracked inserts match into state.db for beadID when the PR is
+// not already tracked, then logs the registration event. It is a low-level
+// helper called by registerExistingPRByBranch and by code paths that already
+// hold a fetched *vcs.OpenPR (avoiding a redundant GetPRByHeadBranch call).
+// Returns the PR number on success, 0 on failure.
+func (d *Daemon) registerPRIfUntracked(ctx context.Context, anvilName, beadID string, match *vcs.OpenPR, baseBranch string) int {
+	if existing, _ := d.db.GetPRByNumber(anvilName, match.Number); existing != nil {
+		// Already tracked — nothing to do, HasOpenPRForBead will return true.
+		return match.Number
+	}
+	dbPR := &state.PR{
+		Number:     match.Number,
+		Anvil:      anvilName,
+		BeadID:     beadID,
+		Branch:     match.Branch,
+		BaseBranch: baseBranch,
+		Status:     state.PROpen,
+		CreatedAt:  time.Now(),
+		Title:      match.Title,
+	}
+	if err := d.db.InsertPR(dbPR); err != nil {
+		d.logger.Warn("failed to insert existing PR record",
+			"anvil", anvilName, "pr", match.Number, "bead", beadID, "error", err)
+		return 0
+	}
+	d.logger.Info("registered existing PR",
+		"bead", beadID, "anvil", anvilName, "pr", match.Number, "branch", match.Branch)
+	if logErr := d.db.LogEvent(state.EventPRCreated,
+		fmt.Sprintf("Registered existing PR #%d for branch %s", match.Number, match.Branch),
+		beadID, anvilName); logErr != nil {
+		d.logger.Warn("failed to log PR registration event", "bead", beadID, "error", logErr)
+	}
+	return match.Number
+}
+
 // registerExistingPRByBranch handles the ErrPRAlreadyExists case from CreatePR
 // by looking up the open PR matching the given branch via the VCS provider and
 // registering it in state.db when it is not already tracked. Without this
@@ -581,33 +616,7 @@ func (d *Daemon) registerExistingPRByBranch(ctx context.Context, anvilName, anvi
 			"anvil", anvilName, "branch", branch, "bead", beadID)
 		return 0
 	}
-	if existing, _ := d.db.GetPRByNumber(anvilName, match.Number); existing != nil {
-		// Already tracked — nothing to do, HasOpenPRForBead will return true.
-		return match.Number
-	}
-	dbPR := &state.PR{
-		Number:     match.Number,
-		Anvil:      anvilName,
-		BeadID:     beadID,
-		Branch:     match.Branch,
-		BaseBranch: baseBranch,
-		Status:     state.PROpen,
-		CreatedAt:  time.Now(),
-		Title:      match.Title,
-	}
-	if err := d.db.InsertPR(dbPR); err != nil {
-		d.logger.Warn("failed to insert existing PR record after ErrPRAlreadyExists",
-			"anvil", anvilName, "pr", match.Number, "bead", beadID, "error", err)
-		return 0
-	}
-	d.logger.Info("registered existing PR for already-exists branch",
-		"bead", beadID, "anvil", anvilName, "pr", match.Number, "branch", branch)
-	if logErr := d.db.LogEvent(state.EventPRCreated,
-		fmt.Sprintf("Registered existing PR #%d for branch %s (recovered from ErrPRAlreadyExists)", match.Number, branch),
-		beadID, anvilName); logErr != nil {
-		d.logger.Warn("failed to log PR registration event", "bead", beadID, "error", logErr)
-	}
-	return match.Number
+	return d.registerPRIfUntracked(ctx, anvilName, beadID, match, baseBranch)
 }
 
 // buildVCSProviders creates a VCS provider for each configured anvil based on
@@ -2528,6 +2537,10 @@ normalPipeline:
 	// burns Smith time on it. A merged stale branch is cleaned up
 	// transparently and dispatch proceeds normally.
 	if !d.preDispatchRemoteBranchCheck(ctx, bead, anvilCfg.Path) {
+		// The pending worker row inserted at claim time must be terminated so
+		// Hearth does not show a permanent pending worker. The pipeline never
+		// ran, so we mark it failed here rather than leaving it in limbo.
+		_ = d.db.UpdateWorkerStatus(claimWorkerID, state.WorkerFailed)
 		return
 	}
 
@@ -3057,14 +3070,25 @@ func (d *Daemon) preDispatchRemoteBranchCheck(ctx context.Context, bead poller.B
 		// duplicate a worker on top of a tracked PR. This may happen when a
 		// prior dispatch created the PR but the daemon crashed before
 		// recording it in state.db.
-		if pr, prErr := d.vcsForAnvil(bead.Anvil).GetPRByHeadBranch(ctx, anvilPath, branch); prErr == nil && pr != nil {
+		pr, prErr := d.vcsForAnvil(bead.Anvil).GetPRByHeadBranch(ctx, anvilPath, branch)
+		if prErr != nil {
+			// A transient gh pr list failure must not cause a false needs_human
+			// escalation. Log the error and abort this dispatch cycle; the next
+			// poll will retry the PR check before deciding.
+			d.logger.Warn("pre-dispatch: PR lookup failed for stranded branch; skipping dispatch until next poll",
+				"bead", bead.ID, "branch", branch, "error", prErr)
+			return false
+		}
+		if pr != nil {
 			d.logger.Info("pre-dispatch: branch has an existing PR; deferring to bellows",
 				"bead", bead.ID, "branch", branch, "pr", pr.Number)
 			_ = d.db.LogEvent(state.EventPRAlreadyExists,
 				fmt.Sprintf("Pre-dispatch: %s already has open PR #%d; dispatch skipped (bellows takes over)",
 					branch, pr.Number),
 				bead.ID, bead.Anvil)
-			d.registerExistingPRByBranch(ctx, bead.Anvil, anvilPath, bead.ID, branch, bead.EpicBranch)
+			// Use registerPRIfUntracked directly with the already-fetched pr to
+			// avoid a redundant GetPRByHeadBranch call inside registerExistingPRByBranch.
+			d.registerPRIfUntracked(ctx, bead.Anvil, bead.ID, pr, bead.EpicBranch)
 			return false
 		}
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3635,6 +3635,179 @@ func TestForgeBranchAheadOfMain(t *testing.T) {
 	})
 }
 
+// TestPreDispatchRemoteBranchCheck verifies the dispatch-time guard that
+// detects stranded origin/forge/<bead-id> branches from a prior worker. The
+// three transition outcomes the daemon must implement:
+//   - Absent → proceed (returns true, no state changes)
+//   - Merged → delete stale branch, proceed (returns true, branch gone on origin)
+//   - Stranded with no PR → mark needs_human and abort (returns false)
+//   - Stranded with PR → log, register PR, abort (returns false; no needs_human)
+func TestPreDispatchRemoteBranchCheck(t *testing.T) {
+	const anvilName = "test-anvil"
+
+	gitLocal := func(t *testing.T, anvilPath string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = anvilPath
+		cmd.Env = cleanGitTestEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	t.Run("absent branch: dispatch proceeds", func(t *testing.T) {
+		anvilPath := initTestGitRepo(t)
+		db, err := state.Open(filepath.Join(anvilPath, "state.db"))
+		require.NoError(t, err)
+		defer db.Close()
+
+		d := &Daemon{
+			db:           db,
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			worktreeMgr:  worktree.NewManager(),
+			vcsProviders: map[string]vcs.Provider{anvilName: &mockVCSProvider{}},
+		}
+		d.cfg.Store(&config.Config{})
+
+		bead := poller.Bead{ID: "PRD-ABSENT", Anvil: anvilName, Title: "absent"}
+		if !d.preDispatchRemoteBranchCheck(context.Background(), bead, anvilPath) {
+			t.Fatal("expected dispatch to proceed when branch is absent")
+		}
+
+		r, err := db.GetRetry(bead.ID, bead.Anvil)
+		require.NoError(t, err)
+		if r != nil && r.NeedsHuman {
+			t.Errorf("bead should not be marked needs_human when branch is absent")
+		}
+	})
+
+	t.Run("merged branch: dispatch proceeds and stale branch is deleted", func(t *testing.T) {
+		anvilPath := initTestGitRepo(t)
+		db, err := state.Open(filepath.Join(anvilPath, "state.db"))
+		require.NoError(t, err)
+		defer db.Close()
+
+		d := &Daemon{
+			db:           db,
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			worktreeMgr:  worktree.NewManager(),
+			vcsProviders: map[string]vcs.Provider{anvilName: &mockVCSProvider{}},
+		}
+		d.cfg.Store(&config.Config{})
+
+		bead := poller.Bead{ID: "PRD-MERGED", Anvil: anvilName, Title: "merged"}
+		branch := worktree.BranchName(bead.ID)
+		// Push a branch pointing at the same commit as main → fully merged.
+		gitLocal(t, anvilPath, "checkout", "-b", branch)
+		gitLocal(t, anvilPath, "push", "origin", branch)
+		gitLocal(t, anvilPath, "checkout", "main")
+
+		if !d.preDispatchRemoteBranchCheck(context.Background(), bead, anvilPath) {
+			t.Fatal("expected dispatch to proceed for merged stale branch")
+		}
+
+		// Branch must be deleted from origin.
+		lsCmd := exec.Command("git", "ls-remote", "--heads", "origin", "--", branch)
+		lsCmd.Dir = anvilPath
+		lsCmd.Env = cleanGitTestEnv()
+		out, err := lsCmd.Output()
+		require.NoError(t, err)
+		if strings.TrimSpace(string(out)) != "" {
+			t.Errorf("expected stale merged branch %s to be deleted from origin; got %q", branch, string(out))
+		}
+	})
+
+	t.Run("stranded branch without PR: dispatch blocked and marked needs_human", func(t *testing.T) {
+		anvilPath := initTestGitRepo(t)
+		db, err := state.Open(filepath.Join(anvilPath, "state.db"))
+		require.NoError(t, err)
+		defer db.Close()
+
+		d := &Daemon{
+			db:           db,
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			worktreeMgr:  worktree.NewManager(),
+			vcsProviders: map[string]vcs.Provider{anvilName: &mockVCSProvider{}},
+		}
+		d.cfg.Store(&config.Config{})
+
+		bead := poller.Bead{ID: "PRD-STRANDED", Anvil: anvilName, Title: "stranded"}
+		branch := worktree.BranchName(bead.ID)
+		// Push a branch with a commit not reachable from main → stranded.
+		gitLocal(t, anvilPath, "checkout", "-b", branch)
+		require.NoError(t, os.WriteFile(filepath.Join(anvilPath, "stranded.txt"), []byte("prior\n"), 0o644))
+		gitLocal(t, anvilPath, "add", "stranded.txt")
+		gitLocal(t, anvilPath, "commit", "-m", "stranded prior work")
+		gitLocal(t, anvilPath, "push", "origin", branch)
+		gitLocal(t, anvilPath, "checkout", "main")
+
+		if d.preDispatchRemoteBranchCheck(context.Background(), bead, anvilPath) {
+			t.Fatal("expected dispatch to be blocked for stranded branch")
+		}
+
+		r, err := db.GetRetry(bead.ID, bead.Anvil)
+		require.NoError(t, err)
+		require.NotNil(t, r, "retry row should be created for stranded bead")
+		if !r.NeedsHuman {
+			t.Errorf("bead should be marked needs_human when branch is stranded")
+		}
+		if !strings.Contains(r.LastError, "prior worker") {
+			t.Errorf("needs_human reason should mention prior worker; got %q", r.LastError)
+		}
+
+		// An EventDispatchBlockedStrandedBranch event should be logged.
+		events, err := db.RecentEvents(20)
+		require.NoError(t, err)
+		var found bool
+		for _, ev := range events {
+			if ev.Type == state.EventDispatchBlockedStrandedBranch && ev.BeadID == bead.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected EventDispatchBlockedStrandedBranch to be logged for %s", bead.ID)
+		}
+	})
+
+	t.Run("stranded branch with existing PR: dispatch blocked, no needs_human", func(t *testing.T) {
+		anvilPath := initTestGitRepo(t)
+		db, err := state.Open(filepath.Join(anvilPath, "state.db"))
+		require.NoError(t, err)
+		defer db.Close()
+
+		bead := poller.Bead{ID: "PRD-STRANDED-PR", Anvil: anvilName, Title: "stranded with PR"}
+		branch := worktree.BranchName(bead.ID)
+		mockVCS := &mockVCSProvider{
+			openPRs: []vcs.OpenPR{{Number: 77, Branch: branch, URL: "https://example.com/77"}},
+		}
+		d := &Daemon{
+			db:           db,
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			worktreeMgr:  worktree.NewManager(),
+			vcsProviders: map[string]vcs.Provider{anvilName: mockVCS},
+		}
+		d.cfg.Store(&config.Config{})
+
+		// Push a stranded branch.
+		gitLocal(t, anvilPath, "checkout", "-b", branch)
+		require.NoError(t, os.WriteFile(filepath.Join(anvilPath, "with-pr.txt"), []byte("prior\n"), 0o644))
+		gitLocal(t, anvilPath, "add", "with-pr.txt")
+		gitLocal(t, anvilPath, "commit", "-m", "stranded prior work with PR")
+		gitLocal(t, anvilPath, "push", "origin", branch)
+		gitLocal(t, anvilPath, "checkout", "main")
+
+		if d.preDispatchRemoteBranchCheck(context.Background(), bead, anvilPath) {
+			t.Fatal("expected dispatch to be blocked when PR exists for stranded branch")
+		}
+
+		r, err := db.GetRetry(bead.ID, bead.Anvil)
+		require.NoError(t, err)
+		if r != nil && r.NeedsHuman {
+			t.Errorf("bead must NOT be marked needs_human when a PR already exists; bellows takes over")
+		}
+	})
+}
+
 func TestHandleIPC_WicketScan(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-test-*")
 	require.NoError(t, err)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3778,7 +3778,7 @@ func TestPreDispatchRemoteBranchCheck(t *testing.T) {
 		bead := poller.Bead{ID: "PRD-STRANDED-PR", Anvil: anvilName, Title: "stranded with PR"}
 		branch := worktree.BranchName(bead.ID)
 		mockVCS := &mockVCSProvider{
-			openPRs: []vcs.OpenPR{{Number: 77, Branch: branch, URL: "https://example.com/77"}},
+			openPRs: []vcs.OpenPR{{Number: 77, Branch: branch}},
 		}
 		d := &Daemon{
 			db:           db,

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1516,6 +1516,10 @@ const (
 	EventSchematicSkipped     EventType = "schematic_skipped"
 	EventDispatchFailed       EventType = "dispatch_failed"
 	EventDispatchCircuitBreak EventType = "dispatch_circuit_break"
+	// EventDispatchBlockedStrandedBranch fires when the pre-dispatch remote
+	// check finds origin/forge/<bead-id> with commits not reachable from the
+	// base ref and no PR — a prior worker pushed but never opened a PR.
+	EventDispatchBlockedStrandedBranch EventType = "dispatch_blocked_stranded_branch"
 	EventRateLimited          EventType = "rate_limited"
 	EventCostLimitHit         EventType = "cost_limit_hit"
 	EventSchematicSubBead     EventType = "schematic_sub_bead"

--- a/internal/worktree/remote.go
+++ b/internal/worktree/remote.go
@@ -133,9 +133,11 @@ func DeleteRemoteBranch(ctx context.Context, anvilPath, branch string) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		// Git reports "error: unable to delete 'branch': remote ref does not exist"
+		// when the branch is already gone (concurrent forge raced us). Treat
+		// that as success so multi-forge dispatch never collides on cleanup.
 		msg := stderr.String()
-		if strings.Contains(msg, "remote ref does not exist") ||
-			strings.Contains(msg, "unable to delete") && strings.Contains(msg, "remote ref does not exist") {
+		if strings.Contains(msg, "remote ref does not exist") {
 			return nil
 		}
 		return fmt.Errorf("git push origin --delete %s: %w: %s", branch, err, strings.TrimSpace(msg))

--- a/internal/worktree/remote.go
+++ b/internal/worktree/remote.go
@@ -1,0 +1,191 @@
+package worktree
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/executil"
+)
+
+// gitCommandTimeout matches the 60s deadline used by gitCmd in worktree.go so
+// every git invocation in this package shares the same shutdown bound.
+const gitCommandTimeout = 60 * time.Second
+
+// RemoteBranchState describes whether a worker branch exists on origin and, if
+// so, whether the commits it carries are already reachable from the base ref.
+type RemoteBranchState int
+
+const (
+	// RemoteBranchAbsent — the branch does not exist on origin. Safe to
+	// dispatch a fresh worker.
+	RemoteBranchAbsent RemoteBranchState = iota
+	// RemoteBranchMerged — the branch exists on origin but every commit is
+	// reachable from the base ref (e.g. origin/main). The branch is a stale
+	// pointer and can be deleted.
+	RemoteBranchMerged
+	// RemoteBranchStranded — the branch exists on origin and carries commits
+	// that are NOT reachable from the base ref. A prior worker pushed work
+	// without opening a PR. Dispatching a fresh worker would produce a
+	// parallel implementation and a non-fast-forward push.
+	RemoteBranchStranded
+)
+
+// String returns a human-readable label for the state.
+func (s RemoteBranchState) String() string {
+	switch s {
+	case RemoteBranchAbsent:
+		return "absent"
+	case RemoteBranchMerged:
+		return "merged"
+	case RemoteBranchStranded:
+		return "stranded"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(s))
+	}
+}
+
+// RemoteBranchInfo carries supplementary detail discovered by
+// CheckRemoteBranchState — most importantly the remote SHA, which callers log
+// in needs-attention messages so an operator can inspect the prior work.
+type RemoteBranchInfo struct {
+	// Branch is the branch name probed on origin.
+	Branch string
+	// SHA is the tip commit of origin/<Branch>, or empty when the branch is
+	// absent.
+	SHA string
+	// BaseRef is the ref used as the reachability base (e.g. "origin/main"),
+	// or empty when reachability was not evaluated (Absent).
+	BaseRef string
+}
+
+// CheckRemoteBranchState reports whether origin/<branch> exists and, if so,
+// whether its tip is reachable from the resolved base ref. anvilPath must be a
+// non-bare git repo with an "origin" remote configured.
+//
+// baseBranch overrides the reachability target — pass the epic branch for
+// crucible children so commits already merged into the epic are correctly
+// classified as merged. Pass "" to use origin/main or origin/master.
+//
+// The check is lightweight: a single git ls-remote followed (only when the
+// branch exists) by a targeted fetch and a merge-base ancestry test. It does
+// NOT mutate state — callers that want to clean up a merged stale branch
+// should call DeleteRemoteBranch separately.
+func CheckRemoteBranchState(ctx context.Context, anvilPath, branch, baseBranch string) (RemoteBranchState, RemoteBranchInfo, error) {
+	info := RemoteBranchInfo{Branch: branch}
+
+	sha, err := lsRemoteBranchSHA(ctx, anvilPath, branch)
+	if err != nil {
+		return RemoteBranchAbsent, info, fmt.Errorf("ls-remote origin %s: %w", branch, err)
+	}
+	if sha == "" {
+		return RemoteBranchAbsent, info, nil
+	}
+	info.SHA = sha
+
+	// Fetch the branch so the local remote-tracking ref reflects the SHA we
+	// just observed via ls-remote. Without this, a stale local origin/<branch>
+	// (or no local ref at all) would make the ancestry check below incorrect.
+	if err := gitCmd(ctx, anvilPath, "fetch", "origin", "--", branch); err != nil {
+		return RemoteBranchAbsent, info, fmt.Errorf("fetching origin %s: %w", branch, err)
+	}
+
+	baseRef, err := resolveBaseRefWithOverride(ctx, anvilPath, baseBranch)
+	if err != nil {
+		return RemoteBranchAbsent, info, fmt.Errorf("resolving base ref: %w", err)
+	}
+	info.BaseRef = baseRef
+
+	// merge-base --is-ancestor exits 0 when the first arg is an ancestor of
+	// the second (i.e. fully reachable from the base) and 1 otherwise.
+	if isAncestor(ctx, anvilPath, sha, baseRef) {
+		return RemoteBranchMerged, info, nil
+	}
+	return RemoteBranchStranded, info, nil
+}
+
+// resolveBaseRefWithOverride returns "origin/<baseBranch>" when baseBranch is
+// non-empty and present on origin, falling back to resolveBaseRef (origin/main
+// or origin/master) otherwise.
+func resolveBaseRefWithOverride(ctx context.Context, anvilPath, baseBranch string) (string, error) {
+	if baseBranch != "" {
+		candidate := "origin/" + baseBranch
+		if err := gitCmd(ctx, anvilPath, "rev-parse", "--verify", candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return resolveBaseRef(ctx, anvilPath)
+}
+
+// DeleteRemoteBranch removes branch from origin. Used to clean up merged
+// stranded branches before dispatching a fresh worker. A "remote ref does not
+// exist" failure (another process beat us to the delete) is treated as
+// success so concurrent forges do not collide.
+func DeleteRemoteBranch(ctx context.Context, anvilPath, branch string) error {
+	cmdCtx, cancel := contextWithGitTimeout(ctx)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "push", "origin", "--delete", "--", branch))
+	cmd.Dir = anvilPath
+	cmd.Env = localGitEnv()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := stderr.String()
+		if strings.Contains(msg, "remote ref does not exist") ||
+			strings.Contains(msg, "unable to delete") && strings.Contains(msg, "remote ref does not exist") {
+			return nil
+		}
+		return fmt.Errorf("git push origin --delete %s: %w: %s", branch, err, strings.TrimSpace(msg))
+	}
+	return nil
+}
+
+// lsRemoteBranchSHA returns the SHA of origin/<branch> as reported by
+// ls-remote, or "" when the branch does not exist on origin.
+func lsRemoteBranchSHA(ctx context.Context, anvilPath, branch string) (string, error) {
+	cmdCtx, cancel := contextWithGitTimeout(ctx)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "ls-remote", "--heads", "origin", "--", branch))
+	cmd.Dir = anvilPath
+	cmd.Env = localGitEnv()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return "", nil
+	}
+	// Output is "<sha>\t<ref>" per matching head; we asked for a single branch
+	// so there is at most one line.
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return "", nil
+	}
+	return fields[0], nil
+}
+
+// isAncestor returns true when ancestor is reachable from descendant in the
+// git history (i.e. every commit reachable from ancestor is reachable from
+// descendant). Errors from git (including non-zero exit when not an ancestor)
+// produce a false result; callers should treat that as "not merged" and
+// proceed conservatively.
+func isAncestor(ctx context.Context, anvilPath, ancestor, descendant string) bool {
+	cmdCtx, cancel := contextWithGitTimeout(ctx)
+	defer cancel()
+	cmd := executil.HideWindow(exec.CommandContext(cmdCtx, "git", "merge-base", "--is-ancestor", ancestor, descendant))
+	cmd.Dir = anvilPath
+	cmd.Env = localGitEnv()
+	return cmd.Run() == nil
+}
+
+// contextWithGitTimeout wraps ctx with the gitCommandTimeout bound so the
+// helper commands in this file inherit consistent shutdown behaviour.
+func contextWithGitTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, gitCommandTimeout)
+}

--- a/internal/worktree/remote.go
+++ b/internal/worktree/remote.go
@@ -86,14 +86,18 @@ func CheckRemoteBranchState(ctx context.Context, anvilPath, branch, baseBranch s
 	}
 	info.SHA = sha
 
-	// Fetch the branch so the local remote-tracking ref reflects the SHA we
-	// just observed via ls-remote. Without this, a stale local origin/<branch>
-	// (or no local ref at all) would make the ancestry check below incorrect.
+	// Fetch the forge branch so the local remote-tracking ref reflects the SHA
+	// we just observed via ls-remote. Without this, a stale local
+	// origin/<branch> (or no local ref at all) would make the ancestry check
+	// below incorrect.
 	if err := gitCmd(ctx, anvilPath, "fetch", "origin", "--", branch); err != nil {
 		return RemoteBranchAbsent, info, fmt.Errorf("fetching origin %s: %w", branch, err)
 	}
 
-	baseRef, err := resolveBaseRefWithOverride(ctx, anvilPath, baseBranch)
+	// Fetch and resolve the base ref so the local tracking ref is current
+	// before the ancestry test. A stale origin/<base> can misclassify a
+	// recently-merged branch as stranded (or vice-versa).
+	baseRef, err := fetchAndResolveBaseRef(ctx, anvilPath, baseBranch)
 	if err != nil {
 		return RemoteBranchAbsent, info, fmt.Errorf("resolving base ref: %w", err)
 	}
@@ -107,16 +111,30 @@ func CheckRemoteBranchState(ctx context.Context, anvilPath, branch, baseBranch s
 	return RemoteBranchStranded, info, nil
 }
 
-// resolveBaseRefWithOverride returns "origin/<baseBranch>" when baseBranch is
-// non-empty and present on origin, falling back to resolveBaseRef (origin/main
-// or origin/master) otherwise.
-func resolveBaseRefWithOverride(ctx context.Context, anvilPath, baseBranch string) (string, error) {
+// fetchAndResolveBaseRef fetches the base ref from origin so the local
+// tracking ref is current, then returns its full refname ("origin/<name>").
+// If baseBranch is non-empty it is fetched from origin and returned when the
+// tracking ref is confirmed locally; otherwise both "main" and "master" are
+// fetched (non-fatally, since the remote may have only one) and whichever is
+// present locally is returned. Fetch errors are treated as non-fatal so a
+// transient network blip does not block the ancestry check — the caller
+// proceeds with whatever local state is available.
+func fetchAndResolveBaseRef(ctx context.Context, anvilPath, baseBranch string) (string, error) {
 	if baseBranch != "" {
-		candidate := "origin/" + baseBranch
-		if err := gitCmd(ctx, anvilPath, "rev-parse", "--verify", candidate); err == nil {
-			return candidate, nil
+		// Fetch the override ref; if the fetch succeeds and the tracking ref
+		// is now present locally, use it. On failure fall through to defaults
+		// so a transient error does not silently ignore the override.
+		if err := gitCmd(ctx, anvilPath, "fetch", "origin", "--", baseBranch); err == nil {
+			candidate := "origin/" + baseBranch
+			if verr := gitCmd(ctx, anvilPath, "rev-parse", "--verify", candidate); verr == nil {
+				return candidate, nil
+			}
 		}
 	}
+	// Non-fatally fetch both default-branch candidates; the remote may have
+	// only one of them.
+	_ = gitCmd(ctx, anvilPath, "fetch", "origin", "--", "main")
+	_ = gitCmd(ctx, anvilPath, "fetch", "origin", "--", "master")
 	return resolveBaseRef(ctx, anvilPath)
 }
 

--- a/internal/worktree/remote_test.go
+++ b/internal/worktree/remote_test.go
@@ -1,0 +1,121 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// initRemoteAndClone creates a bare origin with a single commit on main and a
+// local clone configured with a user identity. Returns the clone (anvil) path.
+func initRemoteAndClone(t *testing.T) string {
+	t.Helper()
+	remote := t.TempDir()
+	runGit(t, remote, "init", "--bare", "--initial-branch=main")
+
+	clone := t.TempDir()
+	runGit(t, clone, "clone", remote, ".")
+	runGit(t, clone, "config", "user.email", "test@example.com")
+	runGit(t, clone, "config", "user.name", "Test")
+
+	if err := os.WriteFile(filepath.Join(clone, "README"), []byte("init\n"), 0o644); err != nil {
+		t.Fatalf("seed README: %v", err)
+	}
+	runGit(t, clone, "add", "README")
+	runGit(t, clone, "commit", "-m", "initial")
+	runGit(t, clone, "push", "origin", "main")
+	return clone
+}
+
+func TestCheckRemoteBranchState_Absent(t *testing.T) {
+	anvil := initRemoteAndClone(t)
+	branch := BranchName("Forge-absent")
+
+	state, info, err := CheckRemoteBranchState(context.Background(), anvil, branch, "")
+	if err != nil {
+		t.Fatalf("CheckRemoteBranchState: %v", err)
+	}
+	if state != RemoteBranchAbsent {
+		t.Fatalf("state = %s; want absent", state)
+	}
+	if info.SHA != "" {
+		t.Errorf("SHA = %q; want empty for absent branch", info.SHA)
+	}
+}
+
+func TestCheckRemoteBranchState_Stranded(t *testing.T) {
+	anvil := initRemoteAndClone(t)
+	branch := BranchName("Forge-stranded")
+
+	// Create a forge branch with a commit not reachable from main and push it.
+	runGit(t, anvil, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(anvil, "work.txt"), []byte("smith\n"), 0o644); err != nil {
+		t.Fatalf("write work.txt: %v", err)
+	}
+	runGit(t, anvil, "add", "work.txt")
+	runGit(t, anvil, "commit", "-m", "smith work")
+	runGit(t, anvil, "push", "origin", branch)
+	runGit(t, anvil, "checkout", "main")
+
+	state, info, err := CheckRemoteBranchState(context.Background(), anvil, branch, "")
+	if err != nil {
+		t.Fatalf("CheckRemoteBranchState: %v", err)
+	}
+	if state != RemoteBranchStranded {
+		t.Fatalf("state = %s; want stranded", state)
+	}
+	if info.SHA == "" {
+		t.Error("SHA should be populated for stranded branch")
+	}
+	if info.BaseRef == "" {
+		t.Error("BaseRef should be populated for stranded branch")
+	}
+}
+
+func TestCheckRemoteBranchState_Merged(t *testing.T) {
+	anvil := initRemoteAndClone(t)
+	branch := BranchName("Forge-merged")
+
+	// Create a branch pointing at an ancestor of main: HEAD~0 is main's tip,
+	// which is reachable from itself. Use the initial commit's SHA so the
+	// branch is unambiguously merged.
+	runGit(t, anvil, "checkout", "-b", branch)
+	runGit(t, anvil, "push", "origin", branch)
+	runGit(t, anvil, "checkout", "main")
+
+	state, _, err := CheckRemoteBranchState(context.Background(), anvil, branch, "")
+	if err != nil {
+		t.Fatalf("CheckRemoteBranchState: %v", err)
+	}
+	if state != RemoteBranchMerged {
+		t.Fatalf("state = %s; want merged", state)
+	}
+}
+
+func TestDeleteRemoteBranch(t *testing.T) {
+	anvil := initRemoteAndClone(t)
+	branch := BranchName("Forge-delete")
+
+	runGit(t, anvil, "checkout", "-b", branch)
+	runGit(t, anvil, "push", "origin", branch)
+	runGit(t, anvil, "checkout", "main")
+
+	if err := DeleteRemoteBranch(context.Background(), anvil, branch); err != nil {
+		t.Fatalf("DeleteRemoteBranch: %v", err)
+	}
+
+	sha, err := lsRemoteBranchSHA(context.Background(), anvil, branch)
+	if err != nil {
+		t.Fatalf("lsRemoteBranchSHA: %v", err)
+	}
+	if sha != "" {
+		t.Errorf("branch still present on origin after delete; sha=%s", sha)
+	}
+
+	// Deleting again is idempotent: a second delete on a missing ref must
+	// not return an error.
+	if err := DeleteRemoteBranch(context.Background(), anvil, branch); err != nil {
+		t.Errorf("second DeleteRemoteBranch should be idempotent: %v", err)
+	}
+}

--- a/internal/worktree/remote_test.go
+++ b/internal/worktree/remote_test.go
@@ -77,9 +77,8 @@ func TestCheckRemoteBranchState_Merged(t *testing.T) {
 	anvil := initRemoteAndClone(t)
 	branch := BranchName("Forge-merged")
 
-	// Create a branch pointing at an ancestor of main: HEAD~0 is main's tip,
-	// which is reachable from itself. Use the initial commit's SHA so the
-	// branch is unambiguously merged.
+	// Create a branch at main's current tip and push it. The tip commit is
+	// reachable from main (it IS the tip), so the branch is classified as merged.
 	runGit(t, anvil, "checkout", "-b", branch)
 	runGit(t, anvil, "push", "origin", branch)
 	runGit(t, anvil, "checkout", "main")
@@ -90,6 +89,60 @@ func TestCheckRemoteBranchState_Merged(t *testing.T) {
 	}
 	if state != RemoteBranchMerged {
 		t.Fatalf("state = %s; want merged", state)
+	}
+}
+
+// TestCheckRemoteBranchState_MergedViaBaseBranch exercises the baseBranch
+// override: a crucible child whose commits have been merged into the epic
+// branch (but NOT into main) should be classified as merged when baseBranch
+// is set to the epic branch, and as stranded when baseBranch is "".
+func TestCheckRemoteBranchState_MergedViaBaseBranch(t *testing.T) {
+	anvil := initRemoteAndClone(t)
+
+	epicBranch := "feature/epic-test"
+	forgeBranch := BranchName("Forge-child-epic")
+
+	// Build epic branch with one extra commit, then create a forge child off it.
+	runGit(t, anvil, "checkout", "-b", epicBranch)
+	if err := os.WriteFile(filepath.Join(anvil, "epic.txt"), []byte("epic\n"), 0o644); err != nil {
+		t.Fatalf("write epic.txt: %v", err)
+	}
+	runGit(t, anvil, "add", "epic.txt")
+	runGit(t, anvil, "commit", "-m", "epic work")
+	runGit(t, anvil, "push", "origin", epicBranch)
+
+	runGit(t, anvil, "checkout", "-b", forgeBranch)
+	if err := os.WriteFile(filepath.Join(anvil, "child.txt"), []byte("child\n"), 0o644); err != nil {
+		t.Fatalf("write child.txt: %v", err)
+	}
+	runGit(t, anvil, "add", "child.txt")
+	runGit(t, anvil, "commit", "-m", "child work")
+	runGit(t, anvil, "push", "origin", forgeBranch)
+
+	// Merge the forge branch into the epic branch (fast-forward: epic tip =
+	// forge tip, so the forge commit is reachable from origin/epicBranch).
+	runGit(t, anvil, "checkout", epicBranch)
+	runGit(t, anvil, "merge", forgeBranch)
+	runGit(t, anvil, "push", "origin", epicBranch)
+	runGit(t, anvil, "checkout", "main")
+
+	// With baseBranch=epicBranch: the forge tip is reachable from the epic
+	// branch → classified as merged.
+	got, _, err := CheckRemoteBranchState(context.Background(), anvil, forgeBranch, epicBranch)
+	if err != nil {
+		t.Fatalf("CheckRemoteBranchState(baseBranch=%s): %v", epicBranch, err)
+	}
+	if got != RemoteBranchMerged {
+		t.Fatalf("state = %s; want merged (reachable from epic branch)", got)
+	}
+
+	// With baseBranch="": the forge commits are not on main → stranded.
+	got, _, err = CheckRemoteBranchState(context.Background(), anvil, forgeBranch, "")
+	if err != nil {
+		t.Fatalf("CheckRemoteBranchState(baseBranch=''): %v", err)
+	}
+	if got != RemoteBranchStranded {
+		t.Fatalf("state = %s; want stranded (not reachable from main)", got)
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Detect stranded remote branches before dispatch** - The daemon now probes `origin/forge/<bead-id>` before spawning a Smith. If the branch carries commits not reachable from the base ref and no PR exists, the bead is marked needs-attention with a clear reason instead of running a fresh worker that would push in parallel and escalate at the end. Merged stale branches are cleaned up transparently. Branches that already have an open PR defer to bellows rather than being treated as stranded. (Forge-9abj)

## Original Issue (bug): Dispatch: detect stranded origin/<branch> from prior worker before creating a new worktree

## Problem

When the forge re-dispatches a bead whose previous worker pushed commits to `origin/forge/<bead-id>` but never opened a PR, the new dispatch creates a fresh worktree from `main` and runs Smith from scratch. The fresh Smith produces a parallel implementation against the same bead description, then escalates on the inevitable non-fast-forward `git push`. The first attempt's pushed work, the second attempt's compute + Sonnet/Opus budget, and the operator's resolution time are all spent for nothing.

This is not a rare race. It fires every time a Smith escalates after `git push` but before `gh pr create` — a window that exists today because the pipeline's push and PR-open steps are not atomic and the orphan branch is not cleaned up on escalation.

### Concrete failure that motivated this bead

On 2026-05-18 the skybert-forge processed Fhi.Metadata-orjp2:

1. **Attempt 1** ran Smith on a clean worktree off `main` (`b04669d9f`). Produced two commits (`28c1d0751 feat: ...` + `e2083a4ae fix: prettier`), pushed to `origin/forge/Fhi.Metadata-orjp2`. Then escalated/crashed/timed-out between push and PR creation — `gh pr list --head forge/Fhi.Metadata-orjp2` returned `[]`.

2. **Attempt 2** dispatched on the next poll cycle. Created a fresh worktree from the same `b04669d9f` base — apparently without checking `origin/forge/Fhi.Metadata-orjp2` for prior content. Smith picked a different abstraction naming (`ListBackend` instead of `VariableListSource`) and added a higher-quality test/Share/Storybook layer, producing local commit `0ee25b36c`. Tried to push → non-fast-forward → escalated:

   > Smith escalated: origin/forge/Fhi.Metadata-orjp2 already has two commits from a prior worker ... My local commit 0ee25b36c is a parallel implementation ... A non-fast-forward git push is rejected; resolving this requires either force-pushing (discards the other worker's committed work) or resetting to origin (discards the additional tests/integration on top). Both are destructive operations beyond my authority.

The Smith escalation message is precise and human-friendly — but it fires at the END of a full worker run instead of at the START. Catching it at dispatch time avoids the wasted compute entirely.

## Root cause

The dispatch path checks for *local* worktree state (is there already a worktree directory for this bead?) but does not check the *remote* state (does `origin/forge/<bead-id>` already exist with commits beyond main?). When the prior worker's local worktree was cleaned up after escalation, the dispatch path sees a clean slate locally and proceeds — even though origin retains the partial work.

Likely files involved (verify before editing — names may have drifted):

- `internal/poller/` — the dispatch decision point.
- `internal/worktree/worktree.go` — `worktree.Create` does `git worktree add -B <branch> <path> origin/<branch>` when the ref exists. That call would actually pick up the prior commits if the dispatch path called it consistently — but the dispatch path may be passing a base that doesn't exist on origin yet (the bead is new) and falling back to creating from main.
- `internal/pipeline/pipeline.go` — pipeline orchestration; would need a pre-Schematic check to refuse to start if origin already has unmerged work.

## Proposed fix

**Step 1: pre-dispatch remote check.**

Before the dispatch path calls `worktree.Create`, run `git ls-remote origin forge/<bead-id>`. Outcomes:

- **No remote ref** → normal flow, dispatch as today.
- **Remote ref exists, is reachable from `origin/main`** → branch already merged; safe to delete the remote ref and proceed as normal. (`git push origin --delete forge/<bead-id>`).
- **Remote ref exists, is NOT reachable from `origin/main`** → prior attempt has unmerged work on origin. Do NOT dispatch. Instead:
  - Mark the bead as needs-attention with reason "prior worker pushed commits to `origin/forge/<bead-id>` but no PR was opened — needs human decision (accept, reset, or merge)".
  - Emit an event (`dispatch_blocked_stranded_branch` or similar).
  - Let Hearth 2.0 surface this via the resolve-needs-attention page from bead 07.

**Step 2: bonus — open PR atomically with push.**

The deeper bug is that `git push` and `gh pr create` are not atomic. If we open the PR *immediately* after a successful push (or if the push step is wrapped so that escalation between push and PR-create rolls the push back), the orphan-branch state stops existing and step 1's "no PR" case becomes unreachable.

The wrap-the-push option is fragile (rolling back a successful push is uncomfortable). The "open PR immediately, fail loud if it doesn't" option is cleaner. Today the Smith subprocess does the push; the PR creation may live in a later pipeline stage. If so, move it adjacent to the push so they share the same retry/escalation boundary.

**Step 3 (optional polish): branch staleness check on long-idle beads.**

For beads where the prior attempt completed normally (PR opened, then closed without merge), the `forge/<bead-id>` branch can sit on origin for a long time. A future dispatch on the same bead-id (e.g. via reopening the bead) would also collide. Mitigate by: when a PR for `forge/<bead-id>` is closed without merge, delete the branch as part of the close-handling logic in bellows.

## Acceptance criteria

- A bead that has been "push-but-no-PR" abandoned by a prior worker is NOT dispatched as a fresh worker on the next poll. Instead, it surfaces as needs-attention with a clear message in Hearth 2.0 (via bead 07's resolve UI when available; via the existing needs-attention surfaces in the meantime).
- A bead whose prior attempt's branch is already merged into main gets the stale branch cleaned up and is then dispatched normally.
- Smith subprocesses never see "your branch is behind origin/<branch>" / non-fast-forward errors as their FIRST signal that a prior attempt exists — the dispatch layer should catch this earlier.
- The fix is unit-testable with a fixture that pre-creates an `origin/forge/<bead-id>` ref pointing to a commit that's NOT reachable from main, then invokes the dispatch decision and asserts the bead is marked needs-attention rather than dispatched.
- For merged-and-stranded branches (rare but real), a fixture covering "origin/forge/<bead-id> is reachable from origin/main" passes via the cleanup path.
- An existing-PR check is preserved: if origin/<branch> exists AND a PR exists for it, the existing flow (bellows monitors the PR) continues unchanged. Dispatch should never duplicate a worker on a bead that already has a tracked PR.

## Notes / cross-refs

- Sister to bead 07 (Hearth 2.0 resolve-needs-attention UI). 07 makes resolving these escalations point-and-click; 08 makes them rare. Both are useful; neither blocks the other.
- The Smith's escalation message format from the 2026-05-18 Fhi.Metadata-orjp2 incident is excellent — preserve that text (or close to it) for the dispatch-time escalation reason so the operator's mental model is consistent regardless of when the check fires.
- Worker A's root cause for push-without-PR is unknown without pod logs. Hypotheses: (a) Smith timed out after push, before reaching `gh pr create`; (b) `gh pr create` hit transient auth/network failure and the pipeline didn't retry; (c) warden bounced post-push and the rollback path doesn't delete the branch. Worth surfacing in the daemon logs as a separate observability bead if it recurs.
- Multi-forge angle: if two forge instances share the same anvil, both could try to dispatch the same bead at different moments. The remote-check approach handles this naturally — whichever forge dispatches second sees the first's pushed branch and stays its hand. Without this fix, multi-forge deployments are even more exposed to the duplicate-work failure mode.
- Related to the spirit of bead 06 (reconcile clobber): both are "dispatch path doesn't consider all the relevant state before acting." This time it's remote git state instead of database state.

---
Bead: Forge-9abj | Branch: forge/Forge-9abj
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->