### PR TITLE
Add /api/forge/resolve HTTP endpoint bridging UI to IPC (Forge-k2ls)

### DIFF
--- a/changelog.d/Forge-k2ls.md
+++ b/changelog.d/Forge-k2ls.md
@@ -1,0 +1,2 @@
+category: Added
+- **Resolve-needs-attention HTTP endpoints** - Wire the Hearth 2.0 escalation page to the daemon via `POST /api/forge/resolve` (dispatching one of clear/retry/clarify/unclarify/stop to the queue IPC handlers) and `GET /api/forge/escalation/{bead_id}` (full untruncated escalation message plus git context — parent base, origin branch commits, local worktree commits, diff range — shelled from the worker's worktree). (Forge-k2ls)

--- a/internal/web/forge_resolve.go
+++ b/internal/web/forge_resolve.go
@@ -1,9 +1,11 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/Robin831/Forge/internal/executil"
 	"github.com/Robin831/Forge/internal/ipc"
+	"github.com/Robin831/Forge/internal/worktree"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -159,17 +162,30 @@ type escalationGit struct {
 // branches.
 const maxEscalationCommits = 50
 
-// gitRunner runs a git subprocess in the given directory and returns
-// stdout. The variable is package-level so tests can swap it without
-// spawning real git processes. The signature mirrors bdShowJSON: dir is
-// the worktree path; args are the git arguments after the program name.
-var gitRunner = func(ctx context.Context, dir string, args ...string) ([]byte, error) {
+// gitEnvGetter returns the git environment for confining git to a worktree.
+// Package-level so tests can replace it without requiring a real git worktree.
+var gitEnvGetter = worktree.GitEnv
+
+// gitRunner runs a git subprocess in the given directory and returns stdout.
+// env, when non-nil, replaces the process environment (use worktree.GitEnv to
+// confine git to a specific worktree). The variable is package-level so tests
+// can swap it without spawning real git processes.
+var gitRunner = func(ctx context.Context, dir string, env []string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
+	if len(env) > 0 {
+		cmd.Env = env
+	}
 	executil.HideWindow(cmd)
-	return cmd.Output()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil && stderr.Len() > 0 {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return out, err
 }
 
 // handleForgeEscalation handles GET /api/forge/escalation/{bead_id}. It
@@ -196,14 +212,18 @@ func (s *Server) handleForgeEscalation(w http.ResponseWriter, r *http.Request) {
 	// and the caller must retry with ?anvil=.
 	if resp.Anvil == "" {
 		resp.Anvil = newAnvilLookup(s.db)(beadID)
+		if resp.Anvil == "" {
+			resp.Errors = append(resp.Errors, "anvil: ambiguous or not found; supply ?anvil= to narrow the lookup")
+		}
 	}
 
 	// Retry row drives both the escalation message and the retry detail
 	// block. A missing row is fine — escalations exist for orphaned beads
-	// (no worker) too — but without it we cannot produce a useful message
-	// either, so add it to the errors list.
+	// (no worker) too.
 	if resp.Anvil != "" {
-		if rec, err := s.db.GetRetry(beadID, resp.Anvil); err == nil && rec != nil {
+		if rec, err := s.db.GetRetry(beadID, resp.Anvil); err != nil {
+			resp.Errors = append(resp.Errors, "retry: "+err.Error())
+		} else if rec != nil {
 			resp.EscalationMessage = rec.LastError
 			detail := &retryDetail{
 				NeedsHuman:          rec.NeedsHuman,
@@ -228,44 +248,37 @@ func (s *Server) handleForgeEscalation(w http.ResponseWriter, r *http.Request) {
 	}
 	anvilPath := s.resolveAnvilPath(resp.Anvil)
 	if anvilPath != "" {
-		resp.WorktreePath = filepath.Join(anvilPath, ".workers", sanitizeBeadIDForPath(beadID))
+		resp.WorktreePath = filepath.Join(anvilPath, ".workers", worktree.SanitizePath(beadID))
 		if info, err := os.Stat(resp.WorktreePath); err == nil && info.IsDir() {
 			resp.WorktreeExists = true
 		}
 	}
 
-	// Gather git context when we have a worktree to read from. Each shell
-	// invocation is bounded and tolerates failures: missing refs or a
-	// non-git worktree append to resp.Errors rather than 5xx the request.
+	// Gather git context when we have a worktree to read from. GitEnv
+	// pins git to the worktree so it cannot walk up into the anvil repo;
+	// a nil return means the directory is not a valid worktree and we skip
+	// the git calls entirely rather than risk cross-branch results.
 	if resp.WorktreeExists && resp.Branch != "" {
-		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
-		defer cancel()
-		resp.Context = gatherEscalationContext(ctx, resp.WorktreePath, resp.Branch, &resp.Errors)
+		gitEnv := gitEnvGetter(resp.WorktreePath)
+		if gitEnv == nil {
+			resp.Errors = append(resp.Errors, "worktree: directory exists but is not a valid git worktree")
+		} else {
+			ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+			defer cancel()
+			resp.Context = gatherEscalationContext(ctx, resp.WorktreePath, resp.Branch, gitEnv, &resp.Errors)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// sanitizeBeadIDForPath mirrors worktree.sanitizePath. The worktree
-// package keeps that function unexported; rather than widen its API for
-// one consumer, we duplicate the four-rune transformation here.
-func sanitizeBeadIDForPath(beadID string) string {
-	r := strings.NewReplacer(
-		"/", "-",
-		"\\", "-",
-		" ", "-",
-		":", "-",
-	)
-	return r.Replace(beadID)
-}
-
 // gatherEscalationContext shells to git in the worker's worktree to
 // produce the parent base, the origin-side and local-side commit lists,
-// and a diff summary. Each step is independent: a failure in one (e.g.
-// the origin branch was deleted) does not prevent the others from
-// running. Errors land in *outErrs as opaque strings the SPA can render
-// in a diagnostics block.
-func gatherEscalationContext(ctx context.Context, worktreePath, branch string, outErrs *[]string) *escalationGit {
+// and a diff summary. env must be a non-nil slice from worktree.GitEnv
+// so that git is confined to the worktree and cannot walk up into the
+// parent anvil repo. Each step is independent: a failure in one does
+// not prevent the others from running; errors land in *outErrs.
+func gatherEscalationContext(ctx context.Context, worktreePath, branch string, env []string, outErrs *[]string) *escalationGit {
 	ctxOut := &escalationGit{}
 
 	addErr := func(stage string, err error) {
@@ -276,9 +289,9 @@ func gatherEscalationContext(ctx context.Context, worktreePath, branch string, o
 	}
 
 	// Parent base: origin/main, falling back to origin/master.
-	if out, err := gitRunner(ctx, worktreePath, "rev-parse", "--verify", "--quiet", "origin/main"); err == nil && len(out) > 0 {
+	if out, err := gitRunner(ctx, worktreePath, env, "rev-parse", "--verify", "--quiet", "origin/main"); err == nil && len(out) > 0 {
 		ctxOut.ParentBase = "origin/main"
-	} else if out, err := gitRunner(ctx, worktreePath, "rev-parse", "--verify", "--quiet", "origin/master"); err == nil && len(out) > 0 {
+	} else if out, err := gitRunner(ctx, worktreePath, env, "rev-parse", "--verify", "--quiet", "origin/master"); err == nil && len(out) > 0 {
 		ctxOut.ParentBase = "origin/master"
 	} else {
 		addErr("parent_base", errors.New("neither origin/main nor origin/master found"))
@@ -287,7 +300,7 @@ func gatherEscalationContext(ctx context.Context, worktreePath, branch string, o
 	// Local commits on the worker branch versus the parent base.
 	if ctxOut.ParentBase != "" {
 		ctxOut.DiffRange = ctxOut.ParentBase + "..HEAD"
-		if out, err := gitRunner(ctx, worktreePath, "log",
+		if out, err := gitRunner(ctx, worktreePath, env, "log",
 			"--pretty=format:%h %s",
 			"-n", strconv.Itoa(maxEscalationCommits),
 			ctxOut.DiffRange,
@@ -299,7 +312,7 @@ func gatherEscalationContext(ctx context.Context, worktreePath, branch string, o
 
 		// Diff stat against the parent base — short summary so the
 		// response stays bounded even for large diffs.
-		if out, err := gitRunner(ctx, worktreePath, "diff", "--shortstat", ctxOut.DiffRange); err == nil {
+		if out, err := gitRunner(ctx, worktreePath, env, "diff", "--shortstat", ctxOut.DiffRange); err == nil {
 			ctxOut.DiffStat = strings.TrimSpace(string(out))
 		} else {
 			addErr("diff_stat", err)
@@ -312,9 +325,9 @@ func gatherEscalationContext(ctx context.Context, worktreePath, branch string, o
 	// worktree). When the branch has not been pushed yet, origin lookup
 	// fails cleanly and OriginBranchExists stays false.
 	ctxOut.OriginBranchRef = "origin/" + branch
-	if out, err := gitRunner(ctx, worktreePath, "rev-parse", "--verify", "--quiet", ctxOut.OriginBranchRef); err == nil && len(out) > 0 {
+	if out, err := gitRunner(ctx, worktreePath, env, "rev-parse", "--verify", "--quiet", ctxOut.OriginBranchRef); err == nil && len(out) > 0 {
 		ctxOut.OriginBranchExists = true
-		if logOut, logErr := gitRunner(ctx, worktreePath, "log",
+		if logOut, logErr := gitRunner(ctx, worktreePath, env, "log",
 			"--pretty=format:%h %s",
 			"-n", strconv.Itoa(maxEscalationCommits),
 			ctxOut.OriginBranchRef,

--- a/internal/web/forge_resolve.go
+++ b/internal/web/forge_resolve.go
@@ -1,0 +1,345 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/executil"
+	"github.com/Robin831/Forge/internal/ipc"
+	"github.com/go-chi/chi/v5"
+)
+
+// resolveAction enumerates the queue-resolution verbs accepted by
+// POST /api/forge/resolve. Each value maps to one of the daemon's
+// queue_* IPC handlers added in sub-task Forge-6qh6.
+const (
+	resolveActionClear     = "clear"
+	resolveActionRetry     = "retry"
+	resolveActionClarify   = "clarify"
+	resolveActionUnclarify = "unclarify"
+	resolveActionStop      = "stop"
+)
+
+// resolveActionToIPC maps the web-facing action verb to the daemon IPC
+// command type. Keeping the table tiny and explicit (rather than computing
+// the IPC type at the call site) makes it obvious which verbs the endpoint
+// accepts and prevents an unrecognised action from sneaking through to the
+// daemon as an "unknown command" error.
+var resolveActionToIPC = map[string]string{
+	resolveActionClear:     "queue_clear",
+	resolveActionRetry:     "queue_retry",
+	resolveActionClarify:   "queue_clarify",
+	resolveActionUnclarify: "queue_unclarify",
+	resolveActionStop:      "queue_stop",
+}
+
+// resolveRequest is the JSON body for POST /api/forge/resolve. anvil_name is
+// optional in the JSON but required by the daemon; the handler enforces
+// that locally so the response is a clean 400 rather than the daemon's
+// "bead_id and anvil are required" 500. forge_id is purely passthrough —
+// the daemon's multi-forge safety check uses it to refuse cross-forge
+// actions; an empty value preserves historical single-forge behaviour.
+type resolveRequest struct {
+	BeadID    string `json:"bead_id"`
+	Action    string `json:"action"`
+	AnvilName string `json:"anvil_name,omitempty"`
+	Note      string `json:"note,omitempty"`
+	ForgeID   string `json:"forge_id,omitempty"`
+}
+
+// handleForgeResolve dispatches POST /api/forge/resolve to one of the
+// daemon's queue_* IPC verbs. The endpoint is a single entry point for the
+// Hearth 2.0 resolve-needs-attention page so the SPA can render a unified
+// action picker rather than five distinct buttons hitting five URLs.
+func (s *Server) handleForgeResolve(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 32*1024))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+	var req resolveRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+	}
+	req.BeadID = strings.TrimSpace(req.BeadID)
+	req.Action = strings.TrimSpace(req.Action)
+	req.AnvilName = strings.TrimSpace(req.AnvilName)
+	req.Note = strings.TrimSpace(req.Note)
+	req.ForgeID = strings.TrimSpace(req.ForgeID)
+
+	if !isValidBeadID(req.BeadID) {
+		writeError(w, http.StatusBadRequest, "invalid bead_id")
+		return
+	}
+	cmdType, ok := resolveActionToIPC[req.Action]
+	if !ok {
+		writeError(w, http.StatusBadRequest, "action must be one of clear|retry|clarify|unclarify|stop")
+		return
+	}
+	if req.AnvilName == "" {
+		writeError(w, http.StatusBadRequest, "anvil_name is required")
+		return
+	}
+	// Clarify requires a note (the clarification reason). Catching it here
+	// returns a 400 instead of the daemon's 500 "reason is required" path.
+	if req.Action == resolveActionClarify && req.Note == "" {
+		writeError(w, http.StatusBadRequest, "note is required for clarify")
+		return
+	}
+
+	s.logActor(r, "forge_resolve", "bead", req.BeadID, "anvil", req.AnvilName, "action", req.Action)
+	s.dispatchAction(w, cmdType, ipc.QueueActionPayload{
+		BeadID:    req.BeadID,
+		ForgeID:   req.ForgeID,
+		AnvilName: req.AnvilName,
+		Note:      req.Note,
+	})
+}
+
+// escalationResponse is the JSON shape returned by
+// GET /api/forge/escalation/{bead_id}. The page renders the full
+// untruncated escalation message alongside the git context the operator
+// needs to triage the worker's state — origin branch tip, local worker
+// commits, and the diff against the parent base. Fields are best-effort:
+// missing worktree directories or unresolvable refs produce empty values
+// and an entry in Errors rather than a 5xx, so the SPA can still render
+// the message itself.
+type escalationResponse struct {
+	BeadID            string           `json:"bead_id"`
+	Anvil             string           `json:"anvil"`
+	Branch            string           `json:"branch,omitempty"`
+	WorktreePath      string           `json:"worktree_path,omitempty"`
+	WorktreeExists    bool             `json:"worktree_exists"`
+	EscalationMessage string           `json:"escalation_message"`
+	Retry             *retryDetail     `json:"retry,omitempty"`
+	Context           *escalationGit   `json:"context,omitempty"`
+	Errors            []string         `json:"errors,omitempty"`
+}
+
+// retryDetail is a slim projection of the retry row used by the escalation
+// page. We expose only the fields the SPA renders so the JSON contract
+// does not couple to internal columns that may change.
+type retryDetail struct {
+	NeedsHuman          bool   `json:"needs_human"`
+	ClarificationNeeded bool   `json:"clarification_needed"`
+	DispatchFailures    int    `json:"dispatch_failures"`
+	RecoveryFailures    int    `json:"recovery_failures"`
+	UpdatedAt           string `json:"updated_at,omitempty"`
+}
+
+// escalationGit bundles the git context shelled out from the worker's
+// worktree. Commits lists are short (capped at maxEscalationCommits) so the
+// response stays small even for long-running branches; full diff stats are
+// summarised rather than emitted verbatim.
+type escalationGit struct {
+	ParentBase         string   `json:"parent_base,omitempty"`
+	DiffRange          string   `json:"diff_range,omitempty"`
+	OriginBranchRef    string   `json:"origin_branch_ref,omitempty"`
+	OriginBranchExists bool     `json:"origin_branch_exists"`
+	OriginCommits      []string `json:"origin_commits,omitempty"`
+	LocalCommits       []string `json:"local_commits,omitempty"`
+	DiffStat           string   `json:"diff_stat,omitempty"`
+}
+
+// maxEscalationCommits caps the per-side commit list so a long-running
+// branch cannot bloat the response. 50 lines comfortably covers the
+// typical case (a handful of commits) while still capping pathological
+// branches.
+const maxEscalationCommits = 50
+
+// gitRunner runs a git subprocess in the given directory and returns
+// stdout. The variable is package-level so tests can swap it without
+// spawning real git processes. The signature mirrors bdShowJSON: dir is
+// the worktree path; args are the git arguments after the program name.
+var gitRunner = func(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	executil.HideWindow(cmd)
+	return cmd.Output()
+}
+
+// handleForgeEscalation handles GET /api/forge/escalation/{bead_id}. It
+// returns the full untruncated escalation message (from the retry row's
+// last_error) plus git context shelled from the worker's worktree. The
+// optional `anvil` query parameter narrows the lookup when a bead ID exists
+// in more than one anvil.
+func (s *Server) handleForgeEscalation(w http.ResponseWriter, r *http.Request) {
+	beadID := chi.URLParam(r, "bead_id")
+	if !isValidBeadID(beadID) {
+		writeError(w, http.StatusBadRequest, "invalid bead id")
+		return
+	}
+	anvilHint := strings.TrimSpace(r.URL.Query().Get("anvil"))
+
+	resp := escalationResponse{
+		BeadID: beadID,
+		Anvil:  anvilHint,
+	}
+
+	// Resolve the owning anvil. When the caller supplied an anvil hint we
+	// trust it; otherwise consult the queue cache for the single anvil the
+	// bead lives in. Beads that exist in more than one anvil resolve to ""
+	// and the caller must retry with ?anvil=.
+	if resp.Anvil == "" {
+		resp.Anvil = newAnvilLookup(s.db)(beadID)
+	}
+
+	// Retry row drives both the escalation message and the retry detail
+	// block. A missing row is fine — escalations exist for orphaned beads
+	// (no worker) too — but without it we cannot produce a useful message
+	// either, so add it to the errors list.
+	if resp.Anvil != "" {
+		if rec, err := s.db.GetRetry(beadID, resp.Anvil); err == nil && rec != nil {
+			resp.EscalationMessage = rec.LastError
+			detail := &retryDetail{
+				NeedsHuman:          rec.NeedsHuman,
+				ClarificationNeeded: rec.ClarificationNeeded,
+				DispatchFailures:    rec.DispatchFailures,
+				RecoveryFailures:    rec.RecoveryFailures,
+			}
+			if !rec.UpdatedAt.IsZero() {
+				detail.UpdatedAt = rec.UpdatedAt.Format(time.RFC3339)
+			}
+			resp.Retry = detail
+		}
+	}
+
+	// Resolve the branch and worktree path. Branch defaults to the most
+	// recent worker row's branch; worktree path is derived from the
+	// anvil's on-disk path (<anvil>/.workers/<sanitized-bead>).
+	if resp.Anvil != "" {
+		if branch, err := s.db.LastWorkerBranchForBead(beadID, resp.Anvil); err == nil {
+			resp.Branch = branch
+		}
+	}
+	anvilPath := s.resolveAnvilPath(resp.Anvil)
+	if anvilPath != "" {
+		resp.WorktreePath = filepath.Join(anvilPath, ".workers", sanitizeBeadIDForPath(beadID))
+		if info, err := os.Stat(resp.WorktreePath); err == nil && info.IsDir() {
+			resp.WorktreeExists = true
+		}
+	}
+
+	// Gather git context when we have a worktree to read from. Each shell
+	// invocation is bounded and tolerates failures: missing refs or a
+	// non-git worktree append to resp.Errors rather than 5xx the request.
+	if resp.WorktreeExists && resp.Branch != "" {
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+		resp.Context = gatherEscalationContext(ctx, resp.WorktreePath, resp.Branch, &resp.Errors)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// sanitizeBeadIDForPath mirrors worktree.sanitizePath. The worktree
+// package keeps that function unexported; rather than widen its API for
+// one consumer, we duplicate the four-rune transformation here.
+func sanitizeBeadIDForPath(beadID string) string {
+	r := strings.NewReplacer(
+		"/", "-",
+		"\\", "-",
+		" ", "-",
+		":", "-",
+	)
+	return r.Replace(beadID)
+}
+
+// gatherEscalationContext shells to git in the worker's worktree to
+// produce the parent base, the origin-side and local-side commit lists,
+// and a diff summary. Each step is independent: a failure in one (e.g.
+// the origin branch was deleted) does not prevent the others from
+// running. Errors land in *outErrs as opaque strings the SPA can render
+// in a diagnostics block.
+func gatherEscalationContext(ctx context.Context, worktreePath, branch string, outErrs *[]string) *escalationGit {
+	ctxOut := &escalationGit{}
+
+	addErr := func(stage string, err error) {
+		if err == nil {
+			return
+		}
+		*outErrs = append(*outErrs, stage+": "+err.Error())
+	}
+
+	// Parent base: origin/main, falling back to origin/master.
+	if out, err := gitRunner(ctx, worktreePath, "rev-parse", "--verify", "--quiet", "origin/main"); err == nil && len(out) > 0 {
+		ctxOut.ParentBase = "origin/main"
+	} else if out, err := gitRunner(ctx, worktreePath, "rev-parse", "--verify", "--quiet", "origin/master"); err == nil && len(out) > 0 {
+		ctxOut.ParentBase = "origin/master"
+	} else {
+		addErr("parent_base", errors.New("neither origin/main nor origin/master found"))
+	}
+
+	// Local commits on the worker branch versus the parent base.
+	if ctxOut.ParentBase != "" {
+		ctxOut.DiffRange = ctxOut.ParentBase + "..HEAD"
+		if out, err := gitRunner(ctx, worktreePath, "log",
+			"--pretty=format:%h %s",
+			"-n", strconv.Itoa(maxEscalationCommits),
+			ctxOut.DiffRange,
+		); err == nil {
+			ctxOut.LocalCommits = splitNonEmptyLines(string(out))
+		} else {
+			addErr("local_commits", err)
+		}
+
+		// Diff stat against the parent base — short summary so the
+		// response stays bounded even for large diffs.
+		if out, err := gitRunner(ctx, worktreePath, "diff", "--shortstat", ctxOut.DiffRange); err == nil {
+			ctxOut.DiffStat = strings.TrimSpace(string(out))
+		} else {
+			addErr("diff_stat", err)
+		}
+	}
+
+	// Origin-side commits on the same branch. The worker may have
+	// already pushed; the SPA shows the divergence between origin/<branch>
+	// (what reviewers see) and the local branch (what's still in the pod
+	// worktree). When the branch has not been pushed yet, origin lookup
+	// fails cleanly and OriginBranchExists stays false.
+	ctxOut.OriginBranchRef = "origin/" + branch
+	if out, err := gitRunner(ctx, worktreePath, "rev-parse", "--verify", "--quiet", ctxOut.OriginBranchRef); err == nil && len(out) > 0 {
+		ctxOut.OriginBranchExists = true
+		if logOut, logErr := gitRunner(ctx, worktreePath, "log",
+			"--pretty=format:%h %s",
+			"-n", strconv.Itoa(maxEscalationCommits),
+			ctxOut.OriginBranchRef,
+		); logErr == nil {
+			ctxOut.OriginCommits = splitNonEmptyLines(string(logOut))
+		} else {
+			addErr("origin_commits", logErr)
+		}
+	}
+
+	return ctxOut
+}
+
+// splitNonEmptyLines splits stdout by \n and trims blank entries. git
+// log's --pretty output never has trailing newlines but its CombinedOutput
+// rarely does either; the helper handles both.
+func splitNonEmptyLines(s string) []string {
+	lines := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+	out := lines[:0]
+	for _, line := range lines {
+		line = strings.TrimRight(line, " \t")
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+

--- a/internal/web/forge_resolve_test.go
+++ b/internal/web/forge_resolve_test.go
@@ -28,7 +28,7 @@ func stubGitRunner(t *testing.T, fn func(args []string) ([]byte, error)) {
 	t.Helper()
 	gitRunnerMu.Lock()
 	prev := gitRunner
-	gitRunner = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+	gitRunner = func(_ context.Context, _ string, _ []string, args ...string) ([]byte, error) {
 		return fn(args)
 	}
 	t.Cleanup(func() {
@@ -306,6 +306,12 @@ func TestForgeEscalation_GathersGitContextFromWorktree(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("upsert retry: %v", err)
 	}
+
+	// Stub gitEnvGetter so the test directory is treated as a valid worktree
+	// without requiring a real git repo on disk.
+	prevEnvGetter := gitEnvGetter
+	gitEnvGetter = func(_ string) []string { return []string{"GIT_TEST=1"} }
+	t.Cleanup(func() { gitEnvGetter = prevEnvGetter })
 
 	// Fake git: respond to the verify and log probes the handler issues.
 	stubGitRunner(t, func(args []string) ([]byte, error) {

--- a/internal/web/forge_resolve_test.go
+++ b/internal/web/forge_resolve_test.go
@@ -1,0 +1,425 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Forge/internal/ipc"
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// gitRunnerMu serialises swaps of the package-level gitRunner so parallel
+// tests cannot race on it.
+var gitRunnerMu sync.Mutex
+
+// stubGitRunner installs a temporary gitRunner implementation. The fn
+// callback receives the args from the test invocation; tests return canned
+// stdout/err so no git subprocess is spawned.
+func stubGitRunner(t *testing.T, fn func(args []string) ([]byte, error)) {
+	t.Helper()
+	gitRunnerMu.Lock()
+	prev := gitRunner
+	gitRunner = func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		return fn(args)
+	}
+	t.Cleanup(func() {
+		gitRunner = prev
+		gitRunnerMu.Unlock()
+	})
+}
+
+func TestForgeResolve_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	req := httptest.NewRequest("POST", "/api/forge/resolve", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestForgeResolve_RejectsInvalidAction(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := postAction(t, srv, cookie, "/api/forge/resolve", map[string]any{
+		"bead_id":    "Forge-abc1",
+		"action":     "explode",
+		"anvil_name": "forge",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown action, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "clear|retry|clarify|unclarify|stop") {
+		t.Errorf("expected error to mention valid actions, got %s", rec.Body.String())
+	}
+}
+
+func TestForgeResolve_RejectsInvalidBeadID(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := postAction(t, srv, cookie, "/api/forge/resolve", map[string]any{
+		"bead_id":    "../etc/passwd",
+		"action":     "clear",
+		"anvil_name": "forge",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestForgeResolve_RejectsMissingAnvil(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := postAction(t, srv, cookie, "/api/forge/resolve", map[string]any{
+		"bead_id": "Forge-abc1",
+		"action":  "clear",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 missing anvil, got %d", rec.Code)
+	}
+}
+
+func TestForgeResolve_RejectsClarifyMissingNote(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := postAction(t, srv, cookie, "/api/forge/resolve", map[string]any{
+		"bead_id":    "Forge-abc1",
+		"action":     "clarify",
+		"anvil_name": "forge",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "note is required") {
+		t.Errorf("expected note-required error, got %s", rec.Body.String())
+	}
+}
+
+// verbCase pairs the action string the SPA sends with the IPC command type
+// the daemon should receive.
+type verbCase struct {
+	action     string
+	expectType string
+}
+
+func TestForgeResolve_DispatchesAllVerbs(t *testing.T) {
+	cases := []verbCase{
+		{resolveActionClear, "queue_clear"},
+		{resolveActionRetry, "queue_retry"},
+		{resolveActionClarify, "queue_clarify"},
+		{resolveActionUnclarify, "queue_unclarify"},
+		{resolveActionStop, "queue_stop"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.action, func(t *testing.T) {
+			rh := &recordingHandler{}
+			srv := newServerWithDefaults(t, rh.handle)
+			cookie := loginAndGetCookie(t, srv)
+
+			body := map[string]any{
+				"bead_id":    "Forge-abc1",
+				"action":     tc.action,
+				"anvil_name": "forge",
+				"note":       "operator context",
+				"forge_id":   "forge-a",
+			}
+			rec := postAction(t, srv, cookie, "/api/forge/resolve", body)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+			}
+			cmd, ok := rh.lastCommand()
+			if !ok {
+				t.Fatalf("no command dispatched")
+			}
+			if cmd.Type != tc.expectType {
+				t.Errorf("expected IPC type %q, got %q", tc.expectType, cmd.Type)
+			}
+			var p ipc.QueueActionPayload
+			if err := json.Unmarshal(cmd.Payload, &p); err != nil {
+				t.Fatalf("payload unmarshal: %v", err)
+			}
+			if p.BeadID != "Forge-abc1" || p.AnvilName != "forge" || p.Note != "operator context" || p.ForgeID != "forge-a" {
+				t.Errorf("payload mismatch: %+v", p)
+			}
+		})
+	}
+}
+
+func TestForgeResolve_DaemonErrorBubblesUp(t *testing.T) {
+	rh := &recordingHandler{
+		resp: ipc.Response{
+			Type:    "error",
+			Payload: []byte(`{"message":"forge_id does not match owning forge: caller=\"forge-b\" local=\"forge-a\""}`),
+		},
+	}
+	srv := newServerWithDefaults(t, rh.handle)
+	cookie := loginAndGetCookie(t, srv)
+
+	rec := postAction(t, srv, cookie, "/api/forge/resolve", map[string]any{
+		"bead_id":    "Forge-abc1",
+		"action":     "clear",
+		"anvil_name": "forge",
+		"forge_id":   "forge-b",
+	})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "forge_id does not match") {
+		t.Errorf("expected forge-mismatch error in body, got %s", rec.Body.String())
+	}
+}
+
+// ---------- /api/forge/escalation/{bead_id} ----------
+
+func TestForgeEscalation_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	req := httptest.NewRequest("GET", "/api/forge/escalation/Forge-abc1", nil)
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestForgeEscalation_InvalidBeadID(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/forge/escalation/..%2Fevil", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	// chi may 404 the malformed segment outright; either rejection is
+	// acceptable as long as the handler does not return 200.
+	if rec.Code != http.StatusBadRequest && rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 400 or 404, got %d", rec.Code)
+	}
+}
+
+func TestForgeEscalation_NoRetryRow_ReturnsEmptyMessage(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	req := httptest.NewRequest("GET", "/api/forge/escalation/Forge-abc1?anvil=forge", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got escalationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.BeadID != "Forge-abc1" || got.Anvil != "forge" {
+		t.Errorf("expected bead/anvil echoed back, got %+v", got)
+	}
+	if got.EscalationMessage != "" {
+		t.Errorf("expected empty escalation message, got %q", got.EscalationMessage)
+	}
+}
+
+func TestForgeEscalation_ReturnsRetryDetail(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	if err := srv.db.UpsertRetry(&state.RetryRecord{
+		BeadID:           "Forge-abc1",
+		Anvil:            "forge",
+		NeedsHuman:       true,
+		DispatchFailures: 3,
+		LastError:        "build failed: missing toolchain\nfull stack:\nline 1\nline 2",
+	}); err != nil {
+		t.Fatalf("upsert retry: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/forge/escalation/Forge-abc1?anvil=forge", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got escalationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(got.EscalationMessage, "missing toolchain") {
+		t.Errorf("expected full escalation message, got %q", got.EscalationMessage)
+	}
+	// The full multi-line text must come through untruncated — this is the
+	// whole reason the endpoint exists, since the queue/event surfaces
+	// summarise.
+	if !strings.Contains(got.EscalationMessage, "line 2") {
+		t.Errorf("expected untruncated last_error, got %q", got.EscalationMessage)
+	}
+	if got.Retry == nil || !got.Retry.NeedsHuman || got.Retry.DispatchFailures != 3 {
+		t.Errorf("retry detail mismatch: %+v", got.Retry)
+	}
+}
+
+func TestForgeEscalation_GathersGitContextFromWorktree(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	// Seed an anvil + a worker so the handler can resolve a worktree path.
+	anvilRoot := t.TempDir()
+	worktreePath := filepath.Join(anvilRoot, ".workers", "Forge-abc1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	srv.SetAnvilLister(func() map[string]string {
+		return map[string]string{"forge": anvilRoot}
+	})
+
+	if err := srv.db.InsertWorker(&state.Worker{
+		ID:        "forge-abc1-123",
+		BeadID:    "Forge-abc1",
+		Anvil:     "forge",
+		Branch:    "forge/Forge-abc1",
+		Status:    state.WorkerFailed,
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("insert worker: %v", err)
+	}
+	if err := srv.db.UpsertRetry(&state.RetryRecord{
+		BeadID:    "Forge-abc1",
+		Anvil:     "forge",
+		LastError: "smith returned NEEDS_HUMAN: API key missing",
+	}); err != nil {
+		t.Fatalf("upsert retry: %v", err)
+	}
+
+	// Fake git: respond to the verify and log probes the handler issues.
+	stubGitRunner(t, func(args []string) ([]byte, error) {
+		switch {
+		case len(args) >= 2 && args[0] == "rev-parse" && contains(args, "origin/main"):
+			return []byte("deadbeef\n"), nil
+		case len(args) >= 2 && args[0] == "rev-parse" && contains(args, "origin/master"):
+			return nil, errors.New("not found")
+		case len(args) >= 2 && args[0] == "rev-parse" && contains(args, "origin/forge/Forge-abc1"):
+			return []byte("cafebabe\n"), nil
+		case len(args) >= 1 && args[0] == "log":
+			if contains(args, "origin/main..HEAD") {
+				return []byte("aaaa fix: A\nbbbb fix: B\n"), nil
+			}
+			if contains(args, "origin/forge/Forge-abc1") {
+				return []byte("aaaa fix: A\n"), nil
+			}
+			return nil, errors.New("unexpected log args")
+		case len(args) >= 1 && args[0] == "diff":
+			return []byte(" 2 files changed, 5 insertions(+), 1 deletion(-)\n"), nil
+		default:
+			return nil, errors.New("unexpected git args")
+		}
+	})
+
+	req := httptest.NewRequest("GET", "/api/forge/escalation/Forge-abc1?anvil=forge", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got escalationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Branch != "forge/Forge-abc1" {
+		t.Errorf("branch: got %q", got.Branch)
+	}
+	if !got.WorktreeExists {
+		t.Errorf("expected worktree_exists=true, body=%s", rec.Body.String())
+	}
+	if got.Context == nil {
+		t.Fatalf("expected git context, body=%s", rec.Body.String())
+	}
+	if got.Context.ParentBase != "origin/main" || got.Context.DiffRange != "origin/main..HEAD" {
+		t.Errorf("parent_base/diff_range mismatch: %+v", got.Context)
+	}
+	if len(got.Context.LocalCommits) != 2 || !strings.HasPrefix(got.Context.LocalCommits[0], "aaaa ") {
+		t.Errorf("local commits: %+v", got.Context.LocalCommits)
+	}
+	if !got.Context.OriginBranchExists || len(got.Context.OriginCommits) != 1 {
+		t.Errorf("origin: %+v", got.Context)
+	}
+	if !strings.Contains(got.Context.DiffStat, "2 files changed") {
+		t.Errorf("diff stat: %q", got.Context.DiffStat)
+	}
+}
+
+func TestForgeEscalation_WorktreeMissing_NoGitCalls(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	// Anvil points at a directory that exists but has no .workers entry
+	// for this bead — the handler should NOT shell to git.
+	anvilRoot := t.TempDir()
+	srv.SetAnvilLister(func() map[string]string {
+		return map[string]string{"forge": anvilRoot}
+	})
+	if err := srv.db.UpsertRetry(&state.RetryRecord{
+		BeadID:    "Forge-abc1",
+		Anvil:     "forge",
+		LastError: "some error",
+	}); err != nil {
+		t.Fatalf("upsert retry: %v", err)
+	}
+
+	called := false
+	stubGitRunner(t, func(args []string) ([]byte, error) {
+		called = true
+		return nil, errors.New("should not be called")
+	})
+
+	req := httptest.NewRequest("GET", "/api/forge/escalation/Forge-abc1?anvil=forge", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Errorf("git was called even though worktree is missing")
+	}
+	var got escalationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.WorktreeExists {
+		t.Errorf("expected worktree_exists=false")
+	}
+	if got.Context != nil {
+		t.Errorf("expected no git context when worktree missing, got %+v", got.Context)
+	}
+}
+
+// contains reports whether ss includes s. Used by the stubbed git runner
+// to match on a single arg without slicing into the variadic.
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -100,6 +100,14 @@ func (s *Server) routes() http.Handler {
 		r.Post("/forge/sessions/{id}/messages", s.handleForgeSessionAppend)
 		r.Post("/forge/sessions/{id}/turn", s.handleForgeSessionTurn)
 		r.Post("/forge/sessions/{id}/create-beads", s.handleForgeSessionCreateBeads)
+
+		// Hearth 2.0 resolve-needs-attention page. The POST endpoint is a
+		// thin façade over the daemon's queue_* IPC verbs so the SPA
+		// renders a single action picker; the GET endpoint returns the
+		// full untruncated escalation message plus git context shelled
+		// from the worker's worktree.
+		r.Post("/forge/resolve", s.handleForgeResolve)
+		r.Get("/forge/escalation/{bead_id}", s.handleForgeEscalation)
 	})
 
 	// Static UI fallback. The next bead replaces this with the embedded

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -922,11 +922,10 @@ func GitEnv(worktreePath string) []string {
 	return env
 }
 
-// sanitizePath converts a bead ID to a safe directory/branch name.
+// SanitizePath converts a bead ID to a safe directory/branch name.
 // E.g., "Forge-n1g.4.1" → "Forge-n1g.4.1" (dots are fine in git branches).
-// Slashes and other problematic chars are replaced.
-func sanitizePath(beadID string) string {
-	// Replace characters that are problematic in file paths or branch names
+// Slashes and other problematic chars are replaced with dashes.
+func SanitizePath(beadID string) string {
 	r := strings.NewReplacer(
 		"/", "-",
 		"\\", "-",
@@ -935,3 +934,6 @@ func sanitizePath(beadID string) string {
 	)
 	return r.Replace(beadID)
 }
+
+// sanitizePath is the unexported alias kept for internal callers.
+func sanitizePath(beadID string) string { return SanitizePath(beadID) }


### PR DESCRIPTION
## Changes

- **Resolve-needs-attention HTTP endpoints** - Wire the Hearth 2.0 escalation page to the daemon via `POST /api/forge/resolve` (dispatching one of clear/retry/clarify/unclarify/stop to the queue IPC handlers) and `GET /api/forge/escalation/{bead_id}` (full untruncated escalation message plus git context — parent base, origin branch commits, local worktree commits, diff range — shelled from the worker's worktree). (Forge-k2ls)

## Original Issue (task): Add /api/forge/resolve HTTP endpoint bridging UI to IPC

In internal/web/forge_chat.go (or a new internal/web/forge_resolve.go), add an HTTP POST handler at /api/forge/resolve that accepts {bead_id, action, anvil_name?, note?} where action is one of clear|retry|clarify|unclarify|stop. The handler validates input, looks up the owning forge_id, then dispatches to the corresponding daemon IPC handler from sub-task 1. Also add a GET endpoint /api/forge/escalation/<bead_id> that returns the full untruncated escalation message plus context (origin branch commits, local pod-worktree commits, diff range, parent base) by shelling to git in the worker's worktree. Wire both routes into the existing forge web mux. Depends on sub-task 1 for the IPC handlers.

---
Bead: Forge-k2ls | Branch: forge/Forge-k2ls
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->