### PR TITLE
Add IPC handlers in daemon.go for queue resolution actions (Forge-6qh6)

### DIFF
--- a/changelog.d/Forge-6qh6.md
+++ b/changelog.d/Forge-6qh6.md
@@ -1,0 +1,2 @@
+category: Added
+- **Queue resolution IPC verbs with multi-forge safety** - New daemon IPC handlers `queue_clarify`, `queue_unclarify`, `queue_retry`, `queue_clear`, and `queue_stop` wrap the shared `internal/queueactions` primitives and accept an optional `forge_id` field that, when supplied, must match the local Forge instance — preventing one Forge from accidentally clobbering another's queue state when several share a database. (Forge-6qh6)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5064,6 +5064,11 @@ func (d *Daemon) handleQueueClarify(cmd ipc.Command) ipc.Response {
 		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_clarify payload"})
 		return ipc.Response{Type: "error", Payload: msg}
 	}
+	if qp.AnvilName != "" {
+		if canonical, _, ok := d.resolveAnvilConfig(qp.AnvilName); ok {
+			qp.AnvilName = canonical
+		}
+	}
 	if err := queueactions.Clarify(context.Background(), d.queueActionsHandle(), queueactions.Params{
 		BeadID:    qp.BeadID,
 		ForgeID:   qp.ForgeID,
@@ -5087,6 +5092,11 @@ func (d *Daemon) handleQueueUnclarify(cmd ipc.Command) ipc.Response {
 	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
 		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_unclarify payload"})
 		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if qp.AnvilName != "" {
+		if canonical, _, ok := d.resolveAnvilConfig(qp.AnvilName); ok {
+			qp.AnvilName = canonical
+		}
 	}
 	if err := queueactions.Unclarify(context.Background(), d.queueActionsHandle(), queueactions.Params{
 		BeadID:    qp.BeadID,
@@ -5112,6 +5122,11 @@ func (d *Daemon) handleQueueRetry(cmd ipc.Command) ipc.Response {
 	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
 		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_retry payload"})
 		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if qp.AnvilName != "" {
+		if canonical, _, ok := d.resolveAnvilConfig(qp.AnvilName); ok {
+			qp.AnvilName = canonical
+		}
 	}
 	hadCircuitBreaker, err := queueactions.Retry(context.Background(), d.queueActionsHandle(), queueactions.Params{
 		BeadID:    qp.BeadID,
@@ -5141,6 +5156,11 @@ func (d *Daemon) handleQueueClear(cmd ipc.Command) ipc.Response {
 		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_clear payload"})
 		return ipc.Response{Type: "error", Payload: msg}
 	}
+	if qp.AnvilName != "" {
+		if canonical, _, ok := d.resolveAnvilConfig(qp.AnvilName); ok {
+			qp.AnvilName = canonical
+		}
+	}
 	if err := queueactions.Clear(context.Background(), d.queueActionsHandle(), queueactions.Params{
 		BeadID:    qp.BeadID,
 		ForgeID:   qp.ForgeID,
@@ -5166,6 +5186,11 @@ func (d *Daemon) handleQueueStop(cmd ipc.Command) ipc.Response {
 	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
 		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_stop payload"})
 		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if qp.AnvilName != "" {
+		if canonical, _, ok := d.resolveAnvilConfig(qp.AnvilName); ok {
+			qp.AnvilName = canonical
+		}
 	}
 	terminatedWorkerID, err := queueactions.Stop(context.Background(), d.queueActionsHandle(), queueactions.Params{
 		BeadID:    qp.BeadID,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5038,10 +5038,152 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		}
 		return ipc.Response{Type: "ok", Payload: data}
 
+	case "queue_clarify":
+		return d.handleQueueClarify(cmd)
+	case "queue_unclarify":
+		return d.handleQueueUnclarify(cmd)
+	case "queue_retry":
+		return d.handleQueueRetry(cmd)
+	case "queue_clear":
+		return d.handleQueueClear(cmd)
+	case "queue_stop":
+		return d.handleQueueStop(cmd)
+
 	default:
 		msg, _ := json.Marshal(map[string]string{"message": "unknown command: " + cmd.Type})
 		return ipc.Response{Type: "error", Payload: msg}
 	}
+}
+
+// handleQueueClarify implements the "queue_clarify" IPC verb: marks a bead
+// as needing human clarification. Required: bead_id, anvil_name, note.
+// Optional: forge_id (multi-forge safety; rejected if mismatched).
+func (d *Daemon) handleQueueClarify(cmd ipc.Command) ipc.Response {
+	var qp ipc.QueueActionPayload
+	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_clarify payload"})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if err := queueactions.Clarify(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		BeadID:    qp.BeadID,
+		ForgeID:   qp.ForgeID,
+		AnvilName: qp.AnvilName,
+		Note:      qp.Note,
+	}); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("set clarification", err)})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	d.logger.Info("bead marked as clarification_needed via queue_clarify",
+		"bead", qp.BeadID, "anvil", qp.AnvilName, "reason", strings.TrimSpace(qp.Note))
+	data, _ := json.Marshal(map[string]string{"message": "clarification_needed set"})
+	return ipc.Response{Type: "ok", Payload: data}
+}
+
+// handleQueueUnclarify implements the "queue_unclarify" IPC verb: clears the
+// clarification_needed flag so a bead can be dispatched again. Required:
+// bead_id, anvil_name. Note is optional and appears in the audit event.
+func (d *Daemon) handleQueueUnclarify(cmd ipc.Command) ipc.Response {
+	var qp ipc.QueueActionPayload
+	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_unclarify payload"})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if err := queueactions.Unclarify(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		BeadID:    qp.BeadID,
+		ForgeID:   qp.ForgeID,
+		AnvilName: qp.AnvilName,
+		Note:      qp.Note,
+	}); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("clear clarification", err)})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	d.logger.Info("clarification_needed cleared via queue_unclarify",
+		"bead", qp.BeadID, "anvil", qp.AnvilName)
+	data, _ := json.Marshal(map[string]string{"message": "clarification_needed cleared"})
+	return ipc.Response{Type: "ok", Payload: data}
+}
+
+// handleQueueRetry implements the "queue_retry" IPC verb: resets the dispatch
+// circuit breaker so the bead re-enters the queue. This is the thin primitive
+// — it does not shell out to bd or kick the poller; callers that need those
+// orchestration steps continue to use retry_bead.
+func (d *Daemon) handleQueueRetry(cmd ipc.Command) ipc.Response {
+	var qp ipc.QueueActionPayload
+	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_retry payload"})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	hadCircuitBreaker, err := queueactions.Retry(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		BeadID:    qp.BeadID,
+		ForgeID:   qp.ForgeID,
+		AnvilName: qp.AnvilName,
+		Note:      qp.Note,
+	})
+	if err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("retry bead", err)})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	d.logger.Info("retry reset for bead via queue_retry",
+		"bead", qp.BeadID, "anvil", qp.AnvilName, "circuit_breaker_cleared", hadCircuitBreaker)
+	respMsg := "retry reset"
+	if hadCircuitBreaker {
+		respMsg = "retry state reset"
+	}
+	data, _ := json.Marshal(map[string]string{"message": respMsg})
+	return ipc.Response{Type: "ok", Payload: data}
+}
+
+// handleQueueClear implements the "queue_clear" IPC verb: drops needs-attention
+// flags from a bead's retry row without re-dispatching it. Idempotent.
+func (d *Daemon) handleQueueClear(cmd ipc.Command) ipc.Response {
+	var qp ipc.QueueActionPayload
+	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_clear payload"})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if err := queueactions.Clear(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		BeadID:    qp.BeadID,
+		ForgeID:   qp.ForgeID,
+		AnvilName: qp.AnvilName,
+		Note:      qp.Note,
+	}); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("clear needs-attention flags", err)})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	d.logger.Info("needs-attention flags cleared via queue_clear",
+		"bead", qp.BeadID, "anvil", qp.AnvilName)
+	data, _ := json.Marshal(map[string]string{"message": "needs-attention flags cleared"})
+	return ipc.Response{Type: "ok", Payload: data}
+}
+
+// handleQueueStop implements the "queue_stop" IPC verb: terminates any running
+// worker for the bead and marks it clarification_needed so neither auto nor
+// manual dispatch picks it up. Unlike stop_bead this primitive does not shell
+// out to bd update — callers needing to release the bd assignee continue to
+// use stop_bead.
+func (d *Daemon) handleQueueStop(cmd ipc.Command) ipc.Response {
+	var qp ipc.QueueActionPayload
+	if err := json.Unmarshal(cmd.Payload, &qp); err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": "invalid queue_stop payload"})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	terminatedWorkerID, err := queueactions.Stop(context.Background(), d.queueActionsHandle(), queueactions.Params{
+		BeadID:    qp.BeadID,
+		ForgeID:   qp.ForgeID,
+		AnvilName: qp.AnvilName,
+		Note:      qp.Note,
+	})
+	if err != nil {
+		msg, _ := json.Marshal(map[string]string{"message": queueActionsErrorMessage("stop bead", err)})
+		return ipc.Response{Type: "error", Payload: msg}
+	}
+	if terminatedWorkerID != "" {
+		d.logger.Info("killed worker for stopped bead via queue_stop",
+			"worker", terminatedWorkerID, "bead", qp.BeadID, "anvil", qp.AnvilName)
+	}
+	d.activeBeads.Delete(qp.BeadID)
+	data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("bead %s stopped", qp.BeadID)})
+	return ipc.Response{Type: "ok", Payload: data}
 }
 
 // BroadcastEvent sends an event to all connected IPC clients.

