### PR TITLE
Backend: validate anvil on session create (Forge-4avf)

### DIFF
--- a/changelog.d/Forge-4avf.md
+++ b/changelog.d/Forge-4avf.md
@@ -1,2 +1,2 @@
 category: Added
-- **Anvil validation on Beads-Forge session create** - Reject `POST /api/forge/sessions` with 400 when the supplied anvil does not match any registered anvil; auto-populate the anvil when exactly one is registered and none was specified; reject with a clear error when several are registered and no choice was made. (Forge-4avf)
+- **Anvil validation on Beads-Forge session create** - Reject `POST /api/forge/sessions` with 400 when the supplied anvil does not match any registered anvil; auto-populate the anvil when exactly one is registered and none was specified; reject with a clear error when several are registered and no choice was made; reject when two registry entries differ only by case so the case-insensitive match is ambiguous. (Forge-4avf)

--- a/changelog.d/Forge-4avf.md
+++ b/changelog.d/Forge-4avf.md
@@ -1,0 +1,2 @@
+category: Added
+- **Anvil validation on Beads-Forge session create** - Reject `POST /api/forge/sessions` with 400 when the supplied anvil does not match any registered anvil; auto-populate the anvil when exactly one is registered and none was specified; reject with a clear error when several are registered and no choice was made. (Forge-4avf)

--- a/internal/web/forge_chat_test.go
+++ b/internal/web/forge_chat_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Robin831/Forge/internal/forgechat"
+	"github.com/Robin831/Forge/internal/state"
 )
 
 // stubRunner is a deterministic forgechat.Runner used by the web tests. It
@@ -383,8 +384,17 @@ func TestForgeTurn_AmbiguousCaseAnvilProducesNilTarget(t *testing.T) {
 		}
 	})
 	cookie := loginAndGetCookie(t, srv)
-	// "MUNIN" has no exact match; the case-insensitive scan finds two candidates.
-	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start","anvil":"MUNIN"}`)
+	// Insert directly via the DB so we can stage an ambiguous case-insensitive
+	// anvil reference — the HTTP create handler rejects this at write time, but
+	// resolveSessionAnvil still needs to handle the case for sessions that were
+	// created before one of the colliding anvils was registered.
+	sess, err := srv.db.CreateForgeSession(state.ForgeSession{
+		Title: "ambiguous", CreatedBy: "alice", Anvil: "MUNIN",
+	})
+	if err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	id := sess.ID
 
 	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
 	if rec.Code != http.StatusOK {
@@ -412,7 +422,17 @@ func TestForgeTurn_UnknownAnvilProducesNilTarget(t *testing.T) {
 		return map[string]string{"other": "/repos/other"}
 	})
 	cookie := loginAndGetCookie(t, srv)
