### PR TITLE
Extract shared queue action logic into internal/queueactions package (Forge-nh12)

### DIFF
--- a/changelog.d/Forge-nh12.md
+++ b/changelog.d/Forge-nh12.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Queue resolution actions now go through a shared package** - The IPC handlers for `forge queue clarify|unclarify|retry|clear|stop` delegate to a new `internal/queueactions` package that enforces multi-forge safety (rejecting requests whose `forge_id` does not match the local Forge) and always writes an audit event to the `events` table. As a side effect, `bead_stopped` events are now logged synchronously when Stop is invoked rather than only on successful `bd update` release. (Forge-nh12)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -33,38 +33,37 @@ import (
 
 	"github.com/Robin831/Forge/internal/adventurer"
 	"github.com/Robin831/Forge/internal/bellows"
-	"github.com/Robin831/Forge/internal/quench"
+	"github.com/Robin831/Forge/internal/burnish"
 	"github.com/Robin831/Forge/internal/config"
 	"github.com/Robin831/Forge/internal/crucible"
 	"github.com/Robin831/Forge/internal/depcheck"
-	"github.com/Robin831/Forge/internal/questgiver"
 	"github.com/Robin831/Forge/internal/executil"
-	"github.com/Robin831/Forge/internal/ingot"
-	"github.com/Robin831/Forge/internal/vcs"
-	"github.com/Robin831/Forge/internal/vcs/github"
 	"github.com/Robin831/Forge/internal/hotreload"
+	"github.com/Robin831/Forge/internal/ingot"
 	"github.com/Robin831/Forge/internal/ipc"
 	"github.com/Robin831/Forge/internal/lifecycle"
 	"github.com/Robin831/Forge/internal/notify"
 	"github.com/Robin831/Forge/internal/pipeline"
 	"github.com/Robin831/Forge/internal/poller"
-	"github.com/Robin831/Forge/internal/queueactions"
 	"github.com/Robin831/Forge/internal/prompt"
 	"github.com/Robin831/Forge/internal/provider"
+	"github.com/Robin831/Forge/internal/quench"
+	"github.com/Robin831/Forge/internal/questgiver"
+	"github.com/Robin831/Forge/internal/queueactions"
 	"github.com/Robin831/Forge/internal/rebase"
-	"github.com/Robin831/Forge/internal/burnish"
-	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/schematic"
 	"github.com/Robin831/Forge/internal/shutdown"
 	"github.com/Robin831/Forge/internal/smelter"
+	"github.com/Robin831/Forge/internal/smith"
 	"github.com/Robin831/Forge/internal/state"
 	"github.com/Robin831/Forge/internal/temper"
+	"github.com/Robin831/Forge/internal/vcs"
+	"github.com/Robin831/Forge/internal/vcs/github"
 	"github.com/Robin831/Forge/internal/vulncheck"
 	"github.com/Robin831/Forge/internal/warden"
 	"github.com/Robin831/Forge/internal/wicket"
 	"github.com/Robin831/Forge/internal/worker"
 	"github.com/Robin831/Forge/internal/worktree"
-
 )
 
 const (
@@ -3977,6 +3976,10 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		reqID, _ := d.reqTracker.Track()
 		beadID := sp.BeadID
 		anvilName := sp.Anvil
+		reason := strings.TrimSpace(sp.Reason)
+		if reason == "" {
+			reason = "manually stopped"
+		}
 		go func() {
 			releaseCtx, releaseCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 			defer releaseCancel()
@@ -3988,7 +3991,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				d.completeAsync(reqID, ipc.Response{Type: "error", Payload: errMsg})
 				return
 			}
-			d.logger.Info("bead stopped", "bead", beadID, "anvil", anvilName)
+			d.logger.Info("bead stopped", "bead", beadID, "anvil", anvilName, "reason", reason)
 			data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("bead %s stopped", beadID)})
 			d.completeAsync(reqID, ipc.Response{Type: "ok", Payload: data})
 		}()
@@ -4067,12 +4070,6 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		// Bead retry: delegate the state mutation + audit event to the
 		// shared queueactions.Retry, then handle the daemon-local async work
 		// (bd shell, crucible cache, poll dispatch) below.