--- a/internal/daemon/daemon_queue_actions_test.go
+++ b/internal/daemon/daemon_queue_actions_test.go
@@ -1,0 +1,370 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/ipc"
+	"github.com/Robin831/Forge/internal/queueactions"
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newQueueActionDaemon builds a minimal Daemon backed by a fresh sqlite
+// state.db. forgeID, when non-empty, is wired through SettingsConfig.ForgeID
+// so queueActionsHandle().LocalForgeID() returns the same value the test
+// passes on the IPC payload.
+func newQueueActionDaemon(t *testing.T, forgeID string) (*Daemon, *state.DB) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "forge-queue-action-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	db, err := state.Open(filepath.Join(tmpDir, "state.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	d := &Daemon{
+		db:     db,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	d.cfg.Store(&config.Config{
+		Settings: config.SettingsConfig{ForgeID: forgeID},
+	})
+	return d, db
+}
+
+// expectEvent asserts that an event of the given type was logged for
+// (beadID, anvil) and that its message contains the supplied note substring.
+func expectEvent(t *testing.T, db *state.DB, wantType state.EventType, beadID, anvil, noteSubstr string) {
+	t.Helper()
+	events, err := db.RecentEvents(50)
+	require.NoError(t, err)
+	for _, e := range events {
+		if e.Type != wantType || e.BeadID != beadID || e.Anvil != anvil {
+			continue
+		}
+		if noteSubstr != "" && !strings.Contains(e.Message, noteSubstr) {
+			t.Fatalf("event found but message %q does not contain note %q", e.Message, noteSubstr)
+		}
+		return
+	}
+	t.Fatalf("did not find %s event for bead=%s anvil=%s", wantType, beadID, anvil)
+}
+
+// unmarshalErrorMessage extracts the "message" field from an error response.
+func unmarshalErrorMessage(t *testing.T, resp ipc.Response) string {
+	t.Helper()
+	require.Equal(t, "error", resp.Type)
+	var msg map[string]string
+	require.NoError(t, json.Unmarshal(resp.Payload, &msg))
+	return msg["message"]
+}
+
+// ---------- queue_clarify ----------
+
+func TestHandleIPC_QueueClarify(t *testing.T) {
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		d, _ := newQueueActionDaemon(t, "forge-a")
+		resp := d.handleIPC(ipc.Command{Type: "queue_clarify", Payload: []byte("not-json")})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), "invalid queue_clarify payload")
+	})
+
+	t.Run("missing bead_id is rejected", func(t *testing.T) {
+		d, _ := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{AnvilName: "anvil-1", Note: "x"})
+		resp := d.handleIPC(ipc.Command{Type: "queue_clarify", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), "bead_id and anvil are required")
+	})
+
+	t.Run("missing note is rejected", func(t *testing.T) {
+		d, _ := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{BeadID: "BD-1", AnvilName: "anvil-1"})
+		resp := d.handleIPC(ipc.Command{Type: "queue_clarify", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), "reason is required")
+	})
+
+	t.Run("happy path writes clarification, event, and note", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-CLARIFY",
+			AnvilName: "anvil-1",
+			Note:      "which auth lib?",
+			ForgeID:   "forge-a",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_clarify", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+
+		r, err := db.GetRetry("BD-CLARIFY", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.True(t, r.ClarificationNeeded, "clarification_needed flag should be set")
+		// SetClarificationNeeded stores the reason in last_error.
+		assert.Equal(t, "which auth lib?", r.LastError)
+
+		expectEvent(t, db, state.EventClarificationNeeded, "BD-CLARIFY", "anvil-1", "which auth lib?")
+	})
+
+	t.Run("forge_id mismatch is rejected with no state mutation", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-MISMATCH",
+			AnvilName: "anvil-1",
+			Note:      "any",
+			ForgeID:   "forge-b",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_clarify", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), queueactions.ErrForgeMismatch.Error())
+
+		r, _ := db.GetRetry("BD-MISMATCH", "anvil-1")
+		assert.Nil(t, r, "no retry row should be created on forge mismatch")
+		events, _ := db.RecentEvents(50)
+		for _, e := range events {
+			if e.BeadID == "BD-MISMATCH" {
+				t.Fatalf("no event should be logged on forge mismatch; got %+v", e)
+			}
+		}
+	})
+}
+
+// ---------- queue_unclarify ----------
+
+func TestHandleIPC_QueueUnclarify(t *testing.T) {
+	t.Run("happy path clears flag and logs event with note", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		// Seed an existing clarification row to verify it is cleared.
+		require.NoError(t, db.SetClarificationNeeded("BD-UNCLR", "anvil-1", true, "old reason"))
+
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-UNCLR",
+			AnvilName: "anvil-1",
+			Note:      "resolved offline",
+			ForgeID:   "forge-a",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_unclarify", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+
+		r, err := db.GetRetry("BD-UNCLR", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.False(t, r.ClarificationNeeded)
+
+		expectEvent(t, db, state.EventClarificationCleared, "BD-UNCLR", "anvil-1", "resolved offline")
+	})
+
+	t.Run("note is optional", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{BeadID: "BD-UNCLR-2", AnvilName: "anvil-1"})
+		resp := d.handleIPC(ipc.Command{Type: "queue_unclarify", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+		expectEvent(t, db, state.EventClarificationCleared, "BD-UNCLR-2", "anvil-1", "")
+	})
+
+	t.Run("forge_id mismatch is rejected", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-UNCLR-3",
+			AnvilName: "anvil-1",
+			ForgeID:   "forge-b",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_unclarify", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), queueactions.ErrForgeMismatch.Error())
+
+		// No retry row should be touched.
+		r, _ := db.GetRetry("BD-UNCLR-3", "anvil-1")
+		assert.Nil(t, r)
+	})
+}
+
+// ---------- queue_retry ----------
+
+func TestHandleIPC_QueueRetry(t *testing.T) {
+	t.Run("happy path with circuit breaker resets and logs event with note", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		_, broke, err := db.IncrementDispatchFailures("BD-RETRY", "anvil-1", 1, "boom")
+		require.NoError(t, err)
+		require.True(t, broke, "expected circuit breaker to trip")
+
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-RETRY",
+			AnvilName: "anvil-1",
+			Note:      "manual retry",
+			ForgeID:   "forge-a",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_retry", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+		var data map[string]string
+		require.NoError(t, json.Unmarshal(resp.Payload, &data))
+		assert.Equal(t, "retry state reset", data["message"], "circuit-breaker path should report state-reset wording")
+
+		r, err := db.GetRetry("BD-RETRY", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.Equal(t, 0, r.DispatchFailures)
+		assert.False(t, r.NeedsHuman)
+
+		expectEvent(t, db, state.EventRetryReset, "BD-RETRY", "anvil-1", "manual retry")
+	})
+
+	t.Run("happy path without circuit breaker reports plain retry reset", func(t *testing.T) {
+		d, _ := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-RETRY-2",
+			AnvilName: "anvil-1",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_retry", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+		var data map[string]string
+		require.NoError(t, json.Unmarshal(resp.Payload, &data))
+		assert.Equal(t, "retry reset", data["message"])
+	})
+
+	t.Run("forge_id mismatch is rejected with no reset", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		_, _, err := db.IncrementDispatchFailures("BD-RETRY-MM", "anvil-1", 1, "boom")
+		require.NoError(t, err)
+
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-RETRY-MM",
+			AnvilName: "anvil-1",
+			ForgeID:   "forge-b",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_retry", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), queueactions.ErrForgeMismatch.Error())
+
+		r, err := db.GetRetry("BD-RETRY-MM", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.Greater(t, r.DispatchFailures, 0, "dispatch failures should not be cleared on mismatch")
+	})
+}
+
+// ---------- queue_clear ----------
+
+func TestHandleIPC_QueueClear(t *testing.T) {
+	t.Run("happy path clears flags and logs event with note", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		require.NoError(t, db.UpsertRetry(&state.RetryRecord{
+			BeadID:           "BD-CLEAR",
+			Anvil:            "anvil-1",
+			NeedsHuman:       true,
+			DispatchFailures: 3,
+			RecoveryFailures: 1,
+			RetryCount:       5,
+			LastError:        "boom",
+		}))
+
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-CLEAR",
+			AnvilName: "anvil-1",
+			Note:      "pr merged",
+			ForgeID:   "forge-a",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_clear", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+
+		r, err := db.GetRetry("BD-CLEAR", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.False(t, r.NeedsHuman)
+		assert.Equal(t, 0, r.DispatchFailures)
+		assert.Equal(t, 0, r.RecoveryFailures)
+		assert.Empty(t, r.LastError)
+
+		expectEvent(t, db, state.EventRetryCleared, "BD-CLEAR", "anvil-1", "pr merged")
+	})
+
+	t.Run("forge_id mismatch is rejected", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		require.NoError(t, db.UpsertRetry(&state.RetryRecord{
+			BeadID:           "BD-CLEAR-MM",
+			Anvil:            "anvil-1",
+			NeedsHuman:       true,
+			DispatchFailures: 2,
+		}))
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-CLEAR-MM",
+			AnvilName: "anvil-1",
+			ForgeID:   "forge-b",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_clear", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), queueactions.ErrForgeMismatch.Error())
+
+		r, err := db.GetRetry("BD-CLEAR-MM", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.True(t, r.NeedsHuman, "needs_human flag should remain on forge mismatch")
+		assert.Equal(t, 2, r.DispatchFailures)
+	})
+}
+
+// ---------- queue_stop ----------
+
+func TestHandleIPC_QueueStop(t *testing.T) {
+	t.Run("happy path sets clarification, frees activeBeads slot, logs event with note", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		d.activeBeads.Store("BD-STOP", struct{}{})
+
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-STOP",
+			AnvilName: "anvil-1",
+			Note:      "wrong approach",
+			ForgeID:   "forge-a",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_stop", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+
+		r, err := db.GetRetry("BD-STOP", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.True(t, r.ClarificationNeeded)
+		// SetClarificationNeeded stores the reason in last_error.
+		assert.Equal(t, "wrong approach", r.LastError)
+
+		_, stillActive := d.activeBeads.Load("BD-STOP")
+		assert.False(t, stillActive, "activeBeads slot should be freed")
+
+		expectEvent(t, db, state.EventBeadStopped, "BD-STOP", "anvil-1", "wrong approach")
+	})
+
+	t.Run("missing note falls back to default reason", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-STOP-2",
+			AnvilName: "anvil-1",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_stop", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+		r, err := db.GetRetry("BD-STOP-2", "anvil-1")
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		assert.Equal(t, "manually stopped", r.LastError)
+	})
+
+	t.Run("forge_id mismatch is rejected with no state mutation", func(t *testing.T) {
+		d, db := newQueueActionDaemon(t, "forge-a")
+		d.activeBeads.Store("BD-STOP-MM", struct{}{})
+
+		payload, _ := json.Marshal(ipc.QueueActionPayload{
+			BeadID:    "BD-STOP-MM",
+			AnvilName: "anvil-1",
+			Note:      "x",
+			ForgeID:   "forge-b",
+		})
+		resp := d.handleIPC(ipc.Command{Type: "queue_stop", Payload: payload})
+		assert.Contains(t, unmarshalErrorMessage(t, resp), queueactions.ErrForgeMismatch.Error())
+
+		r, _ := db.GetRetry("BD-STOP-MM", "anvil-1")
+		assert.Nil(t, r, "no retry row should be created on forge mismatch")
+
+		_, stillActive := d.activeBeads.Load("BD-STOP-MM")
+		assert.True(t, stillActive, "activeBeads slot must not be freed on mismatch")
+	})
+}