-	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start","anvil":"gone"}`)
+	// Insert directly via the DB so we can stage an unknown anvil reference —
+	// the HTTP create handler rejects this at write time, but resolveSessionAnvil
+	// still needs to handle the case for sessions whose anvil was unregistered
+	// after creation.
+	sess, err := srv.db.CreateForgeSession(state.ForgeSession{
+		Title: "unknown", CreatedBy: "alice", Anvil: "gone",
+	})
+	if err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	id := sess.ID
 
 	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
 	if rec.Code != http.StatusOK {

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -2,8 +2,10 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -160,6 +162,10 @@ func (s *Server) handleForgeSessionsCreate(w http.ResponseWriter, r *http.Reques
 	req.Title = strings.TrimSpace(req.Title)
 	req.Anvil = strings.TrimSpace(req.Anvil)
 	req.InitialMessage = strings.TrimSpace(req.InitialMessage)
+	if msg, ok := s.validateSessionAnvil(&req.Anvil); !ok {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
 	if len(req.InitialMessage) > maxForgeMessageBytes {
 		writeError(w, http.StatusBadRequest, "initial message exceeds size limit")
 		return
@@ -455,6 +461,42 @@ func (s *Server) handleForgeSessionAppend(w http.ResponseWriter, r *http.Request
 		"message": toForgeMessageDTO(m),
 		"session": toForgeSessionDTO(*updated, count),
 	})
+}
+
+// validateSessionAnvil enforces the anvil rules at session-create time so a
+// browser bug or stale client can't strand a draft on a non-routable anvil.
+// On success it returns ("", true), possibly rewriting *anvil with the
+// canonical (registry-cased) name; on failure it returns the error message
+// for a 400 response and (..., false). When the registry callback is not
+// wired the function is a no-op — the daemon is responsible for wiring
+// SetAnvilLister in production, and tests that don't care about anvil
+// routing can omit it.
+func (s *Server) validateSessionAnvil(anvil *string) (string, bool) {
+	if s.anvils == nil {
+		return "", true
+	}
+	registry := s.anvils()
+	if *anvil == "" {
+		if len(registry) == 1 {
+			for name := range registry {
+				*anvil = name
+			}
+			return "", true
+		}
+		return "anvil is required when more than one anvil is registered", false
+	}
+	for name := range registry {
+		if strings.EqualFold(name, *anvil) {
+			*anvil = name
+			return "", true
+		}
+	}
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("unknown anvil %s; registered: %s", *anvil, strings.Join(names, ", ")), false
 }
 
 // parseForgeSessionID extracts the {id} URL parameter and parses it as an

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -476,6 +476,9 @@ func (s *Server) validateSessionAnvil(anvil *string) (string, bool) {
 		return "", true
 	}
 	registry := s.anvils()
+	if len(registry) == 0 {
+		return "", true
+	}
 	if *anvil == "" {
 		if len(registry) == 1 {
 			for name := range registry {

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -477,6 +477,9 @@ func (s *Server) validateSessionAnvil(anvil *string) (string, bool) {
 	}
 	registry := s.anvils()
 	if len(registry) == 0 {
+		if *anvil != "" {
+			return fmt.Sprintf("unknown anvil %s; no anvils are registered", *anvil), false
+		}
 		return "", true
 	}
 	if *anvil == "" {

--- a/internal/web/forge_sessions.go
+++ b/internal/web/forge_sessions.go
@@ -488,17 +488,33 @@ func (s *Server) validateSessionAnvil(anvil *string) (string, bool) {
 		}
 		return "anvil is required when more than one anvil is registered", false
 	}
+	if _, ok := registry[*anvil]; ok {
+		return "", true
+	}
+	// No exact match: do a case-insensitive scan. Multiple matches are
+	// ambiguous because map iteration order is unspecified — refuse rather
+	// than pick a winner at random. resolveSessionAnvil applies the same
+	// rule when reading a stored session.
+	var matched string
+	matches := 0
 	for name := range registry {
 		if strings.EqualFold(name, *anvil) {
-			*anvil = name
-			return "", true
+			matched = name
+			matches++
 		}
+	}
+	if matches == 1 {
+		*anvil = matched
+		return "", true
 	}
 	names := make([]string, 0, len(registry))
 	for name := range registry {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	if matches > 1 {
+		return fmt.Sprintf("ambiguous anvil %s; multiple registry entries match case-insensitively (registered: %s)", *anvil, strings.Join(names, ", ")), false
+	}
 	return fmt.Sprintf("unknown anvil %s; registered: %s", *anvil, strings.Join(names, ", ")), false
 }
 

--- a/internal/web/forge_sessions_test.go
+++ b/internal/web/forge_sessions_test.go
@@ -351,6 +351,16 @@ func TestForgeSessions_CreateAnvilValidation(t *testing.T) {
 			wantStatus: http.StatusCreated,
 			wantAnvil:  "Heimdall",
 		},
+		{
+			// Two registry keys differ only by case; map iteration order is
+			// random in Go, so silently picking one would be nondeterministic.
+			// validateSessionAnvil must refuse instead.
+			name:       "ambiguous case-insensitive match rejected",
+			registry:   map[string]string{"munin": "/repos/munin-lower", "Munin": "/repos/munin-upper"},
+			body:       `{"title":"draft","anvil":"MUNIN"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "ambiguous anvil MUNIN",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/web/forge_sessions_test.go
+++ b/internal/web/forge_sessions_test.go
@@ -361,6 +361,16 @@ func TestForgeSessions_CreateAnvilValidation(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 			wantError:  "ambiguous anvil MUNIN",
 		},
+		{
+			// Registry is wired but empty; a non-empty anvil must be rejected
+			// so the caller gets a clear error rather than silently creating a
+			// session on an unroutable anvil.
+			name:       "non-empty anvil rejected when registry is empty",
+			registry:   map[string]string{},
+			body:       `{"title":"draft","anvil":"ghost"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "unknown anvil ghost; no anvils are registered",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/web/forge_sessions_test.go
+++ b/internal/web/forge_sessions_test.go
@@ -309,6 +309,82 @@ func TestForgeSessions_CSRFEnforced(t *testing.T) {
 	}
 }
 
+// TestForgeSessions_CreateAnvilValidation exercises the four anvil-input
+// branches handled by validateSessionAnvil: auto-populate when exactly one
+// is registered, reject when several are registered without a choice,
+// reject unknown names with a registered-list hint, and canonicalise the
+// casing on match.
+func TestForgeSessions_CreateAnvilValidation(t *testing.T) {
+	cases := []struct {
+		name       string
+		registry   map[string]string
+		body       string
+		wantStatus int
+		wantAnvil  string // anvil stored on the session (only checked on 2xx)
+		wantError  string // substring expected in the error body (only on 4xx)
+	}{
+		{
+			name:       "empty anvil auto-populates when exactly one registered",
+			registry:   map[string]string{"alpha": "/anvils/alpha"},
+			body:       `{"title":"draft"}`,
+			wantStatus: http.StatusCreated,
+			wantAnvil:  "alpha",
+		},
+		{
+			name:       "empty anvil rejected when multiple registered",
+			registry:   map[string]string{"alpha": "/anvils/alpha", "beta": "/anvils/beta"},
+			body:       `{"title":"draft"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "anvil is required when more than one anvil is registered",
+		},
+		{
+			name:       "unknown anvil rejected with registered-list hint",
+			registry:   map[string]string{"alpha": "/anvils/alpha", "beta": "/anvils/beta"},
+			body:       `{"title":"draft","anvil":"gamma"}`,
+			wantStatus: http.StatusBadRequest,
+			wantError:  "unknown anvil gamma; registered: alpha, beta",
+		},
+		{
+			name:       "case-insensitive match canonicalises the name",
+			registry:   map[string]string{"Heimdall": "/anvils/heimdall"},
+			body:       `{"title":"draft","anvil":"HEIMDALL"}`,
+			wantStatus: http.StatusCreated,
+			wantAnvil:  "Heimdall",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newServerWithDefaults(t, nil)
+			registry := tc.registry
+			srv.SetAnvilLister(func() map[string]string { return registry })
+			cookie := loginAndGetCookie(t, srv)
+
+			rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions", tc.body, cookie)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status: want %d got %d body=%s", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+			if tc.wantStatus >= 400 {
+				if tc.wantError != "" && !strings.Contains(rec.Body.String(), tc.wantError) {
+					t.Errorf("error body: want substring %q, got %s", tc.wantError, rec.Body.String())
+				}
+				return
+			}
+			var created struct {
+				Session struct {
+					Anvil string `json:"anvil"`
+				} `json:"session"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if created.Session.Anvil != tc.wantAnvil {
+				t.Errorf("anvil: want %q got %q", tc.wantAnvil, created.Session.Anvil)
+			}
+		})
+	}
+}
+
 // itoa converts a positive int64 to its decimal string. We use a tiny
 // helper rather than strconv.Itoa to avoid importing strconv just for the
 // int64→string conversion in test URL building.


### PR DESCRIPTION
## Changes

- **Anvil validation on Beads-Forge session create** - Reject `POST /api/forge/sessions` with 400 when the supplied anvil does not match any registered anvil; auto-populate the anvil when exactly one is registered and none was specified; reject with a clear error when several are registered and no choice was made; reject when two registry entries differ only by case so the case-insensitive match is ambiguous. (Forge-4avf)

## Original Issue (task): Backend: validate anvil on session create

Modify `internal/web/forge_sessions.go` in `handleForgeSessionsCreate` (around line 142, after the existing `req.Anvil = strings.TrimSpace(req.Anvil)`). Add three validation branches: (1) if `req.Anvil == ""` and exactly one anvil is registered, auto-populate `req.Anvil` with that anvil's name; (2) if `req.Anvil == ""` and multiple anvils are registered, return 400 with `{"error":"anvil is required when more than one anvil is registered"}`; (3) if `req.Anvil` is non-empty but does not match any registered anvil (case-insensitive), return 400 with `{"error":"unknown anvil <name>; registered: <list>"}`. Use the existing anvil registry/listing function the daemon already exposes (the same source the listing endpoint uses). Add table-driven tests for all three branches plus the happy path. This sub-task is the server-side guard that prevents the dead-end state regardless of client; the frontend sub-task layers a better UX on top but the backend is the source of truth.

---
Bead: Forge-4avf | Branch: forge/Forge-4avf
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->