### PR TITLE
Archive store + config keys (Forge-7pu1)

### DIFF
--- a/changelog.d/Forge-7pu1.md
+++ b/changelog.d/Forge-7pu1.md
@@ -1,0 +1,2 @@
+category: Added
+- **Warden rule archive store** - Persist superseded or stale review rules to `.forge/warden-rules.archive.yaml` with reason and timestamps, plus `warden.archive_after_days` (default 180) and `warden.dedup_threshold` (default 0.6) config keys to drive future archive/dedup passes. (Forge-7pu1)

--- a/changelog.d/Forge-7pu1.md
+++ b/changelog.d/Forge-7pu1.md
@@ -1,2 +1,2 @@
 category: Added
-- **Warden rule archive store** - Persist superseded or stale review rules to `.forge/warden-rules.archive.yaml` with reason and timestamps, plus `warden.archive_after_days` (default 180) and `warden.dedup_threshold` (default 0.6) config keys to drive future archive/dedup passes. (Forge-7pu1)
+- **Warden rule archive store** - Persist superseded or stale review rules to `.forge/warden-rules.archive.yaml` with reason and timestamps, plus `settings.warden.archive_after_days` (default 180) and `settings.warden.dedup_threshold` (default 0.6) config keys to drive future archive/dedup passes. (Forge-7pu1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -486,6 +486,34 @@ type WardenSettings struct {
 	// Rule.Pattern against the diff. Pointer so unset means "use default
 	// (true)".
 	FilterPatternGrep *bool `mapstructure:"filter_pattern_grep" yaml:"filter_pattern_grep,omitempty"`
+	// ArchiveAfterDays controls when an active rule is moved to the archive
+	// because it has not been observed (via LastSeen) for this many days.
+	// Zero falls back to the default of 180 days.
+	ArchiveAfterDays int `mapstructure:"archive_after_days" yaml:"archive_after_days,omitempty"`
+	// DedupThreshold is the similarity score (0.0–1.0) above which two
+	// active rules are considered duplicates and the older entry is moved to
+	// the archive with reason "duplicate". Zero falls back to the default
+	// of 0.6.
+	DedupThreshold float64 `mapstructure:"dedup_threshold" yaml:"dedup_threshold,omitempty"`
+}
+
+// ResolvedArchiveAfterDays returns the effective archive-after threshold in
+// days. Zero (unset) resolves to the default of 180; negative values are
+// returned as-is so callers can treat them as "never archive".
+func (w WardenSettings) ResolvedArchiveAfterDays() int {
+	if w.ArchiveAfterDays == 0 {
+		return 180
+	}
+	return w.ArchiveAfterDays
+}
+
+// ResolvedDedupThreshold returns the effective dedup-similarity threshold.
+// Zero (unset) resolves to the default of 0.6.
+func (w WardenSettings) ResolvedDedupThreshold() float64 {
+	if w.DedupThreshold == 0 {
+		return 0.6
+	}
+	return w.DedupThreshold
 }
 
 // IsFilterPathGlobEnabled returns true unless the toggle is explicitly false.
@@ -899,6 +927,8 @@ func Defaults() Config {
 				FilterPathGlob:    boolPtr(true),
 				FilterCategory:    boolPtr(true),
 				FilterPatternGrep: boolPtr(true),
+				ArchiveAfterDays:  180,
+				DedupThreshold:    0.6,
 			},
 		},
 	}
@@ -952,6 +982,8 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("settings.warden.filter_path_glob", true)
 	v.SetDefault("settings.warden.filter_category", true)
 	v.SetDefault("settings.warden.filter_pattern_grep", true)