--- a/internal/daemon/daemon_queue_actions_test.go
+++ b/internal/daemon/daemon_queue_actions_test.go
@@ -161,6 +161,10 @@ func TestHandleIPC_QueueUnclarify(t *testing.T) {
 
 	t.Run("note is optional", func(t *testing.T) {
 		d, db := newQueueActionDaemon(t, "forge-a")
+		// SetClarificationNeeded(false) requires an existing retry row;
+		// seed one so the test isolates the "note is optional" behaviour.
+		require.NoError(t, db.SetClarificationNeeded("BD-UNCLR-2", "anvil-1", true, "old reason"))
+
 		payload, _ := json.Marshal(ipc.QueueActionPayload{BeadID: "BD-UNCLR-2", AnvilName: "anvil-1"})
 		resp := d.handleIPC(ipc.Command{Type: "queue_unclarify", Payload: payload})
 		assert.Equal(t, "ok", resp.Type)

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -227,6 +227,21 @@ type StopBeadPayload struct {
 	Reason string `json:"reason"` // Optional; defaults to "manually stopped"
 }
 
+// QueueActionPayload is the payload for the queue resolution verbs:
+// "queue_clarify", "queue_unclarify", "queue_retry", "queue_clear", and
+// "queue_stop". These are thin IPC wrappers around the shared queueactions
+// package functions and accept a forge_id for multi-forge safety: when
+// supplied the daemon rejects the request unless its local forge_id matches.
+//
+// AnvilName uses the legacy "anvil" JSON tag so existing callers can reuse
+// the same field name they pass to set_clarification / stop_bead.
+type QueueActionPayload struct {
+	BeadID    string `json:"bead_id"`
+	ForgeID   string `json:"forge_id,omitempty"`
+	AnvilName string `json:"anvil_name,omitempty"`
+	Note      string `json:"note,omitempty"`
+}
+
 // ResolveOrphanPayload is the payload for a "resolve_orphan" command.
 // Sent by Hearth to the daemon when the user picks an action for an orphaned bead.
 // Action is one of "recover", "close", or "discard".


### PR DESCRIPTION
## Changes

- **Queue resolution IPC verbs with multi-forge safety** - New daemon IPC handlers `queue_clarify`, `queue_unclarify`, `queue_retry`, `queue_clear`, and `queue_stop` wrap the shared `internal/queueactions` primitives and accept an optional `forge_id` field that, when supplied, must match the local Forge instance — preventing one Forge from accidentally clobbering another's queue state when several share a database. (Forge-6qh6)

## Original Issue (task): Add IPC handlers in daemon.go for queue resolution actions

In internal/daemon/daemon.go, add five new IPC action handlers following the assign_bellows template at daemon.go:4656: queue_clear, queue_retry, queue_clarify, queue_unclarify, queue_stop. Each handler parses {bead_id, forge_id, anvil_name?, note?} from the IPC request, validates required fields, and delegates to the corresponding shared function from the internal/queueactions package created in the sibling task. Propagate the multi-forge safety error from the shared layer back as a clear IPC error response. Register each handler in the IPC dispatch table alongside assign_bellows. Add unit/integration tests covering: happy path per verb, forge_id mismatch rejection, and confirming an event row is written with the supplied note.

---
Bead: Forge-6qh6 | Branch: forge/Forge-6qh6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->