-		retry, getErr := d.db.GetRetry(rp.BeadID, rp.Anvil)
-		if getErr != nil {
-			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to get retry state: %v", getErr)})
-			return ipc.Response{Type: "error", Payload: msg}
-		}
-		hasCircuitBreaker := retry != nil && retry.DispatchFailures > 0
 		if err := queueactions.Retry(context.Background(), d.queueActionsHandle(), queueactions.Params{
 			BeadID:    rp.BeadID,
 			AnvilName: rp.Anvil,
@@ -4080,11 +4077,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("retry bead", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		if hasCircuitBreaker {
-			d.logger.Info("retry state reset for bead", "bead", rp.BeadID, "anvil", rp.Anvil)
-		} else {
-			d.logger.Info("retry reset for bead", "bead", rp.BeadID, "anvil", rp.Anvil)
-		}
+		d.logger.Info("retry reset for bead", "bead", rp.BeadID, "anvil", rp.Anvil)
 		reqID, _ := d.reqTracker.Track()
 		go func() {
 			bdUpdateOK := false
@@ -4112,11 +4105,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				d.crucibleStatuses.Delete(rp.Anvil + "/" + rp.BeadID)
 			}
 			d.pollAndDispatch(d.runCtx, false)
-			msg := "retry reset"
-			if hasCircuitBreaker {
-				msg = "retry state reset"
-			}
-			data, _ := json.Marshal(map[string]string{"message": msg})
+			data, _ := json.Marshal(map[string]string{"message": "retry reset"})
 			d.completeAsync(reqID, ipc.Response{Type: "ok", Payload: data})
 		}()
 		resp, _ := ipc.NewQueuedResponse(reqID, "retrying bead")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -48,6 +48,7 @@ import (
 	"github.com/Robin831/Forge/internal/notify"
 	"github.com/Robin831/Forge/internal/pipeline"
 	"github.com/Robin831/Forge/internal/poller"
+	"github.com/Robin831/Forge/internal/queueactions"
 	"github.com/Robin831/Forge/internal/prompt"
 	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/rebase"
@@ -3744,21 +3745,15 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": "invalid set_clarification payload"})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		if cp.BeadID == "" || cp.Anvil == "" {
-			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
+		if err := queueactions.Clarify(context.Background(), d.queueActionsHandle(), queueactions.Params{
+			BeadID:    cp.BeadID,
+			AnvilName: cp.Anvil,
+			Note:      cp.Reason,
+		}); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("set clarification", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		reason := strings.TrimSpace(cp.Reason)
-		if reason == "" {
-			msg, _ := json.Marshal(map[string]string{"message": "reason is required"})
-			return ipc.Response{Type: "error", Payload: msg}
-		}
-		if err := d.db.SetClarificationNeeded(cp.BeadID, cp.Anvil, true, reason); err != nil {
-			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to set clarification: %v", err)})
-			return ipc.Response{Type: "error", Payload: msg}
-		}
-		_ = d.db.LogEvent(state.EventClarificationNeeded, fmt.Sprintf("Bead %s needs clarification: %s", cp.BeadID, reason), cp.BeadID, cp.Anvil)
-		d.logger.Info("bead marked as clarification_needed", "bead", cp.BeadID, "anvil", cp.Anvil, "reason", reason)
+		d.logger.Info("bead marked as clarification_needed", "bead", cp.BeadID, "anvil", cp.Anvil, "reason", strings.TrimSpace(cp.Reason))
 		data, _ := json.Marshal(map[string]string{"message": "clarification_needed set"})
 		return ipc.Response{Type: "ok", Payload: data}
 
@@ -3958,17 +3953,6 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		reason := strings.TrimSpace(sp.Reason)
-		if reason == "" {
-			reason = "manually stopped"
-		}
-		reason = strings.Map(func(r rune) rune {
-			if r < 32 && r != '\n' {
-				return -1
-			}
-			return r
-		}, reason)
-
 		anvilCfg, ok := d.cfg.Load().Anvils[sp.Anvil]
 		if !ok {
 			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("anvil %q not found", sp.Anvil)})
@@ -3979,43 +3963,33 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			return ipc.Response{Type: "error", Payload: msg}
 		}
 
-		// Kill worker and update DB synchronously — these are fast local ops.
-		if w, err := d.db.ActiveWorkerByBeadAndAnvil(sp.BeadID, sp.Anvil); err == nil && w != nil {
-			if w.PID > 0 {
-				if proc, err := os.FindProcess(w.PID); err == nil {
-					if runtime.GOOS == "windows" {
-						_ = proc.Kill()
-					} else {
-						_ = proc.Signal(syscall.SIGINT)
-					}
-				}
-			}
-			_ = d.db.UpdateWorkerStatus(w.ID, state.WorkerFailed)
-			d.logger.Info("killed worker for stopped bead", "worker", w.ID, "bead", sp.BeadID)
-		}
-
-		if err := d.db.SetClarificationNeeded(sp.BeadID, sp.Anvil, true, reason); err != nil {
-			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to set clarification: %v", err)})
+		if err := queueactions.Stop(context.Background(), d.queueActionsHandle(), queueactions.Params{
+			BeadID:    sp.BeadID,
+			AnvilName: sp.Anvil,
+			Note:      sp.Reason,
+		}); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("stop bead", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
 
 		d.activeBeads.Delete(sp.BeadID)
 
 		reqID, _ := d.reqTracker.Track()
+		beadID := sp.BeadID
+		anvilName := sp.Anvil
 		go func() {
 			releaseCtx, releaseCancel := context.WithTimeout(d.runCtx, executil.DefaultBdTimeout)
 			defer releaseCancel()
-			releaseCmd := executil.HideWindow(exec.CommandContext(releaseCtx, "bd", "update", sp.BeadID, "--status=open", "--assignee=", "--json"))
+			releaseCmd := executil.HideWindow(exec.CommandContext(releaseCtx, "bd", "update", beadID, "--status=open", "--assignee=", "--json"))
 			releaseCmd.Dir = anvilCfg.Path
 			if out, err := releaseCmd.CombinedOutput(); err != nil {
-				d.logger.Warn("bd update failed when releasing stopped bead", "bead", sp.BeadID, "error", err, "output", strings.TrimSpace(string(out)))
+				d.logger.Warn("bd update failed when releasing stopped bead", "bead", beadID, "error", err, "output", strings.TrimSpace(string(out)))
 				errMsg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("bead stopped but bd release failed: %v", err)})
 				d.completeAsync(reqID, ipc.Response{Type: "error", Payload: errMsg})
 				return
 			}
-			_ = d.db.LogEvent(state.EventBeadStopped, fmt.Sprintf("Bead %s stopped: %s", sp.BeadID, reason), sp.BeadID, sp.Anvil)
-			d.logger.Info("bead stopped", "bead", sp.BeadID, "anvil", sp.Anvil, "reason", reason)
-			data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("bead %s stopped", sp.BeadID)})
+			d.logger.Info("bead stopped", "bead", beadID, "anvil", anvilName)
+			data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("bead %s stopped", beadID)})
 			d.completeAsync(reqID, ipc.Response{Type: "ok", Payload: data})
 		}()
 		resp, _ := ipc.NewQueuedResponse(reqID, "stopping bead")
@@ -4027,15 +4001,14 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": "invalid clear_clarification payload"})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		if cp.BeadID == "" || cp.Anvil == "" {
-			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
+		if err := queueactions.Unclarify(context.Background(), d.queueActionsHandle(), queueactions.Params{
+			BeadID:    cp.BeadID,
+			AnvilName: cp.Anvil,
+			Note:      cp.Reason,
+		}); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("clear clarification", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		if err := d.db.SetClarificationNeeded(cp.BeadID, cp.Anvil, false, ""); err != nil {
-			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to clear clarification: %v", err)})
-			return ipc.Response{Type: "error", Payload: msg}
-		}
-		_ = d.db.LogEvent(state.EventClarificationCleared, fmt.Sprintf("Clarification cleared for bead %s", cp.BeadID), cp.BeadID, cp.Anvil)
 		d.logger.Info("clarification_needed cleared", "bead", cp.BeadID, "anvil", cp.Anvil)
 		data, _ := json.Marshal(map[string]string{"message": "clarification_needed cleared"})
 		return ipc.Response{Type: "ok", Payload: data}
@@ -4091,25 +4064,25 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			data, _ := json.Marshal(map[string]string{"message": "PR fix counts reset, status set to open"})
 			return ipc.Response{Type: "ok", Payload: data}
 		}
-		// Bead retry: validate DB state synchronously, then shell out async.
-		retry, err := d.db.GetRetry(rp.BeadID, rp.Anvil)
-		if err != nil {
-			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to get retry state: %v", err)})
+		// Bead retry: delegate the state mutation + audit event to the
+		// shared queueactions.Retry, then handle the daemon-local async work
+		// (bd shell, crucible cache, poll dispatch) below.
+		retry, getErr := d.db.GetRetry(rp.BeadID, rp.Anvil)
+		if getErr != nil {
+			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to get retry state: %v", getErr)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
 		hasCircuitBreaker := retry != nil && retry.DispatchFailures > 0
+		if err := queueactions.Retry(context.Background(), d.queueActionsHandle(), queueactions.Params{
+			BeadID:    rp.BeadID,
+			AnvilName: rp.Anvil,
+		}); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("retry bead", err)})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
 		if hasCircuitBreaker {
-			if err := d.db.ResetRetry(rp.BeadID, rp.Anvil); err != nil {
-				msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to reset retry state: %v", err)})
-				return ipc.Response{Type: "error", Payload: msg}
-			}
-			_ = d.db.LogEvent(state.EventRetryReset, fmt.Sprintf("Retry state reset for bead %s (manual)", rp.BeadID), rp.BeadID, rp.Anvil)
 			d.logger.Info("retry state reset for bead", "bead", rp.BeadID, "anvil", rp.Anvil)
 		} else {
-			if err := d.db.ResetRetry(rp.BeadID, rp.Anvil); err != nil {
-				d.logger.Warn("ResetRetry failed (might not have a retry record)", "bead", rp.BeadID, "anvil", rp.Anvil, "error", err)
-			}
-			_ = d.db.LogEvent(state.EventRetryReset, fmt.Sprintf("Retry reset for bead %s (manual)", rp.BeadID), rp.BeadID, rp.Anvil)
 			d.logger.Info("retry reset for bead", "bead", rp.BeadID, "anvil", rp.Anvil)
 		}
 		reqID, _ := d.reqTracker.Track()