+	v.SetDefault("settings.warden.archive_after_days", 180)
+	v.SetDefault("settings.warden.dedup_threshold", 0.6)
 
 	// Environment variable support: FORGE_SETTINGS_POLL_INTERVAL etc.
 	// SetEnvKeyReplacer maps dotted config keys (settings.auto_learn_rules) to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -486,9 +486,11 @@ type WardenSettings struct {
 	// Rule.Pattern against the diff. Pointer so unset means "use default
 	// (true)".
 	FilterPatternGrep *bool `mapstructure:"filter_pattern_grep" yaml:"filter_pattern_grep,omitempty"`
-	// ArchiveAfterDays controls when an active rule is moved to the archive
-	// because it has not been observed (via LastSeen) for this many days.
-	// Zero falls back to the default of 180 days.
+	// ArchiveAfterDays controls the staleness threshold (in days) that a
+	// future archive/dedup pass will use to retire inactive rules. Rule
+	// entries do not yet carry a last-seen timestamp; when that tracking is
+	// added, this value will gate the archive pass. Zero falls back to the
+	// default of 180 days.
 	ArchiveAfterDays int `mapstructure:"archive_after_days" yaml:"archive_after_days,omitempty"`
 	// DedupThreshold is the similarity score (0.0–1.0) above which two
 	// active rules are considered duplicates and the older entry is moved to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1126,6 +1126,8 @@ func TestLoad_WardenSettings_Default(t *testing.T) {
 	assert.True(t, cfg.Settings.Warden.IsFilterPathGlobEnabled())
 	assert.True(t, cfg.Settings.Warden.IsFilterCategoryEnabled())
 	assert.True(t, cfg.Settings.Warden.IsFilterPatternGrepEnabled())
+	assert.Equal(t, 180, cfg.Settings.Warden.ResolvedArchiveAfterDays())
+	assert.InDelta(t, 0.6, cfg.Settings.Warden.ResolvedDedupThreshold(), 1e-9)
 }
 
 func TestLoad_WardenSettings_Custom(t *testing.T) {
@@ -1139,6 +1141,8 @@ settings:
     filter_path_glob: false
     filter_category: false
     filter_pattern_grep: false
+    archive_after_days: 90
+    dedup_threshold: 0.8
 `
 	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
 
@@ -1149,6 +1153,8 @@ settings:
 	assert.False(t, cfg.Settings.Warden.IsFilterPathGlobEnabled())
 	assert.False(t, cfg.Settings.Warden.IsFilterCategoryEnabled())
 	assert.False(t, cfg.Settings.Warden.IsFilterPatternGrepEnabled())
+	assert.Equal(t, 90, cfg.Settings.Warden.ResolvedArchiveAfterDays())
+	assert.InDelta(t, 0.8, cfg.Settings.Warden.ResolvedDedupThreshold(), 1e-9)
 }
 
 func TestTemperStepConfig_VerifyNoConflictMarkersRoundTrip(t *testing.T) {

--- a/internal/warden/archive.go
+++ b/internal/warden/archive.go
@@ -136,8 +136,9 @@ func (a *Archive) Save(path string) error {
 // Add appends a rule to the archive, recording the reason it was archived
 // and (optionally) the ID of the rule that supersedes it. If an entry with
 // the same ID already exists, it is replaced in place so the archive stays
-// deduplicated by ID. ArchivedAt is set to time.Now(); LastSeen falls back
-// to ArchivedAt when the source rule has no recorded LastSeen.
+// deduplicated by ID. Both ArchivedAt and LastSeen are set to time.Now() at
+// archive time (Rule has no last-seen field yet; a future pass will propagate
+// one when per-rule activity tracking is introduced).
 func (a *Archive) Add(rule Rule, reason, supersededBy string) {
 	now := time.Now().UTC()
 	entry := ArchivedRule{

--- a/internal/warden/archive.go
+++ b/internal/warden/archive.go
@@ -1,0 +1,120 @@
+package warden
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ArchiveFileName is the per-anvil file storing archived (superseded or
+// stale) review rules.
+const ArchiveFileName = ".forge/warden-rules.archive.yaml"
+
+// Archive reason constants. ArchivedRule.ArchiveReason must be one of these.
+const (
+	ArchiveReasonDuplicate = "duplicate"
+	ArchiveReasonStale     = "stale"
+)
+
+// ArchivedRule represents a Rule that has been retired from the active
+// rules file. It embeds the original Rule and adds bookkeeping fields
+// describing why and when the rule was archived.
+type ArchivedRule struct {
+	Rule          `yaml:",inline"`
+	SupersededBy  string    `yaml:"superseded_by,omitempty" json:"superseded_by,omitempty"`
+	LastSeen      time.Time `yaml:"last_seen,omitempty"     json:"last_seen,omitempty"`
+	ArchivedAt    time.Time `yaml:"archived_at"             json:"archived_at"`
+	ArchiveReason string    `yaml:"archive_reason"          json:"archive_reason"`
+}
+
+// Archive is the top-level structure of warden-rules.archive.yaml.
+type Archive struct {
+	Rules []ArchivedRule `yaml:"rules"`
+}
+
+// ArchivePath returns the full path to the archive file for an anvil.
+func ArchivePath(anvilPath string) string {
+	return filepath.Join(anvilPath, ArchiveFileName)
+}
+
+// LoadArchive reads the archive file at the given path. Returns an empty
+// Archive (not an error) if the file does not exist.
+func LoadArchive(path string) (*Archive, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Archive{}, nil
+		}
+		return nil, fmt.Errorf("reading warden archive: %w", err)
+	}
+
+	var a Archive
+	if err := yaml.Unmarshal(data, &a); err != nil {
+		return nil, fmt.Errorf("parsing warden archive: %w", err)
+	}
+	return &a, nil
+}
+
+// Save writes the archive to the given file path, creating the parent
+// directory if it does not exist.
+func (a *Archive) Save(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating archive directory: %w", err)
+	}
+
+	data, err := yaml.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("marshaling warden archive: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Add appends a rule to the archive, recording the reason it was archived
+// and (optionally) the ID of the rule that supersedes it. If an entry with
+// the same ID already exists, it is replaced in place so the archive stays
+// deduplicated by ID. ArchivedAt is set to time.Now(); LastSeen falls back
+// to ArchivedAt when the source rule has no recorded LastSeen.
+func (a *Archive) Add(rule Rule, reason, supersededBy string) {
+	now := time.Now().UTC()
+	entry := ArchivedRule{
+		Rule:          rule,
+		SupersededBy:  supersededBy,
+		LastSeen:      now,
+		ArchivedAt:    now,
+		ArchiveReason: reason,
+	}
+
+	for i, existing := range a.Rules {
+		if existing.ID == rule.ID {
+			a.Rules[i] = entry
+			return
+		}
+	}
+	a.Rules = append(a.Rules, entry)
+}
+
+// Find returns the archived rule with the given ID and true when present.
+func (a *Archive) Find(id string) (*ArchivedRule, bool) {
+	for i := range a.Rules {
+		if a.Rules[i].ID == id {
+			return &a.Rules[i], true
+		}
+	}
+	return nil, false
+}
+
+// Remove deletes the archived rule with the given ID and returns it. The
+// second return value reports whether a rule was found and removed.
+func (a *Archive) Remove(id string) (*ArchivedRule, bool) {
+	for i, r := range a.Rules {
+		if r.ID == id {
+			removed := r
+			a.Rules = append(a.Rules[:i], a.Rules[i+1:]...)
+			return &removed, true
+		}
+	}
+	return nil, false
+}

--- a/internal/warden/archive.go
+++ b/internal/warden/archive.go
@@ -30,6 +30,67 @@ type ArchivedRule struct {
 	ArchiveReason string    `yaml:"archive_reason"          json:"archive_reason"`
 }
 
+// MarshalYAML produces a single mapping node combining Rule's fields (via
+// its custom marshaller) with the archive-specific fields. The default
+// inline embedding does not work here because Rule.MarshalYAML returns a
+// mapping node that would otherwise replace the entire ArchivedRule
+// mapping, dropping the archive bookkeeping fields.
+func (ar ArchivedRule) MarshalYAML() (any, error) {
+	ruleAny, err := ar.Rule.MarshalYAML()
+	if err != nil {
+		return nil, err
+	}
+	mapping, ok := ruleAny.(*yaml.Node)
+	if !ok || mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("archive: Rule.MarshalYAML did not return a mapping node")
+	}
+
+	extras := struct {
+		SupersededBy  string    `yaml:"superseded_by,omitempty"`
+		LastSeen      time.Time `yaml:"last_seen,omitempty"`
+		ArchivedAt    time.Time `yaml:"archived_at"`
+		ArchiveReason string    `yaml:"archive_reason"`
+	}{
+		SupersededBy:  ar.SupersededBy,
+		LastSeen:      ar.LastSeen,
+		ArchivedAt:    ar.ArchivedAt,
+		ArchiveReason: ar.ArchiveReason,
+	}
+
+	var extraNode yaml.Node
+	if err := extraNode.Encode(extras); err != nil {
+		return nil, err
+	}
+	if extraNode.Kind == yaml.MappingNode {
+		mapping.Content = append(mapping.Content, extraNode.Content...)
+	}
+	return mapping, nil
+}
+
+// UnmarshalYAML decodes a mapping node into both the embedded Rule and the
+// archive-specific fields. Decoding the same node twice — once into Rule
+// and once into the extras struct — sidesteps the inline+custom-marshaler
+// interaction that would otherwise silently drop fields.
+func (ar *ArchivedRule) UnmarshalYAML(value *yaml.Node) error {
+	if err := value.Decode(&ar.Rule); err != nil {
+		return err
+	}
+	var extras struct {
+		SupersededBy  string    `yaml:"superseded_by"`
+		LastSeen      time.Time `yaml:"last_seen"`
+		ArchivedAt    time.Time `yaml:"archived_at"`
+		ArchiveReason string    `yaml:"archive_reason"`
+	}
+	if err := value.Decode(&extras); err != nil {
+		return err
+	}
+	ar.SupersededBy = extras.SupersededBy
+	ar.LastSeen = extras.LastSeen
+	ar.ArchivedAt = extras.ArchivedAt
+	ar.ArchiveReason = extras.ArchiveReason
+	return nil
+}
+
 // Archive is the top-level structure of warden-rules.archive.yaml.
 type Archive struct {
 	Rules []ArchivedRule `yaml:"rules"`

--- a/internal/warden/archive_test.go
+++ b/internal/warden/archive_test.go
@@ -1,0 +1,102 @@
+package warden
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadArchive_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	a, err := LoadArchive(filepath.Join(dir, "missing.yaml"))
+	require.NoError(t, err)
+	assert.Empty(t, a.Rules)
+}
+
+func TestArchive_SaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ArchiveFileName)
+
+	a := &Archive{}
+	a.Add(
+		Rule{ID: "r1", Category: "testing", Pattern: "p", Check: "c", Source: SourceList{"manual"}, Added: "2026-03-07"},
+		ArchiveReasonDuplicate,
+		"r2",
+	)
+
+	require.NoError(t, a.Save(path))
+
+	// Parent .forge directory must have been created.
+	_, err := os.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+
+	loaded, err := LoadArchive(path)
+	require.NoError(t, err)
+	require.Len(t, loaded.Rules, 1)
+	assert.Equal(t, "r1", loaded.Rules[0].ID)
+	assert.Equal(t, "testing", loaded.Rules[0].Category)
+	assert.Equal(t, "r2", loaded.Rules[0].SupersededBy)
+	assert.Equal(t, ArchiveReasonDuplicate, loaded.Rules[0].ArchiveReason)
+	assert.False(t, loaded.Rules[0].ArchivedAt.IsZero())
+}
+
+func TestArchive_AddReplacesExistingID(t *testing.T) {
+	a := &Archive{}
+	a.Add(Rule{ID: "dup", Check: "first"}, ArchiveReasonStale, "")
+	a.Add(Rule{ID: "dup", Check: "second"}, ArchiveReasonDuplicate, "winner")
+
+	require.Len(t, a.Rules, 1)
+	assert.Equal(t, "second", a.Rules[0].Check)
+	assert.Equal(t, ArchiveReasonDuplicate, a.Rules[0].ArchiveReason)
+	assert.Equal(t, "winner", a.Rules[0].SupersededBy)
+}
+
+func TestArchive_AddSetsTimestamps(t *testing.T) {
+	a := &Archive{}
+	before := time.Now().UTC().Add(-time.Second)
+	a.Add(Rule{ID: "r1"}, ArchiveReasonStale, "")
+	after := time.Now().UTC().Add(time.Second)
+
+	got := a.Rules[0]
+	assert.True(t, !got.ArchivedAt.Before(before) && !got.ArchivedAt.After(after), "ArchivedAt within window")
+	assert.True(t, !got.LastSeen.Before(before) && !got.LastSeen.After(after), "LastSeen within window")
+}
+
+func TestArchive_Find(t *testing.T) {
+	a := &Archive{}
+	a.Add(Rule{ID: "r1"}, ArchiveReasonStale, "")
+	a.Add(Rule{ID: "r2"}, ArchiveReasonDuplicate, "r3")
+
+	got, ok := a.Find("r2")
+	require.True(t, ok)
+	assert.Equal(t, "r2", got.ID)
+	assert.Equal(t, "r3", got.SupersededBy)
+
+	_, ok = a.Find("missing")
+	assert.False(t, ok)
+}
+
+func TestArchive_Remove(t *testing.T) {
+	a := &Archive{}
+	a.Add(Rule{ID: "r1"}, ArchiveReasonStale, "")
+	a.Add(Rule{ID: "r2"}, ArchiveReasonDuplicate, "r3")
+
+	removed, ok := a.Remove("r1")
+	require.True(t, ok)
+	assert.Equal(t, "r1", removed.ID)
+	assert.Len(t, a.Rules, 1)
+	assert.Equal(t, "r2", a.Rules[0].ID)
+
+	_, ok = a.Remove("missing")
+	assert.False(t, ok)
+	assert.Len(t, a.Rules, 1)
+}
+
+func TestArchivePath(t *testing.T) {
+	got := ArchivePath("/anvil")
+	assert.Equal(t, filepath.Join("/anvil", ".forge", "warden-rules.archive.yaml"), got)
+}


### PR DESCRIPTION
## Changes

- **Warden rule archive store** - Persist superseded or stale review rules to `.forge/warden-rules.archive.yaml` with reason and timestamps, plus `warden.archive_after_days` (default 180) and `warden.dedup_threshold` (default 0.6) config keys to drive future archive/dedup passes. (Forge-7pu1)

## Original Issue (task): Archive store + config keys

Create internal/warden/archive.go with types and Load/Save functions for .forge/warden-rules.archive.yaml. Define ArchivedRule struct embedding the existing Rule plus SupersededBy string, LastSeen time.Time, ArchivedAt time.Time, ArchiveReason string (one of 'duplicate'|'stale'). Provide functions: LoadArchive(path string) (*Archive, error), (*Archive).Save(path string) error, (*Archive).Add(rule Rule, reason, supersededBy string), (*Archive).Find(id string) (*ArchivedRule, bool), (*Archive).Remove(id string) (*ArchivedRule, bool). Add config keys warden.archive_after_days (default 180) and warden.dedup_threshold (default 0.6) to the existing settings struct/loader. This is the foundation other sub-tasks build on — Pass 1 and Pass 2 both write to this archive, and the restore subcommand reads from it.

---
Bead: Forge-7pu1 | Branch: forge/Forge-7pu1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->