@@ -4155,20 +4128,18 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			msg, _ := json.Marshal(map[string]string{"message": "invalid clear_bead payload"})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		if cp.BeadID == "" || cp.Anvil == "" {
-			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
-			return ipc.Response{Type: "error", Payload: msg}
-		}
 		if cp.Anvil != "" {
 			if canonical, _, ok := d.resolveAnvilConfig(cp.Anvil); ok {
 				cp.Anvil = canonical
 			}
 		}
-		if err := d.db.ClearNeedsAttention(cp.BeadID, cp.Anvil); err != nil {
-			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to clear needs-attention flags: %v", err)})
+		if err := queueactions.Clear(context.Background(), d.queueActionsHandle(), queueactions.Params{
+			BeadID:    cp.BeadID,
+			AnvilName: cp.Anvil,
+		}); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("clear needs-attention flags", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
-		_ = d.db.LogEvent(state.EventRetryCleared, fmt.Sprintf("Needs-attention flags cleared for bead %s (manual)", cp.BeadID), cp.BeadID, cp.Anvil)
 		d.logger.Info("needs-attention flags cleared", "bead", cp.BeadID, "anvil", cp.Anvil)
 		data, _ := json.Marshal(map[string]string{"message": "needs-attention flags cleared"})
 		return ipc.Response{Type: "ok", Payload: data}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3962,13 +3962,17 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 			return ipc.Response{Type: "error", Payload: msg}
 		}
 
-		if err := queueactions.Stop(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		terminatedWorkerID, err := queueactions.Stop(context.Background(), d.queueActionsHandle(), queueactions.Params{
 			BeadID:    sp.BeadID,
 			AnvilName: sp.Anvil,
 			Note:      sp.Reason,
-		}); err != nil {
+		})
+		if err != nil {
 			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("stop bead", err)})
 			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if terminatedWorkerID != "" {
+			d.logger.Info("killed worker for stopped bead", "worker", terminatedWorkerID, "bead", sp.BeadID, "anvil", sp.Anvil)
 		}
 
 		d.activeBeads.Delete(sp.BeadID)
@@ -3976,7 +3980,7 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		reqID, _ := d.reqTracker.Track()
 		beadID := sp.BeadID
 		anvilName := sp.Anvil
-		reason := strings.TrimSpace(sp.Reason)
+		reason := queueactions.SanitizeControl(strings.TrimSpace(sp.Reason))
 		if reason == "" {
 			reason = "manually stopped"
 		}
@@ -4070,10 +4074,11 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		// Bead retry: delegate the state mutation + audit event to the
 		// shared queueactions.Retry, then handle the daemon-local async work
 		// (bd shell, crucible cache, poll dispatch) below.
-		if err := queueactions.Retry(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		hadCircuitBreaker, err := queueactions.Retry(context.Background(), d.queueActionsHandle(), queueactions.Params{
 			BeadID:    rp.BeadID,
 			AnvilName: rp.Anvil,
-		}); err != nil {
+		})
+		if err != nil {
 			msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("retry bead", err)})
 			return ipc.Response{Type: "error", Payload: msg}
 		}
@@ -4105,7 +4110,14 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 				d.crucibleStatuses.Delete(rp.Anvil + "/" + rp.BeadID)
 			}
 			d.pollAndDispatch(d.runCtx, false)
-			data, _ := json.Marshal(map[string]string{"message": "retry reset"})
+			// Preserve the pre-refactor response wording: CLI/web consumers
+			// distinguish "retry state reset" (circuit-breaker cleared) from
+			// "retry reset" (no circuit-breaker, just a manual nudge).
+			retryMsg := "retry reset"
+			if hadCircuitBreaker {
+				retryMsg = "retry state reset"
+			}
+			data, _ := json.Marshal(map[string]string{"message": retryMsg})
 			d.completeAsync(reqID, ipc.Response{Type: "ok", Payload: data})
 		}()
 		resp, _ := ipc.NewQueuedResponse(reqID, "retrying bead")

--- a/internal/daemon/queueactions_handle.go
+++ b/internal/daemon/queueactions_handle.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Robin831/Forge/internal/queueactions"
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// queueActionsErrorMessage formats a queueactions error for the IPC error
+// payload. Required-field validation collapses to the legacy "bead_id and
+// anvil are required" string so existing CLI/web callers keep matching;
+// forge-mismatch is surfaced as-is so the sibling IPC handlers can show the
+// caller what's wrong. Everything else is prefixed with the action name in
+// the legacy "failed to X: <err>" shape.
+func queueActionsErrorMessage(action string, err error) string {
+	switch {
+	case errors.Is(err, queueactions.ErrMissingBeadID),
+		errors.Is(err, queueactions.ErrMissingAnvil):
+		return "bead_id and anvil are required"
+	case errors.Is(err, queueactions.ErrMissingReason):
+		return "reason is required"
+	case errors.Is(err, queueactions.ErrForgeMismatch):
+		return err.Error()
+	default:
+		return fmt.Sprintf("failed to %s: %v", action, err)
+	}
+}
+
+// queueActionsHandle adapts the daemon's state.DB and config snapshot to the
+// queueactions.QueueHandle interface so the shared business logic can run
+// from inside the daemon's IPC dispatcher without dragging the full Daemon
+// type into the queueactions package.
+type queueActionsHandle struct {
+	db      *state.DB
+	forgeID string
+}
+
+func (d *Daemon) queueActionsHandle() queueactions.QueueHandle {
+	return &queueActionsHandle{
+		db:      d.db,
+		forgeID: d.cfg.Load().Settings.ResolvedForgeID(),
+	}
+}
+
+func (h *queueActionsHandle) LocalForgeID() string { return h.forgeID }
+
+func (h *queueActionsHandle) SetClarificationNeeded(beadID, anvil string, needed bool, reason string) error {
+	return h.db.SetClarificationNeeded(beadID, anvil, needed, reason)
+}
+
+func (h *queueActionsHandle) ClearNeedsAttention(beadID, anvil string) error {
+	return h.db.ClearNeedsAttention(beadID, anvil)
+}
+
+func (h *queueActionsHandle) GetRetry(beadID, anvil string) (*state.RetryRecord, error) {
+	return h.db.GetRetry(beadID, anvil)
+}
+
+func (h *queueActionsHandle) ResetRetry(beadID, anvil string) error {
+	return h.db.ResetRetry(beadID, anvil)
+}
+
+func (h *queueActionsHandle) ActiveWorkerByBeadAndAnvil(beadID, anvil string) (*state.Worker, error) {
+	return h.db.ActiveWorkerByBeadAndAnvil(beadID, anvil)
+}
+
+func (h *queueActionsHandle) UpdateWorkerStatus(workerID string, status state.WorkerStatus) error {
+	return h.db.UpdateWorkerStatus(workerID, status)
+}
+
+func (h *queueActionsHandle) LogEvent(typ state.EventType, message, beadID, anvil string) error {
+	return h.db.LogEvent(typ, message, beadID, anvil)
+}

--- a/internal/queueactions/errors.go
+++ b/internal/queueactions/errors.go
@@ -1,0 +1,20 @@
+package queueactions
+
+import "errors"
+
+// ErrForgeMismatch is returned when the caller's forge_id does not match the
+// forge that owns the worker/bead being acted on. This is the multi-forge
+// safety check that prevents one Forge instance from clobbering another's
+// state when they share a database or are addressed by a shared client (e.g.
+// the web UI).
+var ErrForgeMismatch = errors.New("forge_id does not match owning forge")
+
+// ErrMissingBeadID indicates the caller did not supply a bead identifier.
+var ErrMissingBeadID = errors.New("bead_id is required")
+
+// ErrMissingAnvil indicates the caller did not supply an anvil name.
+var ErrMissingAnvil = errors.New("anvil is required")
+
+// ErrMissingReason indicates the caller did not supply a reason/note where
+// the action requires one (currently: clarify).
+var ErrMissingReason = errors.New("reason is required")

--- a/internal/queueactions/queueactions.go
+++ b/internal/queueactions/queueactions.go
@@ -103,21 +103,25 @@ func Unclarify(ctx context.Context, q QueueHandle, p Params) error {
 // retry (resetting bellows fix counts) remains in the daemon because it
 // requires lifecycle and bellows references that have no place behind the
 // shared interface.
-func Retry(ctx context.Context, q QueueHandle, p Params) error {
+//
+// The returned bool is true when a circuit-breaker row with DispatchFailures>0
+// was found and cleared; callers can use this to preserve the prior IPC
+// response wording ("retry state reset" vs "retry reset").
+func Retry(ctx context.Context, q QueueHandle, p Params) (bool, error) {
 	if err := validateCommon(p); err != nil {
-		return err
+		return false, err
 	}
 	if err := checkForge(q, p); err != nil {
-		return err
+		return false, err
 	}
 	retry, err := q.GetRetry(p.BeadID, p.AnvilName)
 	if err != nil {
-		return fmt.Errorf("get retry state: %w", err)
+		return false, fmt.Errorf("get retry state: %w", err)
 	}
 	hasCircuitBreaker := retry != nil && retry.DispatchFailures > 0
 	if err := q.ResetRetry(p.BeadID, p.AnvilName); err != nil {
 		if hasCircuitBreaker {
-			return fmt.Errorf("reset retry state: %w", err)
+			return false, fmt.Errorf("reset retry state: %w", err)
 		}
 		// Pre-existing behaviour: a missing retry row is not fatal when there
 		// was no circuit breaker to clear. Swallow and continue so the audit
@@ -128,9 +132,9 @@ func Retry(ctx context.Context, q QueueHandle, p Params) error {
 		base = fmt.Sprintf("Retry reset for bead %s (manual)", p.BeadID)
 	}
 	if err := q.LogEvent(state.EventRetryReset, formatEvent(base, p.Note), p.BeadID, p.AnvilName); err != nil {
-		return fmt.Errorf("log event: %w", err)
+		return false, fmt.Errorf("log event: %w", err)
 	}
-	return nil
+	return hasCircuitBreaker, nil
 }
 
 // Clear drops the needs-attention flags from a bead's retry row without
@@ -156,35 +160,41 @@ func Clear(ctx context.Context, q QueueHandle, p Params) error {
 // clarification (preventing both auto and manual re-dispatch), and writes an
 // audit event. The caller is responsible for any follow-up shell work — most
 // notably `bd update --status=open --assignee=` to release the claim.
-func Stop(ctx context.Context, q QueueHandle, p Params) error {
+//
+// The returned string is the worker ID that was signalled and marked failed,
+// or empty if no active worker was found. Callers can log this to preserve
+// operator visibility into which process was terminated.
+func Stop(ctx context.Context, q QueueHandle, p Params) (string, error) {
 	if err := validateCommon(p); err != nil {
-		return err
+		return "", err
 	}
 	if err := checkForge(q, p); err != nil {
-		return err
+		return "", err
 	}
 	reason := strings.TrimSpace(p.Note)
 	if reason == "" {
 		reason = "manually stopped"
 	}
-	reason = sanitizeControl(reason)
+	reason = SanitizeControl(reason)
 
+	var terminatedWorkerID string
 	if w, err := q.ActiveWorkerByBeadAndAnvil(p.BeadID, p.AnvilName); err == nil && w != nil {
 		if w.PID > 0 {
 			signalWorker(w.PID)
 		}
 		_ = q.UpdateWorkerStatus(w.ID, state.WorkerFailed)
+		terminatedWorkerID = w.ID
 	}
 
 	if err := q.SetClarificationNeeded(p.BeadID, p.AnvilName, true, reason); err != nil {
-		return fmt.Errorf("set clarification: %w", err)
+		return "", fmt.Errorf("set clarification: %w", err)
 	}
 
 	msg := fmt.Sprintf("Bead %s stopped: %s", p.BeadID, reason)
 	if err := q.LogEvent(state.EventBeadStopped, msg, p.BeadID, p.AnvilName); err != nil {
-		return fmt.Errorf("log event: %w", err)
+		return "", fmt.Errorf("log event: %w", err)
 	}
-	return nil
+	return terminatedWorkerID, nil
 }
 
 // validateCommon enforces the shared required fields (BeadID, AnvilName).
@@ -199,15 +209,22 @@ func validateCommon(p Params) error {
 }
 
 // checkForge enforces the multi-forge safety rule: if the caller supplied a
-// forge_id, it must match the local forge. An empty forge_id preserves
+// forge_id, it must match the local forge. An empty caller forge_id preserves
 // historical single-forge behaviour where the daemon implicitly owned every
 // worker/bead in its state DB.
+//
+// When the caller supplies a forge_id but the local daemon has none configured,
+// the request is rejected rather than silently accepted — an unconfigured local
+// id is precisely when cross-forge clobbering is most likely and least visible.
 func checkForge(q QueueHandle, p Params) error {
 	if strings.TrimSpace(p.ForgeID) == "" {
 		return nil
 	}
 	local := strings.TrimSpace(q.LocalForgeID())
-	if local == "" || p.ForgeID == local {
+	if local == "" {
+		return fmt.Errorf("%w: caller=%q local=<unconfigured>", ErrForgeMismatch, p.ForgeID)
+	}
+	if p.ForgeID == local {
 		return nil
 	}
 	return fmt.Errorf("%w: caller=%q local=%q", ErrForgeMismatch, p.ForgeID, local)
@@ -223,10 +240,11 @@ func formatEvent(base, note string) string {
 	return base + " (note: " + note + ")"
 }
 
-// sanitizeControl strips control characters (except newline) from operator
+// SanitizeControl strips control characters (except newline) from operator
 // input that ends up in the bead's clarification_reason and event message.
-// Mirrors the historical Stop handler so log lines remain greppable.
-func sanitizeControl(s string) string {
+// Exported so daemon log sites can apply the same transform and remain
+// consistent with what the audit event records.
+func SanitizeControl(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r < 32 && r != '\n' {
 			return -1

--- a/internal/queueactions/queueactions.go
+++ b/internal/queueactions/queueactions.go
@@ -1,0 +1,251 @@
+// Package queueactions hosts the shared business logic behind the queue
+// resolution verbs: clarify, unclarify, retry, clear, stop.
+//
+// These functions are the single source of truth for the state mutations and
+// audit-trail entries that back the CLI verbs (forge queue clarify, etc.) and
+// the IPC handlers (queue_clarify, queue_unclarify, queue_retry, queue_clear,
+// queue_stop). Daemon-specific orchestration that surrounds each action —
+// shelling out to `bd`, refreshing in-memory caches, kicking the poller — is
+// not part of this package; callers compose those on top of the action.
+//
+// Multi-forge safety is enforced inside each function: if the caller supplies
+// a forge_id that does not match the QueueHandle's local forge_id, the action
+// is refused with ErrForgeMismatch. A caller that omits forge_id retains the
+// historical single-forge behaviour.
+package queueactions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// Params bundles the inputs common to all queue resolution actions. AnvilName
+// is canonicalised by the caller before invocation. Note is the operator's
+// free-form explanation, captured in the audit event.
+type Params struct {
+	BeadID    string
+	ForgeID   string
+	AnvilName string
+	Note      string
+}
+
+// QueueHandle abstracts the daemon state operations that the shared actions
+// rely on. The daemon implements this directly against state.DB; tests pass
+// in a fake to verify behaviour without a real database.
+type QueueHandle interface {
+	// LocalForgeID returns the forge_id of the Forge instance handling the
+	// request. Compared against Params.ForgeID for the multi-forge safety
+	// check.
+	LocalForgeID() string
+
+	SetClarificationNeeded(beadID, anvil string, needed bool, reason string) error
+	ClearNeedsAttention(beadID, anvil string) error
+	GetRetry(beadID, anvil string) (*state.RetryRecord, error)
+	ResetRetry(beadID, anvil string) error
+
+	ActiveWorkerByBeadAndAnvil(beadID, anvil string) (*state.Worker, error)
+	UpdateWorkerStatus(workerID string, status state.WorkerStatus) error
+
+	LogEvent(typ state.EventType, message, beadID, anvil string) error
+}
+
+// Clarify marks a bead as needing human clarification before further dispatch.
+// Mirrors the legacy set_clarification IPC handler. The note is required and
+// captured both as the bead's clarification reason and in the audit event.
+func Clarify(ctx context.Context, q QueueHandle, p Params) error {
+	if err := validateCommon(p); err != nil {
+		return err
+	}
+	reason := strings.TrimSpace(p.Note)
+	if reason == "" {
+		return ErrMissingReason
+	}
+	if err := checkForge(q, p); err != nil {
+		return err
+	}
+	if err := q.SetClarificationNeeded(p.BeadID, p.AnvilName, true, reason); err != nil {
+		return fmt.Errorf("set clarification: %w", err)
+	}
+	msg := fmt.Sprintf("Bead %s needs clarification: %s", p.BeadID, reason)
+	if err := q.LogEvent(state.EventClarificationNeeded, msg, p.BeadID, p.AnvilName); err != nil {
+		return fmt.Errorf("log event: %w", err)
+	}
+	return nil
+}
+
+// Unclarify clears the clarification_needed flag so a bead can be dispatched
+// again. The note is optional; when supplied it is appended to the audit
+// event so operators can see why the flag was lifted.
+func Unclarify(ctx context.Context, q QueueHandle, p Params) error {
+	if err := validateCommon(p); err != nil {
+		return err
+	}
+	if err := checkForge(q, p); err != nil {
+		return err
+	}
+	if err := q.SetClarificationNeeded(p.BeadID, p.AnvilName, false, ""); err != nil {
+		return fmt.Errorf("clear clarification: %w", err)
+	}
+	if err := q.LogEvent(state.EventClarificationCleared, formatEvent("Clarification cleared for bead "+p.BeadID, p.Note), p.BeadID, p.AnvilName); err != nil {
+		return fmt.Errorf("log event: %w", err)
+	}
+	return nil
+}
+
+// Retry resets the dispatch circuit breaker for a bead so the next poll
+// cycle re-dispatches it. Only the bead-level reset lives here; PR-level
+// retry (resetting bellows fix counts) remains in the daemon because it
+// requires lifecycle and bellows references that have no place behind the
+// shared interface.
+func Retry(ctx context.Context, q QueueHandle, p Params) error {
+	if err := validateCommon(p); err != nil {
+		return err
+	}
+	if err := checkForge(q, p); err != nil {
+		return err
+	}
+	retry, err := q.GetRetry(p.BeadID, p.AnvilName)
+	if err != nil {
+		return fmt.Errorf("get retry state: %w", err)
+	}
+	hasCircuitBreaker := retry != nil && retry.DispatchFailures > 0
+	if err := q.ResetRetry(p.BeadID, p.AnvilName); err != nil {
+		if hasCircuitBreaker {
+			return fmt.Errorf("reset retry state: %w", err)
+		}
+		// Pre-existing behaviour: a missing retry row is not fatal when there
+		// was no circuit breaker to clear. Swallow and continue so the audit
+		// event still fires.
+	}
+	base := fmt.Sprintf("Retry state reset for bead %s (manual)", p.BeadID)
+	if !hasCircuitBreaker {
+		base = fmt.Sprintf("Retry reset for bead %s (manual)", p.BeadID)
+	}
+	if err := q.LogEvent(state.EventRetryReset, formatEvent(base, p.Note), p.BeadID, p.AnvilName); err != nil {
+		return fmt.Errorf("log event: %w", err)
+	}
+	return nil
+}
+
+// Clear drops the needs-attention flags from a bead's retry row without
+// re-dispatching it. Idempotent — safe on an already-clean bead.
+func Clear(ctx context.Context, q QueueHandle, p Params) error {
+	if err := validateCommon(p); err != nil {
+		return err
+	}
+	if err := checkForge(q, p); err != nil {
+		return err
+	}
+	if err := q.ClearNeedsAttention(p.BeadID, p.AnvilName); err != nil {
+		return fmt.Errorf("clear needs-attention: %w", err)
+	}
+	msg := fmt.Sprintf("Needs-attention flags cleared for bead %s (manual)", p.BeadID)
+	if err := q.LogEvent(state.EventRetryCleared, formatEvent(msg, p.Note), p.BeadID, p.AnvilName); err != nil {
+		return fmt.Errorf("log event: %w", err)
+	}
+	return nil
+}
+
+// Stop terminates any running worker for the bead, marks the bead as needing
+// clarification (preventing both auto and manual re-dispatch), and writes an
+// audit event. The caller is responsible for any follow-up shell work — most
+// notably `bd update --status=open --assignee=` to release the claim.
+func Stop(ctx context.Context, q QueueHandle, p Params) error {
+	if err := validateCommon(p); err != nil {
+		return err
+	}
+	if err := checkForge(q, p); err != nil {
+		return err
+	}
+	reason := strings.TrimSpace(p.Note)
+	if reason == "" {
+		reason = "manually stopped"
+	}
+	reason = sanitizeControl(reason)
+
+	if w, err := q.ActiveWorkerByBeadAndAnvil(p.BeadID, p.AnvilName); err == nil && w != nil {
+		if w.PID > 0 {
+			signalWorker(w.PID)
+		}
+		_ = q.UpdateWorkerStatus(w.ID, state.WorkerFailed)
+	}
+
+	if err := q.SetClarificationNeeded(p.BeadID, p.AnvilName, true, reason); err != nil {
+		return fmt.Errorf("set clarification: %w", err)
+	}
+
+	msg := fmt.Sprintf("Bead %s stopped: %s", p.BeadID, reason)
+	if err := q.LogEvent(state.EventBeadStopped, msg, p.BeadID, p.AnvilName); err != nil {
+		return fmt.Errorf("log event: %w", err)
+	}
+	return nil
+}
+
+// validateCommon enforces the shared required fields (BeadID, AnvilName).
+func validateCommon(p Params) error {
+	if strings.TrimSpace(p.BeadID) == "" {
+		return ErrMissingBeadID
+	}
+	if strings.TrimSpace(p.AnvilName) == "" {
+		return ErrMissingAnvil
+	}
+	return nil
+}
+
+// checkForge enforces the multi-forge safety rule: if the caller supplied a
+// forge_id, it must match the local forge. An empty forge_id preserves
+// historical single-forge behaviour where the daemon implicitly owned every
+// worker/bead in its state DB.
+func checkForge(q QueueHandle, p Params) error {
+	if strings.TrimSpace(p.ForgeID) == "" {
+		return nil
+	}
+	local := strings.TrimSpace(q.LocalForgeID())
+	if local == "" || p.ForgeID == local {
+		return nil
+	}
+	return fmt.Errorf("%w: caller=%q local=%q", ErrForgeMismatch, p.ForgeID, local)
+}
+
+// formatEvent appends an operator-supplied note to the canonical event
+// message so audit consumers see both the action and the human context.
+func formatEvent(base, note string) string {
+	note = strings.TrimSpace(note)
+	if note == "" {
+		return base
+	}
+	return base + " (note: " + note + ")"
+}
+
+// sanitizeControl strips control characters (except newline) from operator
+// input that ends up in the bead's clarification_reason and event message.
+// Mirrors the historical Stop handler so log lines remain greppable.
+func sanitizeControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 32 && r != '\n' {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// signalWorker delivers the platform-appropriate termination signal to a
+// running worker process. SIGINT on POSIX gives Smith a chance to flush logs;
+// Windows has no SIGINT so we fall back to Kill.
+func signalWorker(pid int) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	if runtime.GOOS == "windows" {
+		_ = proc.Kill()
+		return
+	}
+	_ = proc.Signal(syscall.SIGINT)
+}

--- a/internal/queueactions/queueactions_test.go
+++ b/internal/queueactions/queueactions_test.go
@@ -1,0 +1,386 @@
+package queueactions
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// fakeHandle is a hand-rolled QueueHandle that records every call so tests
+// can assert on the exact mutations and events the shared functions produce.
+type fakeHandle struct {
+	localForgeID string
+
+	clarifications []clarifyCall
+	cleared        []clearCall
+	resets         []resetCall
+
+	retryRecords map[string]*state.RetryRecord
+	workers      map[string]*state.Worker
+	workerStatus []workerStatusCall
+
+	events []state.Event
+
+	failReset bool
+}
+
+type clarifyCall struct {
+	BeadID string
+	Anvil  string
+	Needed bool
+	Reason string
+}
+
+type clearCall struct {
+	BeadID string
+	Anvil  string
+}
+
+type resetCall struct {
+	BeadID string
+	Anvil  string
+}
+
+type workerStatusCall struct {
+	WorkerID string
+	Status   state.WorkerStatus
+}
+
+func newFakeHandle() *fakeHandle {
+	return &fakeHandle{
+		localForgeID: "forge-a",
+		retryRecords: map[string]*state.RetryRecord{},
+		workers:      map[string]*state.Worker{},
+	}
+}
+
+func (f *fakeHandle) LocalForgeID() string { return f.localForgeID }
+
+func (f *fakeHandle) SetClarificationNeeded(beadID, anvil string, needed bool, reason string) error {
+	f.clarifications = append(f.clarifications, clarifyCall{beadID, anvil, needed, reason})
+	return nil
+}
+
+func (f *fakeHandle) ClearNeedsAttention(beadID, anvil string) error {
+	f.cleared = append(f.cleared, clearCall{beadID, anvil})
+	return nil
+}
+
+func (f *fakeHandle) GetRetry(beadID, anvil string) (*state.RetryRecord, error) {
+	return f.retryRecords[beadID+"/"+anvil], nil
+}
+
+func (f *fakeHandle) ResetRetry(beadID, anvil string) error {
+	if f.failReset {
+		return errors.New("boom: ResetRetry")
+	}
+	f.resets = append(f.resets, resetCall{beadID, anvil})
+	delete(f.retryRecords, beadID+"/"+anvil)
+	return nil
+}
+
+func (f *fakeHandle) ActiveWorkerByBeadAndAnvil(beadID, anvil string) (*state.Worker, error) {
+	return f.workers[beadID+"/"+anvil], nil
+}
+
+func (f *fakeHandle) UpdateWorkerStatus(workerID string, status state.WorkerStatus) error {
+	f.workerStatus = append(f.workerStatus, workerStatusCall{workerID, status})
+	return nil
+}
+
+func (f *fakeHandle) LogEvent(typ state.EventType, message, beadID, anvil string) error {
+	f.events = append(f.events, state.Event{Type: typ, Message: message, BeadID: beadID, Anvil: anvil})
+	return nil
+}
+
+func TestClarify(t *testing.T) {
+	t.Run("success records clarification and event", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clarify(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "which auth lib?"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := len(h.clarifications); got != 1 {
+			t.Fatalf("expected 1 clarification call, got %d", got)
+		}
+		c := h.clarifications[0]
+		if c.BeadID != "BD-1" || c.Anvil != "munin" || !c.Needed || c.Reason != "which auth lib?" {
+			t.Fatalf("unexpected clarification call: %+v", c)
+		}
+		if len(h.events) != 1 || h.events[0].Type != state.EventClarificationNeeded {
+			t.Fatalf("expected EventClarificationNeeded, got %+v", h.events)
+		}
+		if !strings.Contains(h.events[0].Message, "which auth lib?") {
+			t.Fatalf("expected note in event message, got %q", h.events[0].Message)
+		}
+	})
+
+	t.Run("requires bead id", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clarify(context.Background(), h, Params{AnvilName: "munin", Note: "x"})
+		if !errors.Is(err, ErrMissingBeadID) {
+			t.Fatalf("expected ErrMissingBeadID, got %v", err)
+		}
+	})
+
+	t.Run("requires anvil", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clarify(context.Background(), h, Params{BeadID: "BD-1", Note: "x"})
+		if !errors.Is(err, ErrMissingAnvil) {
+			t.Fatalf("expected ErrMissingAnvil, got %v", err)
+		}
+	})
+
+	t.Run("requires note", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clarify(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		if !errors.Is(err, ErrMissingReason) {
+			t.Fatalf("expected ErrMissingReason, got %v", err)
+		}
+	})
+
+	t.Run("forge mismatch rejected", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clarify(context.Background(), h, Params{
+			BeadID:    "BD-1",
+			AnvilName: "munin",
+			Note:      "x",
+			ForgeID:   "forge-b",
+		})
+		if !errors.Is(err, ErrForgeMismatch) {
+			t.Fatalf("expected ErrForgeMismatch, got %v", err)
+		}
+		if len(h.clarifications) != 0 || len(h.events) != 0 {
+			t.Fatalf("no state should have been mutated; got clarifications=%d events=%d", len(h.clarifications), len(h.events))
+		}
+	})
+
+	t.Run("forge match accepted", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clarify(context.Background(), h, Params{
+			BeadID:    "BD-1",
+			AnvilName: "munin",
+			Note:      "x",
+			ForgeID:   "forge-a",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty forge id skips check", func(t *testing.T) {
+		h := newFakeHandle()
+		h.localForgeID = "forge-a"
+		err := Clarify(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "x"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestUnclarify(t *testing.T) {
+	t.Run("success clears flag and logs event with note", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Unclarify(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "resolved offline"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.clarifications) != 1 {
+			t.Fatalf("expected 1 clarification call, got %d", len(h.clarifications))
+		}
+		c := h.clarifications[0]
+		if c.Needed || c.Reason != "" {
+			t.Fatalf("expected unset clarification, got %+v", c)
+		}
+		if len(h.events) != 1 || h.events[0].Type != state.EventClarificationCleared {
+			t.Fatalf("expected EventClarificationCleared, got %+v", h.events)
+		}
+		if !strings.Contains(h.events[0].Message, "resolved offline") {
+			t.Fatalf("expected note in event message, got %q", h.events[0].Message)
+		}
+	})
+
+	t.Run("note is optional", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Unclarify(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(h.events))
+		}
+	})
+
+	t.Run("forge mismatch rejected", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Unclarify(context.Background(), h, Params{
+			BeadID:    "BD-1",
+			AnvilName: "munin",
+			ForgeID:   "forge-b",
+		})
+		if !errors.Is(err, ErrForgeMismatch) {
+			t.Fatalf("expected ErrForgeMismatch, got %v", err)
+		}
+	})
+}
+
+func TestRetry(t *testing.T) {
+	t.Run("with circuit breaker", func(t *testing.T) {
+		h := newFakeHandle()
+		h.retryRecords["BD-1/munin"] = &state.RetryRecord{BeadID: "BD-1", Anvil: "munin", DispatchFailures: 3}
+		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "manual retry"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.resets) != 1 {
+			t.Fatalf("expected 1 reset, got %d", len(h.resets))
+		}
+		if len(h.events) != 1 || h.events[0].Type != state.EventRetryReset {
+			t.Fatalf("expected EventRetryReset, got %+v", h.events)
+		}
+		if !strings.Contains(h.events[0].Message, "manual retry") {
+			t.Fatalf("expected note in event message, got %q", h.events[0].Message)
+		}
+		if !strings.Contains(h.events[0].Message, "Retry state reset") {
+			t.Fatalf("expected circuit-breaker phrasing, got %q", h.events[0].Message)
+		}
+	})
+
+	t.Run("without circuit breaker", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.events) != 1 || h.events[0].Type != state.EventRetryReset {
+			t.Fatalf("expected EventRetryReset, got %+v", h.events)
+		}
+		if !strings.Contains(h.events[0].Message, "Retry reset") {
+			t.Fatalf("expected no-circuit phrasing, got %q", h.events[0].Message)
+		}
+	})
+
+	t.Run("circuit breaker reset failure surfaces error", func(t *testing.T) {
+		h := newFakeHandle()
+		h.retryRecords["BD-1/munin"] = &state.RetryRecord{BeadID: "BD-1", Anvil: "munin", DispatchFailures: 2}
+		h.failReset = true
+		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		if err == nil {
+			t.Fatalf("expected error from failed reset")
+		}
+		if len(h.events) != 0 {
+			t.Fatalf("no event should be logged on failed reset; got %+v", h.events)
+		}
+	})
+
+	t.Run("forge mismatch rejected", func(t *testing.T) {
+		h := newFakeHandle()
+		h.retryRecords["BD-1/munin"] = &state.RetryRecord{BeadID: "BD-1", Anvil: "munin", DispatchFailures: 1}
+		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b"})
+		if !errors.Is(err, ErrForgeMismatch) {
+			t.Fatalf("expected ErrForgeMismatch, got %v", err)
+		}
+		if len(h.resets) != 0 {
+			t.Fatalf("expected no resets on mismatch, got %d", len(h.resets))
+		}
+	})
+}
+
+func TestClear(t *testing.T) {
+	t.Run("success clears flags and logs event", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clear(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "pr merged"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.cleared) != 1 {
+			t.Fatalf("expected 1 clear call, got %d", len(h.cleared))
+		}
+		if len(h.events) != 1 || h.events[0].Type != state.EventRetryCleared {
+			t.Fatalf("expected EventRetryCleared, got %+v", h.events)
+		}
+		if !strings.Contains(h.events[0].Message, "pr merged") {
+			t.Fatalf("expected note in event message, got %q", h.events[0].Message)
+		}
+	})
+
+	t.Run("forge mismatch rejected", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Clear(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b"})
+		if !errors.Is(err, ErrForgeMismatch) {
+			t.Fatalf("expected ErrForgeMismatch, got %v", err)
+		}
+	})
+}
+
+func TestStop(t *testing.T) {
+	t.Run("kills worker and sets clarification", func(t *testing.T) {
+		h := newFakeHandle()
+		h.workers["BD-1/munin"] = &state.Worker{ID: "w-1", BeadID: "BD-1", Anvil: "munin", PID: 0}
+		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "wrong approach"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.workerStatus) != 1 || h.workerStatus[0].WorkerID != "w-1" || h.workerStatus[0].Status != state.WorkerFailed {
+			t.Fatalf("expected worker w-1 marked failed, got %+v", h.workerStatus)
+		}
+		if len(h.clarifications) != 1 || !h.clarifications[0].Needed || h.clarifications[0].Reason != "wrong approach" {
+			t.Fatalf("expected clarification with reason 'wrong approach', got %+v", h.clarifications)
+		}
+		if len(h.events) != 1 || h.events[0].Type != state.EventBeadStopped {
+			t.Fatalf("expected EventBeadStopped, got %+v", h.events)
+		}
+		if !strings.Contains(h.events[0].Message, "wrong approach") {
+			t.Fatalf("expected note in event message, got %q", h.events[0].Message)
+		}
+	})
+
+	t.Run("falls back to default reason", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if h.clarifications[0].Reason != "manually stopped" {
+			t.Fatalf("expected default reason, got %q", h.clarifications[0].Reason)
+		}
+	})
+
+	t.Run("strips control characters from note", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "bad\x07stuff\nok"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if h.clarifications[0].Reason != "badstuff\nok" {
+			t.Fatalf("expected control chars stripped, got %q", h.clarifications[0].Reason)
+		}
+	})
+
+	t.Run("no worker is fine", func(t *testing.T) {
+		h := newFakeHandle()
+		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "x"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(h.workerStatus) != 0 {
+			t.Fatalf("expected no worker status updates, got %+v", h.workerStatus)
+		}
+	})
+
+	t.Run("forge mismatch rejected", func(t *testing.T) {
+		h := newFakeHandle()
+		h.workers["BD-1/munin"] = &state.Worker{ID: "w-1", BeadID: "BD-1", Anvil: "munin"}
+		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b", Note: "x"})
+		if !errors.Is(err, ErrForgeMismatch) {
+			t.Fatalf("expected ErrForgeMismatch, got %v", err)
+		}
+		if len(h.workerStatus) != 0 || len(h.clarifications) != 0 || len(h.events) != 0 {
+			t.Fatalf("no state should have been mutated; got status=%d clarifications=%d events=%d",
+				len(h.workerStatus), len(h.clarifications), len(h.events))
+		}
+	})
+}

--- a/internal/queueactions/queueactions_test.go
+++ b/internal/queueactions/queueactions_test.go
@@ -231,9 +231,12 @@ func TestRetry(t *testing.T) {
 	t.Run("with circuit breaker", func(t *testing.T) {
 		h := newFakeHandle()
 		h.retryRecords["BD-1/munin"] = &state.RetryRecord{BeadID: "BD-1", Anvil: "munin", DispatchFailures: 3}
-		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "manual retry"})
+		hadCB, err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "manual retry"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if !hadCB {
+			t.Fatalf("expected hasCircuitBreaker=true for a record with DispatchFailures>0")
 		}
 		if len(h.resets) != 1 {
 			t.Fatalf("expected 1 reset, got %d", len(h.resets))
@@ -251,9 +254,12 @@ func TestRetry(t *testing.T) {
 
 	t.Run("without circuit breaker", func(t *testing.T) {
 		h := newFakeHandle()
-		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		hadCB, err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if hadCB {
+			t.Fatalf("expected hasCircuitBreaker=false when no retry record exists")
 		}
 		if len(h.events) != 1 || h.events[0].Type != state.EventRetryReset {
 			t.Fatalf("expected EventRetryReset, got %+v", h.events)
@@ -267,7 +273,7 @@ func TestRetry(t *testing.T) {
 		h := newFakeHandle()
 		h.retryRecords["BD-1/munin"] = &state.RetryRecord{BeadID: "BD-1", Anvil: "munin", DispatchFailures: 2}
 		h.failReset = true
-		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		_, err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
 		if err == nil {
 			t.Fatalf("expected error from failed reset")
 		}
@@ -279,7 +285,7 @@ func TestRetry(t *testing.T) {
 	t.Run("forge mismatch rejected", func(t *testing.T) {
 		h := newFakeHandle()
 		h.retryRecords["BD-1/munin"] = &state.RetryRecord{BeadID: "BD-1", Anvil: "munin", DispatchFailures: 1}
-		err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b"})
+		_, err := Retry(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b"})
 		if !errors.Is(err, ErrForgeMismatch) {
 			t.Fatalf("expected ErrForgeMismatch, got %v", err)
 		}
@@ -320,9 +326,12 @@ func TestStop(t *testing.T) {
 	t.Run("kills worker and sets clarification", func(t *testing.T) {
 		h := newFakeHandle()
 		h.workers["BD-1/munin"] = &state.Worker{ID: "w-1", BeadID: "BD-1", Anvil: "munin", PID: 0}
-		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "wrong approach"})
+		workerID, err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "wrong approach"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if workerID != "w-1" {
+			t.Fatalf("expected terminated workerID=%q, got %q", "w-1", workerID)
 		}
 		if len(h.workerStatus) != 1 || h.workerStatus[0].WorkerID != "w-1" || h.workerStatus[0].Status != state.WorkerFailed {
 			t.Fatalf("expected worker w-1 marked failed, got %+v", h.workerStatus)
@@ -340,7 +349,7 @@ func TestStop(t *testing.T) {
 
 	t.Run("falls back to default reason", func(t *testing.T) {
 		h := newFakeHandle()
-		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
+		_, err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -351,7 +360,7 @@ func TestStop(t *testing.T) {
 
 	t.Run("strips control characters from note", func(t *testing.T) {
 		h := newFakeHandle()
-		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "bad\x07stuff\nok"})
+		_, err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "bad\x07stuff\nok"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -362,9 +371,12 @@ func TestStop(t *testing.T) {
 
 	t.Run("no worker is fine", func(t *testing.T) {
 		h := newFakeHandle()
-		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "x"})
+		workerID, err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", Note: "x"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if workerID != "" {
+			t.Fatalf("expected empty workerID when no worker exists, got %q", workerID)
 		}
 		if len(h.workerStatus) != 0 {
 			t.Fatalf("expected no worker status updates, got %+v", h.workerStatus)
@@ -374,13 +386,22 @@ func TestStop(t *testing.T) {
 	t.Run("forge mismatch rejected", func(t *testing.T) {
 		h := newFakeHandle()
 		h.workers["BD-1/munin"] = &state.Worker{ID: "w-1", BeadID: "BD-1", Anvil: "munin"}
-		err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b", Note: "x"})
+		_, err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-b", Note: "x"})
 		if !errors.Is(err, ErrForgeMismatch) {
 			t.Fatalf("expected ErrForgeMismatch, got %v", err)
 		}
 		if len(h.workerStatus) != 0 || len(h.clarifications) != 0 || len(h.events) != 0 {
 			t.Fatalf("no state should have been mutated; got status=%d clarifications=%d events=%d",
 				len(h.workerStatus), len(h.clarifications), len(h.events))
+		}
+	})
+
+	t.Run("unconfigured local forge rejects targeted request", func(t *testing.T) {
+		h := newFakeHandle()
+		h.localForgeID = ""
+		_, err := Stop(context.Background(), h, Params{BeadID: "BD-1", AnvilName: "munin", ForgeID: "forge-a", Note: "x"})
+		if !errors.Is(err, ErrForgeMismatch) {
+			t.Fatalf("expected ErrForgeMismatch when local forge_id is unconfigured, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Changes

- **Queue resolution actions now go through a shared package** - The IPC handlers for `forge queue clarify|unclarify|retry|clear|stop` delegate to a new `internal/queueactions` package that enforces multi-forge safety (rejecting requests whose `forge_id` does not match the local Forge) and always writes an audit event to the `events` table. As a side effect, `bead_stopped` events are now logged synchronously when Stop is invoked rather than only on successful `bd update` release. (Forge-nh12)

## Original Issue (task): Extract shared queue action logic into internal/queueactions package

Create a new package internal/queueactions (or similar) and move the core business logic of `forge queue clarify|unclarify|retry|clear|stop` out of the CLI verb implementations into shared functions. Each function should accept a context, a queue/worker handle, and parameters like (beadID, forgeID, anvilName, note) and return an error. Enforce multi-forge safety inside these shared functions: reject if the provided forge_id does not match the forge that owns the worker/bead, returning a clear typed error. Each function must also write an event row to the events table (audit trail) including the user's note. Refactor the existing CLI verb implementations to call these shared functions so behavior is preserved. This is the foundation that the IPC handlers in the sibling task will call into.

---
Bead: Forge-nh12 | Branch: forge/Forge-nh12
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->