### PR TITLE
Pass 1: Smelter near-duplicate consolidation (Forge-f3iv)

### DIFF
--- a/changelog.d/Forge-f3iv.md
+++ b/changelog.d/Forge-f3iv.md
@@ -1,0 +1,2 @@
+category: Added
+- **Smelter Pass 1 near-duplicate consolidation** - The Smelter now clusters active warden rules by category, scores pairwise Jaccard similarity over their pattern+check word bags, and asks the warden-stage provider to merge each cluster (>= `warden.dedup_threshold`) into a single canonical rule. Superseded rules move to the per-anvil archive with reason `duplicate` and `superseded_by` set, and the consolidation summary is appended to the Smelter PR commit message. (Forge-f3iv)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1070,7 +1070,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Always create the worker when enabled so hot-reload can update interval/paths.
 	// Run handles interval <= 0 by pausing the ticker until a positive value arrives.
 	if d.config().Settings.IsSmelterEnabled() {
-		d.smelterWorker = smelter.New(d.db, d.config().Settings.SmelterInterval, monitorAnvils)
+		d.smelterWorker = smelter.New(
+			d.db,
+			d.config().Settings.SmelterInterval,
+			monitorAnvils,
+			smelter.WithConsolidator(warden.DefaultConsolidationRunner()),
+			smelter.WithDedupThreshold(func() float64 {
+				return d.config().Settings.Warden.ResolvedDedupThreshold()
+			}),
+		)
 		go func() {
 			if err := d.smelterWorker.Run(ctx); err != nil && err != context.Canceled {
 				d.logger.Error("Smelter error", "error", err)

--- a/internal/smelter/smelter.go
+++ b/internal/smelter/smelter.go
@@ -14,6 +14,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -65,18 +66,49 @@ type Smelter struct {
 
 	// intervalCh signals Run to reset the ticker with a new duration.
 	intervalCh chan time.Duration
+
+	// consolidator is the AI invocation hook used by the consolidation pass.
+	// When nil, consolidation is skipped (legacy behavior). Set via
+	// WithConsolidator.
+	consolidator warden.ConsolidationRunner
+	// dedupThreshold returns the active similarity threshold. When nil or it
+	// returns <= 0, consolidation is skipped.
+	dedupThreshold func() float64
+}
+
+// Option configures a Smelter at construction time.
+type Option func(*Smelter)
+
+// WithConsolidator wires the AI invocation hook used by Pass 1 consolidation.
+// When the runner returns a JSON object with the merged rule fields, the
+// Smelter replaces the cluster members in the active rules file and moves
+// the originals to the archive store. Pass nil to disable consolidation.
+func WithConsolidator(runner warden.ConsolidationRunner) Option {
+	return func(s *Smelter) { s.consolidator = runner }
+}
+
+// WithDedupThreshold supplies a function the Smelter calls at flush time to
+// resolve the current dedup similarity threshold. A function (rather than a
+// value) is used so config hot-reload can take effect without restarting
+// the smelter. A nil function or one returning <= 0 disables consolidation.
+func WithDedupThreshold(fn func() float64) Option {
+	return func(s *Smelter) { s.dedupThreshold = fn }
 }
 
 // New creates a Smelter. interval controls how often Flush is called;
 // pass 0 to disable scheduled runs (Flush can still be called directly).
-func New(db *state.DB, interval time.Duration, anvilPaths map[string]string) *Smelter {
-	return &Smelter{
+func New(db *state.DB, interval time.Duration, anvilPaths map[string]string, opts ...Option) *Smelter {
+	s := &Smelter{
 		db:         db,
 		wtMgr:      worktree.NewManager(),
 		interval:   interval,
 		anvilPaths: anvilPaths,
 		intervalCh: make(chan time.Duration, 1),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // UpdateAnvilPaths replaces the set of anvils. Safe to call while Run is active.
@@ -317,8 +349,20 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 		flushedIDs = append(flushedIDs, pr.ID)
 	}
 
-	if added == 0 {
-		// All rules were duplicates (already in the file) or malformed. Delete from DB and emit a flush event.
+	// 2b. Pass 1 consolidation: cluster near-duplicate rules and merge each
+	//     cluster into a single canonical rule via the warden-stage AI. Runs
+	//     before save/commit so the merge lands in the same Smelter PR.
+	consolidationSummary, archived, err := s.runConsolidation(ctx, wt.Path, anvilName, rf)
+	if err != nil {
+		// Non-fatal: log and continue with whatever rules we have. The original
+		// (pre-consolidation) rules are still in rf because Consolidate only
+		// mutates rf when at least one cluster merged successfully.
+		log.Printf("[smelter] consolidation error for %s: %v", anvilName, err)
+	}
+
+	if added == 0 && len(consolidationSummary) == 0 {
+		// All rules were duplicates (already in the file) or malformed AND
+		// nothing was consolidated. Delete from DB and emit a flush event.
 		log.Printf("[smelter] All %d pending rule(s) for %s were duplicates or malformed — cleaning up", len(rules), anvilName)
 		if err := s.db.DeletePendingRules(flushedIDs); err != nil {
 			return err
@@ -336,8 +380,17 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 		return fmt.Errorf("saving warden rules for %s: %w", anvilName, err)
 	}
 
+	// 3b. Persist archived rules (replaced by consolidation) to the per-anvil
+	//     archive store. Done before commit so the archive file is part of the
+	//     same Smelter PR.
+	if len(archived) > 0 {
+		if err := s.archiveRules(wt.Path, archived, consolidationSummary); err != nil {
+			log.Printf("[smelter] archive write failed for %s: %v", anvilName, err)
+		}
+	}
+
 	// 4. Commit and force-push from the worktree.
-	if err := s.commitAndPush(ctx, wt.Path, branch, added); err != nil {
+	if err := s.commitAndPush(ctx, wt.Path, branch, added, consolidationSummary); err != nil {
 		return fmt.Errorf("commit/push for %s: %w", anvilName, err)
 	}
 
@@ -358,9 +411,68 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 	return nil
 }
 
+// runConsolidation invokes warden.Consolidate over the in-memory rules file
+// when a consolidator and positive threshold are configured. It returns the
+// per-cluster summary and the original rule entries that were superseded so
+// the caller can write them to the archive store. Errors that occur for
+// individual clusters are aggregated and returned but do not abort the pass.
+func (s *Smelter) runConsolidation(ctx context.Context, wtPath, anvilName string, rf *warden.RulesFile) ([]warden.MergeResult, []warden.Rule, error) {
+	if s.consolidator == nil || s.dedupThreshold == nil {
+		return nil, nil, nil
+	}
+	threshold := s.dedupThreshold()
+	if threshold <= 0 {
+		return nil, nil, nil
+	}
+	replaced, summary, errs := warden.Consolidate(ctx, wtPath, rf, threshold, s.consolidator)
+	if len(summary) > 0 {
+		log.Printf("[smelter] consolidated %d cluster(s) for %s", len(summary), anvilName)
+		_ = s.db.LogEvent(state.EventSmelterFlushed,
+			fmt.Sprintf("Consolidated %d cluster(s) for %s", len(summary), anvilName), "", anvilName)
+	}
+	var combined error
+	if len(errs) > 0 {
+		// Surface the first error verbatim; the rest go to the log.
+		for i, e := range errs {
+			if i == 0 {
+				combined = e
+				continue
+			}
+			log.Printf("[smelter] additional consolidation error for %s: %v", anvilName, e)
+		}
+	}
+	return summary, replaced, combined
+}
+
+// archiveRules persists the superseded rules to the per-anvil archive store
+// with reason="duplicate" and superseded_by set to the merged rule's ID.
+// summary is consulted so each archived rule is tagged with the correct
+// superseder.
+func (s *Smelter) archiveRules(wtPath string, archived []warden.Rule, summary []warden.MergeResult) error {
+	// Build map: originalID -> mergedID.
+	supersededBy := make(map[string]string, len(archived))
+	for _, m := range summary {
+		for _, id := range m.ReplacedIDs {
+			supersededBy[id] = m.Merged.ID
+		}
+	}
+
+	archivePath := warden.ArchivePath(wtPath)
+	archive, err := warden.LoadArchive(archivePath)
+	if err != nil {
+		return fmt.Errorf("loading archive: %w", err)
+	}
+	for _, r := range archived {
+		archive.Add(r, warden.ArchiveReasonDuplicate, supersededBy[r.ID])
+	}
+	return archive.Save(archivePath)
+}
+
 // commitAndPush stages the rules file, commits, and force-pushes from the
-// worktree. The worktree is already on the correct branch.
-func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, ruleCount int) error {
+// worktree. The worktree is already on the correct branch. When summary is
+// non-empty it is appended to the commit message body so reviewers can see
+// which clusters were merged.
+func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, ruleCount int, summary []warden.MergeResult) error {
 	gitEnv := cleanGitEnv()
 	git := func(args ...string) error {
 		cmdCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -376,13 +488,25 @@ func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, rule
 		return nil
 	}
 
-	// Stage the rules file.
+	// Stage the rules file and the archive file (when present — the
+	// archive may have been written by the consolidation pass).
 	if err := git("add", warden.RulesFileName); err != nil {
 		return err
 	}
+	if _, statErr := os.Stat(filepath.Join(wtPath, warden.ArchiveFileName)); statErr == nil {
+		if err := git("add", warden.ArchiveFileName); err != nil {
+			return err
+		}
+	}
 
-	// Commit with the specified message format.
-	commitMsg := fmt.Sprintf("forge: learn %d warden rule(s) from pending queue [no-changelog]", ruleCount)
+	// Build the commit message: keep the existing single-line subject for
+	// backwards compatibility, then append a structured consolidation
+	// summary body when Pass 1 merged any clusters.
+	subject := fmt.Sprintf("forge: learn %d warden rule(s) from pending queue [no-changelog]", ruleCount)
+	commitMsg := subject
+	if body := warden.FormatConsolidationSummary(summary); body != "" {
+		commitMsg = subject + "\n\n" + body
+	}
 	if err := git("commit", "-m", commitMsg); err != nil {
 		return err
 	}

--- a/internal/smelter/smelter.go
+++ b/internal/smelter/smelter.go
@@ -515,7 +515,15 @@ func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, rule
 	// Build the commit message: keep the existing single-line subject for
 	// backwards compatibility, then append a structured consolidation
 	// summary body when Pass 1 merged any clusters.
-	subject := fmt.Sprintf("forge: learn %d warden rule(s) from pending queue [no-changelog]", ruleCount)
+	var subject string
+	switch {
+	case ruleCount > 0 && len(summary) > 0:
+		subject = fmt.Sprintf("forge: learn %d warden rule(s), consolidate %d cluster(s) [no-changelog]", ruleCount, len(summary))
+	case len(summary) > 0:
+		subject = fmt.Sprintf("forge: consolidate %d warden rule cluster(s) [no-changelog]", len(summary))
+	default:
+		subject = fmt.Sprintf("forge: learn %d warden rule(s) from pending queue [no-changelog]", ruleCount)
+	}
 	commitMsg := subject
 	if body := warden.FormatConsolidationSummary(summary); body != "" {
 		commitMsg = subject + "\n\n" + body

--- a/internal/smelter/smelter.go
+++ b/internal/smelter/smelter.go
@@ -375,18 +375,13 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 		return nil
 	}
 
-	// 3. Save the updated rules file in the worktree.
-	if err := warden.SaveRules(wt.Path, rf); err != nil {
-		return fmt.Errorf("saving warden rules for %s: %w", anvilName, err)
-	}
-
-	// 3b. Persist archived rules (replaced by consolidation) to the per-anvil
-	//     archive store. Done before commit so the archive file is part of the
-	//     same Smelter PR.
-	if len(archived) > 0 {
-		if err := s.archiveRules(wt.Path, archived, consolidationSummary); err != nil {
-			log.Printf("[smelter] archive write failed for %s: %v", anvilName, err)
-		}
+	// 3. Persist the archive and active rules file. Archive must land first
+	//    so the active rules file can never be committed without a matching
+	//    archive entry for the rules it replaced (the bead contract). If
+	//    either step fails we abort before staging/commit/push, leaving the
+	//    pending queue intact for the next flush.
+	if err := s.persistRulesAndArchive(wt.Path, rf, archived, consolidationSummary); err != nil {
+		return fmt.Errorf("persisting warden rules for %s: %w", anvilName, err)
 	}
 
 	// 4. Commit and force-push from the worktree.
@@ -442,6 +437,24 @@ func (s *Smelter) runConsolidation(ctx context.Context, wtPath, anvilName string
 		}
 	}
 	return summary, replaced, combined
+}
+
+// persistRulesAndArchive writes the archive entries (when any) and then
+// saves the active rules file. Ordering is load-bearing: the archive must
+// land before the active rules file so a partial failure can never leave
+// the rules file on disk without a matching archive record for the rules
+// it superseded. Any error from either step is returned so callers can
+// abort the flush before staging/commit/push.
+func (s *Smelter) persistRulesAndArchive(wtPath string, rf *warden.RulesFile, archived []warden.Rule, summary []warden.MergeResult) error {
+	if len(archived) > 0 {
+		if err := s.archiveRules(wtPath, archived, summary); err != nil {
+			return fmt.Errorf("archiving consolidated rules: %w", err)
+		}
+	}
+	if err := warden.SaveRules(wtPath, rf); err != nil {
+		return fmt.Errorf("saving warden rules: %w", err)
+	}
+	return nil
 }
 
 // archiveRules persists the superseded rules to the per-anvil archive store

--- a/internal/smelter/smelter_test.go
+++ b/internal/smelter/smelter_test.go
@@ -2,6 +2,7 @@ package smelter
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -263,6 +264,128 @@ func TestFlush_MultipleRulesSameAnvil_AllProcessed(t *testing.T) {
 	assert.Len(t, byAnvil["anvil-a"], 3, "all 3 rules should be queried for anvil-a")
 }
 
+// stubConsolidator returns a runner that emits a fixed merged-rule JSON
+// payload for every call. Used by smelter consolidation tests.
+func stubConsolidator(t *testing.T, mergedID, pattern, check string) warden.ConsolidationRunner {
+	t.Helper()
+	return func(_ context.Context, _, _ string) ([]byte, error) {
+		body, err := json.Marshal(map[string]string{
+			"id":      mergedID,
+			"pattern": pattern,
+			"check":   check,
+		})
+		require.NoError(t, err)
+		return body, nil
+	}
+}
+
+// TestRunConsolidation_DisabledByDefault verifies that without explicit
+// configuration the consolidation pass is a no-op.
+func TestRunConsolidation_DisabledByDefault(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "shared word", Check: "shared concern"},
+		{ID: "r2", Category: "style", Pattern: "shared word", Check: "shared concern"},
+	}}
+
+	summary, replaced, err := s.runConsolidation(context.Background(), t.TempDir(), "anvil-a", rf)
+	require.NoError(t, err)
+	assert.Empty(t, summary)
+	assert.Empty(t, replaced)
+	assert.Len(t, rf.Rules, 2)
+}
+
+// TestRunConsolidation_MergesClusterAndPopulatesSummary verifies the smelter
+// integrates warden.Consolidate correctly and returns the summary metadata
+// needed for the commit message.
+func TestRunConsolidation_MergesClusterAndPopulatesSummary(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{},
+		WithConsolidator(stubConsolidator(t, "shared-concern", "shared pattern", "verify shared concern")),
+		WithDedupThreshold(func() float64 { return 0.3 }),
+	)
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "shared word here", Check: "verify shared concern", Source: warden.SourceList{"PR-1"}, Added: "2024-02-01"},
+		{ID: "r2", Category: "style", Pattern: "shared word there", Check: "ensure shared concern", Source: warden.SourceList{"PR-2"}, Added: "2024-01-01"},
+		// Unrelated rule should be untouched.
+		{ID: "r3", Category: "security", Pattern: "sql injection", Check: "use prepared statements"},
+	}}
+
+	summary, replaced, err := s.runConsolidation(context.Background(), t.TempDir(), "anvil-a", rf)
+	require.NoError(t, err)
+	require.Len(t, summary, 1)
+	assert.Equal(t, "style", summary[0].Category)
+	assert.ElementsMatch(t, []string{"r1", "r2"}, summary[0].ReplacedIDs)
+	assert.Equal(t, "shared-concern", summary[0].Merged.ID)
+	assert.Equal(t, "2024-01-01", summary[0].Merged.Added, "merged Added should be the oldest in cluster")
+	assert.Equal(t, warden.SourceList{"PR-1", "PR-2"}, summary[0].Merged.Source)
+
+	assert.Len(t, replaced, 2)
+
+	// Rules file should now contain r3 plus the merged rule.
+	ids := make([]string, 0, len(rf.Rules))
+	for _, r := range rf.Rules {
+		ids = append(ids, r.ID)
+	}
+	assert.ElementsMatch(t, []string{"r3", "shared-concern"}, ids)
+}
+
+// TestRunConsolidation_ZeroThresholdSkipsPass verifies that a zero threshold
+// disables consolidation even when a consolidator is wired.
+func TestRunConsolidation_ZeroThresholdSkipsPass(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{},
+		WithConsolidator(stubConsolidator(t, "m", "p", "c")),
+		WithDedupThreshold(func() float64 { return 0 }),
+	)
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "same", Check: "same"},
+		{ID: "r2", Category: "style", Pattern: "same", Check: "same"},
+	}}
+
+	summary, replaced, err := s.runConsolidation(context.Background(), t.TempDir(), "anvil-a", rf)
+	require.NoError(t, err)
+	assert.Empty(t, summary)
+	assert.Empty(t, replaced)
+	assert.Len(t, rf.Rules, 2)
+}
+
+// TestArchiveRules_WritesSupersededByCorrectly verifies the smelter archives
+// each replaced rule with reason=duplicate and the correct superseded_by ID.
+func TestArchiveRules_WritesSupersededByCorrectly(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+	archived := []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "p1", Check: "c1"},
+		{ID: "r2", Category: "style", Pattern: "p2", Check: "c2"},
+	}
+	summary := []warden.MergeResult{
+		{
+			Merged:      warden.Rule{ID: "merged-1", Category: "style"},
+			ReplacedIDs: []string{"r1", "r2"},
+			Category:    "style",
+		},
+	}
+
+	require.NoError(t, s.archiveRules(dir, archived, summary))
+
+	a, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, a.Rules, 2)
+
+	for _, ar := range a.Rules {
+		assert.Equal(t, warden.ArchiveReasonDuplicate, ar.ArchiveReason)
+		assert.Equal(t, "merged-1", ar.SupersededBy)
+		assert.False(t, ar.ArchivedAt.IsZero())
+	}
+}
+
 // TestCommitAndPush_FreshWorktreeWithExistingRemoteBranch verifies that
 // commitAndPush succeeds when the batch branch already exists on origin but
 // the local worktree has no remote-tracking ref (fresh creation path). The
@@ -350,6 +473,6 @@ func TestCommitAndPush_FreshWorktreeWithExistingRemoteBranch(t *testing.T) {
 
 	// commitAndPush must succeed: the fetch populates the remote-tracking ref
 	// so --force-with-lease can verify the lease and allow the push.
-	err = s.commitAndPush(ctx, localDir, branch, 1)
+	err = s.commitAndPush(ctx, localDir, branch, 1, nil)
 	require.NoError(t, err, "commitAndPush should succeed after fetching remote-tracking ref")
 }

--- a/internal/smelter/smelter_test.go
+++ b/internal/smelter/smelter_test.go
@@ -386,6 +386,96 @@ func TestArchiveRules_WritesSupersededByCorrectly(t *testing.T) {
 	}
 }
 
+// TestPersistRulesAndArchive_ArchiveFirstThenRules verifies the happy path:
+// when both archive and rules-file writes succeed, both files land on disk.
+func TestPersistRulesAndArchive_ArchiveFirstThenRules(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "merged-1", Category: "style", Pattern: "p", Check: "c"},
+	}}
+	archived := []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "p1", Check: "c1"},
+	}
+	summary := []warden.MergeResult{{
+		Merged:      warden.Rule{ID: "merged-1", Category: "style"},
+		ReplacedIDs: []string{"r1"},
+		Category:    "style",
+	}}
+
+	require.NoError(t, s.persistRulesAndArchive(dir, rf, archived, summary))
+
+	rulesData, err := os.ReadFile(filepath.Join(dir, warden.RulesFileName))
+	require.NoError(t, err)
+	assert.Contains(t, string(rulesData), "merged-1")
+
+	a, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, a.Rules, 1)
+	assert.Equal(t, "r1", a.Rules[0].ID)
+	assert.Equal(t, "merged-1", a.Rules[0].SupersededBy)
+}
+
+// TestPersistRulesAndArchive_ArchiveFailureAbortsRulesSave verifies the
+// load-bearing ordering invariant: if archive write fails, the active rules
+// file must NOT be written. Otherwise the smelter would commit a rules file
+// whose superseded entries have no archive record (bead-contract violation).
+func TestPersistRulesAndArchive_ArchiveFailureAbortsRulesSave(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+
+	// Force archive write to fail by creating a *directory* at the archive
+	// file path. os.WriteFile inside Archive.Save will then return EISDIR.
+	require.NoError(t, os.MkdirAll(filepath.Dir(warden.ArchivePath(dir)), 0o755))
+	require.NoError(t, os.MkdirAll(warden.ArchivePath(dir), 0o755))
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "merged-1", Category: "style", Pattern: "p", Check: "c"},
+	}}
+	archived := []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "p1", Check: "c1"},
+	}
+	summary := []warden.MergeResult{{
+		Merged:      warden.Rule{ID: "merged-1", Category: "style"},
+		ReplacedIDs: []string{"r1"},
+		Category:    "style",
+	}}
+
+	err := s.persistRulesAndArchive(dir, rf, archived, summary)
+	require.Error(t, err, "archive failure must propagate")
+	assert.Contains(t, err.Error(), "archiving consolidated rules")
+
+	// Critical: the active rules file must not have been written.
+	_, statErr := os.Stat(filepath.Join(dir, warden.RulesFileName))
+	assert.True(t, os.IsNotExist(statErr),
+		"active rules file must not be saved when archive write fails (got stat err: %v)", statErr)
+}
+
+// TestPersistRulesAndArchive_NoArchiveSkipsArchiveStep verifies that when
+// there are no consolidated rules to archive, the archive file is not
+// created — only the active rules file is written.
+func TestPersistRulesAndArchive_NoArchiveSkipsArchiveStep(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "p", Check: "c"},
+	}}
+
+	require.NoError(t, s.persistRulesAndArchive(dir, rf, nil, nil))
+
+	_, err := os.Stat(filepath.Join(dir, warden.RulesFileName))
+	assert.NoError(t, err, "rules file should be saved")
+
+	_, err = os.Stat(warden.ArchivePath(dir))
+	assert.True(t, os.IsNotExist(err), "archive file should not be created when nothing to archive")
+}
+
 // TestCommitAndPush_FreshWorktreeWithExistingRemoteBranch verifies that
 // commitAndPush succeeds when the batch branch already exists on origin but
 // the local worktree has no remote-tracking ref (fresh creation path). The

--- a/internal/warden/consolidate.go
+++ b/internal/warden/consolidate.go
@@ -252,14 +252,16 @@ func Consolidate(ctx context.Context, repoDir string, rf *RulesFile, threshold f
 				continue
 			}
 
-			// Free the cluster members' IDs from activeIDs before picking
-			// the merged ID — the merged rule may reasonably reuse one of
-			// the cluster's existing IDs without colliding.
+			// Pick the merged ID while the cluster members' IDs are still in
+			// activeIDs so the merged rule always gets an ID distinct from every
+			// replaced rule. Reusing a replaced ID would create a self-referential
+			// archive entry (superseded_by == own ID). Remove the replaced IDs
+			// from activeIDs only after the merged rule's ID has been chosen.
+			mergedRule := MergeRule(c.Rules, cat, pattern, check, suggestedID, activeIDs)
+			activeIDs[mergedRule.ID] = struct{}{}
 			for _, mem := range c.Rules {
 				delete(activeIDs, mem.ID)
 			}
-			mergedRule := MergeRule(c.Rules, cat, pattern, check, suggestedID, activeIDs)
-			activeIDs[mergedRule.ID] = struct{}{}
 
 			ids := make([]string, 0, len(c.Rules))
 			for _, mem := range c.Rules {

--- a/internal/warden/consolidate.go
+++ b/internal/warden/consolidate.go
@@ -1,0 +1,318 @@
+package warden
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ConsolidationRunner is the AI invocation hook for merging a cluster of
+// rules into a canonical single rule. It receives the working directory and
+// the prompt and returns the raw response bytes.
+//
+// In production this is satisfied by warden.DefaultConsolidationRunner.
+// Tests inject a stub that returns a deterministic JSON response.
+type ConsolidationRunner func(ctx context.Context, dir, prompt string) ([]byte, error)
+
+// DefaultConsolidationRunner returns a ConsolidationRunner that invokes the
+// standard warden-stage AI provider chain (Claude → Gemini fallback). Use
+// this when wiring the Smelter from the daemon.
+func DefaultConsolidationRunner() ConsolidationRunner {
+	return func(ctx context.Context, dir, prompt string) ([]byte, error) {
+		return aiRunner(ctx, dir, prompt)
+	}
+}
+
+// MergeResult describes one cluster consolidation outcome.
+type MergeResult struct {
+	// Merged is the new canonical rule replacing the cluster.
+	Merged Rule
+	// ReplacedIDs lists the IDs of the rules that were superseded by Merged.
+	ReplacedIDs []string
+	// Category is the shared category across the cluster.
+	Category string
+	// MaxSimilarity is the highest pairwise Jaccard score observed in the
+	// cluster (carried through from ClusterByJaccard).
+	MaxSimilarity float64
+}
+
+// DistillMergedRule asks the warden-stage AI provider to consolidate a
+// cluster of near-duplicate rules into one canonical rule. The cluster is
+// passed verbatim; the response must be a single JSON object describing the
+// merged rule's pattern and check. The caller is responsible for stitching
+// in metadata (sources, added timestamp, ID).
+//
+// runner is the AI invocation function. When nil, aiRunner is used so this
+// helper works with the standard provider fallback chain.
+func DistillMergedRule(ctx context.Context, repoDir string, cluster []Rule, runner ConsolidationRunner) (pattern, check string, suggestedID string, err error) {
+	if len(cluster) < 2 {
+		return "", "", "", fmt.Errorf("DistillMergedRule: cluster must contain at least 2 rules (got %d)", len(cluster))
+	}
+	if runner == nil {
+		runner = aiRunner
+	}
+
+	prompt := buildConsolidationPrompt(cluster)
+	raw, err := runner(ctx, repoDir, prompt)
+	if err != nil {
+		return "", "", "", fmt.Errorf("ai consolidate: %w", err)
+	}
+
+	output := strings.TrimSpace(string(raw))
+	jsonStr := extractJSON(output, "check")
+	if jsonStr == "" {
+		jsonStr = output
+	}
+
+	var parsed struct {
+		ID      string `json:"id"`
+		Pattern string `json:"pattern"`
+		Check   string `json:"check"`
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		return "", "", "", fmt.Errorf("parsing merged rule: %w (output: %s)", err, output)
+	}
+	if strings.TrimSpace(parsed.Check) == "" {
+		return "", "", "", fmt.Errorf("merged rule missing required field: check")
+	}
+
+	return parsed.Pattern, parsed.Check, parsed.ID, nil
+}
+
+// buildConsolidationPrompt renders the warden-stage AI prompt for merging a
+// cluster of similar rules into a single canonical rule.
+func buildConsolidationPrompt(cluster []Rule) string {
+	var sb strings.Builder
+	sb.WriteString("You are consolidating a set of near-duplicate code review rules into a single canonical rule.\n\n")
+	sb.WriteString("Each rule below targets a similar concern. Produce ONE merged rule whose `pattern` and `check` describe the shared intent clearly and concisely. Do not narrow the scope so much that any individual rule's concern is dropped.\n\n")
+	sb.WriteString("## Rules to Consolidate\n\n")
+	for i, r := range cluster {
+		fmt.Fprintf(&sb, "### Rule %d (id: %s)\n- pattern: %s\n- check: %s\n\n", i+1, r.ID, r.Pattern, r.Check)
+	}
+	sb.WriteString("## Output Format\n\n")
+	sb.WriteString("Respond with ONLY a JSON object (no markdown fences, no explanation) in this exact format:\n\n")
+	sb.WriteString(`{"id": "short-kebab-case-id", "pattern": "shared pattern", "check": "what reviewers must verify"}`)
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// MergeMetadata combines the deduplicated source list and oldest Added
+// timestamp from a cluster of rules. Returned Added is in YYYY-MM-DD form;
+// if no cluster member carries a parseable Added date, the returned string
+// is empty (callers can default to "today").
+func MergeMetadata(cluster []Rule) (sources SourceList, oldestAdded string) {
+	seen := make(map[string]struct{})
+	var dedup []string
+	for _, r := range cluster {
+		for _, s := range r.Source {
+			if s == "" {
+				continue
+			}
+			if _, ok := seen[s]; ok {
+				continue
+			}
+			seen[s] = struct{}{}
+			dedup = append(dedup, s)
+		}
+	}
+	sort.Strings(dedup)
+	sources = SourceList(dedup)
+
+	const layout = "2006-01-02"
+	var oldest time.Time
+	for _, r := range cluster {
+		if r.Added == "" {
+			continue
+		}
+		t, err := time.Parse(layout, r.Added)
+		if err != nil {
+			continue
+		}
+		if oldest.IsZero() || t.Before(oldest) {
+			oldest = t
+		}
+	}
+	if !oldest.IsZero() {
+		oldestAdded = oldest.Format(layout)
+	}
+	return sources, oldestAdded
+}
+
+// MergeRule builds the canonical merged Rule from a cluster, the AI-derived
+// pattern/check, and a freshly minted ID. existingIDs is consulted so the
+// generated ID does not collide with active rules in the file; when a
+// collision is found, a numeric suffix is appended.
+func MergeRule(cluster []Rule, category, pattern, check, suggestedID string, existingIDs map[string]struct{}) Rule {
+	sources, oldestAdded := MergeMetadata(cluster)
+	if oldestAdded == "" {
+		oldestAdded = time.Now().UTC().Format("2006-01-02")
+	}
+
+	id := pickMergedID(suggestedID, cluster, existingIDs)
+
+	// Union paths across cluster members; preserve first-seen order so the
+	// merged rule still applies wherever its parents applied.
+	var paths []string
+	pathSeen := make(map[string]struct{})
+	for _, r := range cluster {
+		for _, p := range r.Paths {
+			if _, ok := pathSeen[p]; ok {
+				continue
+			}
+			pathSeen[p] = struct{}{}
+			paths = append(paths, p)
+		}
+	}
+
+	return Rule{
+		ID:       id,
+		Category: category,
+		Pattern:  pattern,
+		Check:    check,
+		Source:   sources,
+		Added:    oldestAdded,
+		Paths:    paths,
+	}
+}
+
+// pickMergedID chooses an ID for the merged rule. It prefers a non-empty
+// AI-suggested ID, falls back to "merged-<first-id>" when none is given,
+// and appends "-N" if the chosen ID collides with existing rules.
+func pickMergedID(suggested string, cluster []Rule, existingIDs map[string]struct{}) string {
+	base := strings.TrimSpace(suggested)
+	if base == "" {
+		if len(cluster) > 0 && cluster[0].ID != "" {
+			base = "merged-" + cluster[0].ID
+		} else {
+			base = "merged-rule"
+		}
+	}
+	if _, clash := existingIDs[base]; !clash {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if _, clash := existingIDs[candidate]; !clash {
+			return candidate
+		}
+	}
+}
+
+// Consolidate runs the full consolidation pass over rf.Rules: it groups
+// rules by category, clusters within each category at the given threshold,
+// asks runner to merge each cluster, and replaces the cluster members in rf
+// with their merged rule. Replaced rules are returned so the caller can
+// archive them. The summary slice lists one MergeResult per consolidated
+// cluster, suitable for inclusion in a commit message.
+//
+// Behaviour notes:
+//   - Categories with fewer than 2 rules are skipped (no clustering possible).
+//   - When threshold <= 0, the pass is a no-op (returns nil, nil, nil).
+//   - When runner returns an error for a specific cluster the cluster is
+//     skipped (logged via the returned error slice) so a single AI failure
+//     does not block other consolidations from completing.
+//
+// runner may be nil; the default aiRunner is used in that case. Callers
+// wanting a specific warden-stage provider chain should pass a runner built
+// for that chain (e.g. via DefaultConsolidationRunner).
+func Consolidate(ctx context.Context, repoDir string, rf *RulesFile, threshold float64, runner ConsolidationRunner) (replaced []Rule, summary []MergeResult, errs []error) {
+	if rf == nil || threshold <= 0 || len(rf.Rules) < 2 {
+		return nil, nil, nil
+	}
+
+	catOrder, byCat := GroupRulesByCategory(rf.Rules)
+
+	// Track which rule IDs are removed so we can rebuild rf.Rules in
+	// stable order after all clusters are processed.
+	removed := make(map[string]struct{})
+	var merged []Rule
+
+	// Set of currently active IDs (excludes removed) for collision checking
+	// when picking the merged ID.
+	activeIDs := make(map[string]struct{}, len(rf.Rules))
+	for _, r := range rf.Rules {
+		if r.ID != "" {
+			activeIDs[r.ID] = struct{}{}
+		}
+	}
+
+	for _, cat := range catOrder {
+		rules := byCat[cat]
+		if len(rules) < 2 {
+			continue
+		}
+		clusters := ClusterByJaccard(rules, threshold)
+		for _, c := range clusters {
+			pattern, check, suggestedID, err := DistillMergedRule(ctx, repoDir, c.Rules, runner)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("consolidating cluster (category=%s, size=%d): %w", cat, len(c.Rules), err))
+				continue
+			}
+
+			// Free the cluster members' IDs from activeIDs before picking
+			// the merged ID — the merged rule may reasonably reuse one of
+			// the cluster's existing IDs without colliding.
+			for _, mem := range c.Rules {
+				delete(activeIDs, mem.ID)
+			}
+			mergedRule := MergeRule(c.Rules, cat, pattern, check, suggestedID, activeIDs)
+			activeIDs[mergedRule.ID] = struct{}{}
+
+			ids := make([]string, 0, len(c.Rules))
+			for _, mem := range c.Rules {
+				removed[mem.ID] = struct{}{}
+				replaced = append(replaced, mem)
+				ids = append(ids, mem.ID)
+			}
+			merged = append(merged, mergedRule)
+
+			summary = append(summary, MergeResult{
+				Merged:        mergedRule,
+				ReplacedIDs:   ids,
+				Category:      cat,
+				MaxSimilarity: c.MaxSimilarity,
+			})
+		}
+	}
+
+	if len(merged) == 0 {
+		return nil, nil, errs
+	}
+
+	// Rebuild rf.Rules: keep original order minus removed, then append
+	// merged rules at the end so the active file remains diff-readable.
+	newRules := make([]Rule, 0, len(rf.Rules)-len(replaced)+len(merged))
+	for _, r := range rf.Rules {
+		if _, gone := removed[r.ID]; gone {
+			continue
+		}
+		newRules = append(newRules, r)
+	}
+	newRules = append(newRules, merged...)
+	rf.Rules = newRules
+
+	return replaced, summary, errs
+}
+
+// FormatConsolidationSummary renders a human-readable bullet list of the
+// consolidations performed in a smelter run. Used in the commit/PR body.
+// Returns "" when summary is empty so callers can omit the section entirely.
+func FormatConsolidationSummary(summary []MergeResult) string {
+	if len(summary) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("Consolidated near-duplicate rules:\n")
+	for _, r := range summary {
+		cat := r.Category
+		if cat == "" {
+			cat = "(no category)"
+		}
+		fmt.Fprintf(&sb, "- [%s] %s ← %s (sim=%.2f)\n",
+			cat, r.Merged.ID, strings.Join(r.ReplacedIDs, ", "), r.MaxSimilarity)
+	}
+	return sb.String()
+}

--- a/internal/warden/consolidate_test.go
+++ b/internal/warden/consolidate_test.go
@@ -1,0 +1,191 @@
+package warden
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMergedRule is what the stub runner returns when invoked.
+type fakeMergedRule struct {
+	ID      string `json:"id"`
+	Pattern string `json:"pattern"`
+	Check   string `json:"check"`
+}
+
+func stubRunner(t *testing.T, response fakeMergedRule) ConsolidationRunner {
+	t.Helper()
+	return func(_ context.Context, _, _ string) ([]byte, error) {
+		data, err := json.Marshal(response)
+		require.NoError(t, err)
+		return data, nil
+	}
+}
+
+func TestDistillMergedRule_ParsesResponse(t *testing.T) {
+	cluster := []Rule{
+		{ID: "r1", Pattern: "missing error", Check: "check err"},
+		{ID: "r2", Pattern: "unchecked error", Check: "verify error handling"},
+	}
+	runner := stubRunner(t, fakeMergedRule{ID: "err-check", Pattern: "missing error check", Check: "verify errors are handled"})
+
+	p, c, id, err := DistillMergedRule(context.Background(), t.TempDir(), cluster, runner)
+	require.NoError(t, err)
+	assert.Equal(t, "missing error check", p)
+	assert.Equal(t, "verify errors are handled", c)
+	assert.Equal(t, "err-check", id)
+}
+
+func TestDistillMergedRule_RejectsClusterSmallerThanTwo(t *testing.T) {
+	_, _, _, err := DistillMergedRule(context.Background(), "", []Rule{{ID: "r1"}}, stubRunner(t, fakeMergedRule{}))
+	require.Error(t, err)
+}
+
+func TestDistillMergedRule_RejectsMissingCheckField(t *testing.T) {
+	cluster := []Rule{{ID: "r1", Check: "a"}, {ID: "r2", Check: "b"}}
+	runner := stubRunner(t, fakeMergedRule{ID: "x", Pattern: "p", Check: ""})
+	_, _, _, err := DistillMergedRule(context.Background(), "", cluster, runner)
+	require.Error(t, err)
+}
+
+func TestMergeMetadata_UnionsSourcesAndPicksOldestAdded(t *testing.T) {
+	cluster := []Rule{
+		{Source: SourceList{"copilot:PR#1", "copilot:PR#2"}, Added: "2025-01-15"},
+		{Source: SourceList{"copilot:PR#2", "copilot:PR#3"}, Added: "2024-12-01"},
+		{Source: SourceList{}, Added: ""},
+	}
+	sources, added := MergeMetadata(cluster)
+	assert.Equal(t, SourceList{"copilot:PR#1", "copilot:PR#2", "copilot:PR#3"}, sources)
+	assert.Equal(t, "2024-12-01", added)
+}
+
+func TestMergeMetadata_EmptyClusterReturnsEmpty(t *testing.T) {
+	sources, added := MergeMetadata(nil)
+	assert.Empty(t, sources)
+	assert.Empty(t, added)
+}
+
+func TestMergeRule_SetsAllFields(t *testing.T) {
+	cluster := []Rule{
+		{ID: "r1", Source: SourceList{"PR-1"}, Added: "2024-01-01", Paths: []string{"**/*.go"}},
+		{ID: "r2", Source: SourceList{"PR-2"}, Added: "2023-06-01", Paths: []string{"**/*.go", "**/*.ts"}},
+	}
+	merged := MergeRule(cluster, "style", "shared pattern", "verify x", "err-check", map[string]struct{}{})
+	assert.Equal(t, "err-check", merged.ID)
+	assert.Equal(t, "style", merged.Category)
+	assert.Equal(t, "shared pattern", merged.Pattern)
+	assert.Equal(t, "verify x", merged.Check)
+	assert.Equal(t, "2023-06-01", merged.Added)
+	assert.Equal(t, SourceList{"PR-1", "PR-2"}, merged.Source)
+	assert.Equal(t, []string{"**/*.go", "**/*.ts"}, merged.Paths)
+}
+
+func TestMergeRule_GeneratesNonCollidingID(t *testing.T) {
+	cluster := []Rule{{ID: "r1"}, {ID: "r2"}}
+	existing := map[string]struct{}{"err-check": {}, "err-check-2": {}}
+	merged := MergeRule(cluster, "style", "p", "c", "err-check", existing)
+	assert.Equal(t, "err-check-3", merged.ID)
+}
+
+func TestMergeRule_FallbackIDWhenSuggestionEmpty(t *testing.T) {
+	cluster := []Rule{{ID: "r1"}, {ID: "r2"}}
+	merged := MergeRule(cluster, "style", "p", "c", "", map[string]struct{}{})
+	assert.Equal(t, "merged-r1", merged.ID)
+}
+
+func TestConsolidate_GroupsByCategoryAndMerges(t *testing.T) {
+	rf := &RulesFile{Rules: []Rule{
+		// Cluster A in "style"
+		{ID: "a1", Category: "style", Pattern: "missing comma trailing", Check: "verify trailing comma", Source: SourceList{"PR-1"}, Added: "2024-01-01"},
+		{ID: "a2", Category: "style", Pattern: "trailing comma missing", Check: "ensure trailing comma present", Source: SourceList{"PR-2"}, Added: "2024-02-01"},
+		// Different category, no cluster
+		{ID: "b1", Category: "security", Pattern: "sql injection risk", Check: "use parameterized queries"},
+		// Singleton in "style"
+		{ID: "a3", Category: "style", Pattern: "unrelated thing", Check: "different concern"},
+	}}
+
+	runner := stubRunner(t, fakeMergedRule{ID: "trailing-comma", Pattern: "trailing comma missing", Check: "verify trailing comma is present"})
+
+	replaced, summary, errs := Consolidate(context.Background(), t.TempDir(), rf, 0.3, runner)
+	require.Empty(t, errs)
+	require.Len(t, summary, 1)
+	require.Len(t, replaced, 2)
+
+	// Verify summary metadata.
+	assert.Equal(t, "style", summary[0].Category)
+	assert.ElementsMatch(t, []string{"a1", "a2"}, summary[0].ReplacedIDs)
+	assert.Equal(t, "trailing-comma", summary[0].Merged.ID)
+	// Sources should be unioned and sorted.
+	assert.Equal(t, SourceList{"PR-1", "PR-2"}, summary[0].Merged.Source)
+	// Added should pick the oldest.
+	assert.Equal(t, "2024-01-01", summary[0].Merged.Added)
+
+	// Verify the rules file: a1/a2 gone, b1 + a3 + merged remain.
+	ids := []string{}
+	for _, r := range rf.Rules {
+		ids = append(ids, r.ID)
+	}
+	assert.ElementsMatch(t, []string{"b1", "a3", "trailing-comma"}, ids)
+}
+
+func TestConsolidate_BelowThresholdIsNoop(t *testing.T) {
+	rf := &RulesFile{Rules: []Rule{
+		{ID: "r1", Category: "style", Pattern: "alpha", Check: "beta"},
+		{ID: "r2", Category: "style", Pattern: "gamma", Check: "delta"},
+	}}
+	replaced, summary, errs := Consolidate(context.Background(), t.TempDir(), rf, 0.99, stubRunner(t, fakeMergedRule{ID: "m", Check: "c"}))
+	assert.Empty(t, errs)
+	assert.Empty(t, summary)
+	assert.Empty(t, replaced)
+	assert.Len(t, rf.Rules, 2, "no rules should be removed when nothing clusters")
+}
+
+func TestConsolidate_ZeroThresholdIsNoop(t *testing.T) {
+	rf := &RulesFile{Rules: []Rule{
+		{ID: "r1", Category: "style", Pattern: "alpha", Check: "beta"},
+		{ID: "r2", Category: "style", Pattern: "alpha", Check: "beta"},
+	}}
+	// threshold=0 disables the pass entirely
+	replaced, summary, errs := Consolidate(context.Background(), t.TempDir(), rf, 0, stubRunner(t, fakeMergedRule{ID: "m", Check: "c"}))
+	assert.Empty(t, errs)
+	assert.Empty(t, summary)
+	assert.Empty(t, replaced)
+}
+
+func TestConsolidate_RunnerErrorIsIsolated(t *testing.T) {
+	rf := &RulesFile{Rules: []Rule{
+		{ID: "r1", Category: "style", Pattern: "shared word here", Check: "verify shared"},
+		{ID: "r2", Category: "style", Pattern: "shared word again", Check: "ensure shared"},
+	}}
+	failing := ConsolidationRunner(func(_ context.Context, _, _ string) ([]byte, error) {
+		return nil, assert.AnError
+	})
+	replaced, summary, errs := Consolidate(context.Background(), t.TempDir(), rf, 0.3, failing)
+	assert.Empty(t, summary)
+	assert.Empty(t, replaced)
+	assert.Len(t, errs, 1)
+	assert.Len(t, rf.Rules, 2, "rules unchanged when AI fails")
+}
+
+func TestFormatConsolidationSummary_Empty(t *testing.T) {
+	assert.Equal(t, "", FormatConsolidationSummary(nil))
+}
+
+func TestFormatConsolidationSummary_RendersBullets(t *testing.T) {
+	got := FormatConsolidationSummary([]MergeResult{
+		{
+			Merged:        Rule{ID: "merged-1"},
+			ReplacedIDs:   []string{"r1", "r2"},
+			Category:      "style",
+			MaxSimilarity: 0.72,
+		},
+	})
+	assert.True(t, strings.Contains(got, "merged-1"))
+	assert.True(t, strings.Contains(got, "r1, r2"))
+	assert.True(t, strings.Contains(got, "[style]"))
+	assert.True(t, strings.Contains(got, "0.72"))
+}

--- a/internal/warden/similarity.go
+++ b/internal/warden/similarity.go
@@ -1,0 +1,202 @@
+package warden
+
+import (
+	"strings"
+	"unicode"
+)
+
+// TokenSet is the bag-of-words representation used by Jaccard similarity.
+// It is a set keyed by lowercase token; values are unused (struct{}).
+type TokenSet map[string]struct{}
+
+// minTokenLen is the minimum length for a token to be retained after
+// tokenization. Shorter tokens (e.g. "is", "to", "be") add noise without
+// improving similarity discrimination.
+const minTokenLen = 3
+
+// Tokenize splits s into a set of significant lowercase word tokens:
+//   - Splits on any non-alphanumeric rune.
+//   - Lowercases every token.
+//   - Drops tokens shorter than minTokenLen.
+//   - Drops stopwords (defined in learn.go).
+//
+// Returns an empty (non-nil) set for empty or all-stopword input so callers
+// can safely range over the result without nil checks.
+func Tokenize(s string) TokenSet {
+	out := make(TokenSet)
+	if s == "" {
+		return out
+	}
+	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	for _, w := range fields {
+		if len(w) < minTokenLen {
+			continue
+		}
+		if stopWords[w] {
+			continue
+		}
+		out[w] = struct{}{}
+	}
+	return out
+}
+
+// Jaccard returns |A ∩ B| / |A ∪ B|. Returns 0 when the union is empty so
+// callers can treat "no shared signal" as "not similar" rather than divide
+// by zero.
+func Jaccard(a, b TokenSet) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	// Iterate over the smaller set for O(min(|a|,|b|)) intersection.
+	small, large := a, b
+	if len(small) > len(large) {
+		small, large = large, small
+	}
+	for t := range small {
+		if _, ok := large[t]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// RuleWordBag returns the union of tokens from a rule's Pattern and Check
+// fields. This is the canonical bag-of-words used to score rule similarity.
+func RuleWordBag(r Rule) TokenSet {
+	bag := Tokenize(r.Pattern)
+	for t := range Tokenize(r.Check) {
+		bag[t] = struct{}{}
+	}
+	return bag
+}
+
+// Cluster represents a group of rules that the similarity pass considers
+// near-duplicates. MaxSimilarity is the highest Jaccard score observed
+// between any pair in the cluster (useful for surfacing diagnostics).
+type Cluster struct {
+	Rules         []Rule
+	MaxSimilarity float64
+}
+
+// ClusterByJaccard groups rules whose pairwise Jaccard similarity on
+// RuleWordBag meets or exceeds threshold. Clustering uses union-find:
+// every pair scoring >= threshold is unioned, so transitive matches end up
+// in the same cluster even when not all pairs cross the threshold directly.
+//
+// Only clusters containing more than one rule are returned; singletons
+// (rules with no similar neighbours) are dropped. The order of returned
+// clusters mirrors the order of the first rule in each cluster as it
+// appeared in the input — stable for deterministic downstream processing.
+func ClusterByJaccard(rules []Rule, threshold float64) []Cluster {
+	n := len(rules)
+	if n < 2 {
+		return nil
+	}
+
+	// Pre-compute word bags once.
+	bags := make([]TokenSet, n)
+	for i, r := range rules {
+		bags[i] = RuleWordBag(r)
+	}
+
+	// Union-find over rule indices.
+	parent := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		for parent[x] != x {
+			parent[x] = parent[parent[x]]
+			x = parent[x]
+		}
+		return x
+	}
+
+	// Track the max similarity per cluster root so we can report it later.
+	maxSim := make(map[int]float64, n)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			sim := Jaccard(bags[i], bags[j])
+			if sim < threshold {
+				continue
+			}
+			ri, rj := find(i), find(j)
+			if ri != rj {
+				parent[ri] = rj
+			}
+			// Record max similarity against the (new) root.
+			root := find(i)
+			if sim > maxSim[root] {
+				maxSim[root] = sim
+			}
+		}
+	}
+
+	// Collect clusters in first-occurrence order.
+	type bucket struct {
+		members []int
+		firstIx int
+	}
+	buckets := make(map[int]*bucket)
+	for i := 0; i < n; i++ {
+		root := find(i)
+		b, ok := buckets[root]
+		if !ok {
+			b = &bucket{firstIx: i}
+			buckets[root] = b
+		}
+		b.members = append(b.members, i)
+	}
+
+	// Sort by firstIx to keep output deterministic.
+	roots := make([]int, 0, len(buckets))
+	for r := range buckets {
+		roots = append(roots, r)
+	}
+	// Simple insertion sort — small N (clusters per category).
+	for i := 1; i < len(roots); i++ {
+		for j := i; j > 0 && buckets[roots[j-1]].firstIx > buckets[roots[j]].firstIx; j-- {
+			roots[j-1], roots[j] = roots[j], roots[j-1]
+		}
+	}
+
+	var out []Cluster
+	for _, root := range roots {
+		b := buckets[root]
+		if len(b.members) < 2 {
+			continue
+		}
+		c := Cluster{
+			Rules:         make([]Rule, 0, len(b.members)),
+			MaxSimilarity: maxSim[root],
+		}
+		for _, ix := range b.members {
+			c.Rules = append(c.Rules, rules[ix])
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// GroupRulesByCategory partitions rules by Category, preserving first-seen
+// order within each category and across categories. Rules with an empty
+// Category are grouped under "".
+func GroupRulesByCategory(rules []Rule) ([]string, map[string][]Rule) {
+	var order []string
+	byCat := make(map[string][]Rule)
+	for _, r := range rules {
+		if _, ok := byCat[r.Category]; !ok {
+			order = append(order, r.Category)
+		}
+		byCat[r.Category] = append(byCat[r.Category], r)
+	}
+	return order, byCat
+}

--- a/internal/warden/similarity.go
+++ b/internal/warden/similarity.go
@@ -3,6 +3,7 @@ package warden
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // TokenSet is the bag-of-words representation used by Jaccard similarity.
@@ -31,7 +32,7 @@ func Tokenize(s string) TokenSet {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	})
 	for _, w := range fields {
-		if len(w) < minTokenLen {
+		if utf8.RuneCountInString(w) < minTokenLen {
 			continue
 		}
 		if stopWords[w] {
@@ -130,6 +131,11 @@ func ClusterByJaccard(rules []Rule, threshold float64) []Cluster {
 			}
 			ri, rj := find(i), find(j)
 			if ri != rj {
+				// Carry the losing root's accumulated maxSim to the winner
+				// before re-parenting so it isn't orphaned.
+				if maxSim[ri] > maxSim[rj] {
+					maxSim[rj] = maxSim[ri]
+				}
 				parent[ri] = rj
 			}
 			// Record max similarity against the (new) root.

--- a/internal/warden/similarity_test.go
+++ b/internal/warden/similarity_test.go
@@ -114,13 +114,13 @@ func TestClusterByJaccard_NoMerge(t *testing.T) {
 }
 
 func TestClusterByJaccard_BoundaryThreshold(t *testing.T) {
-	// Two rules whose Jaccard is exactly the threshold should cluster.
+	// Two rules whose Jaccard equals the threshold exactly should cluster.
 	rules := []Rule{
 		{ID: "r1", Pattern: "alpha beta", Check: "gamma delta"},   // {alpha, beta, gamma, delta}
 		{ID: "r2", Pattern: "alpha epsilon", Check: "zeta gamma"}, // {alpha, epsilon, zeta, gamma}
 	}
-	// intersection: {alpha, gamma} = 2; union: 6; jaccard = 2/6 ≈ 0.333
-	clusters := ClusterByJaccard(rules, 0.33)
+	// intersection: {alpha, gamma} = 2; union: 6; jaccard = 2/6 exactly
+	clusters := ClusterByJaccard(rules, 2.0/6.0)
 	assert.Len(t, clusters, 1, "boundary case should still cluster when sim >= threshold")
 	clusters = ClusterByJaccard(rules, 0.5)
 	assert.Empty(t, clusters)

--- a/internal/warden/similarity_test.go
+++ b/internal/warden/similarity_test.go
@@ -1,0 +1,155 @@
+package warden
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenize_BasicSplitAndLowercase(t *testing.T) {
+	got := Tokenize("Database Connection Leak Detected")
+	for _, want := range []string{"database", "connection", "leak", "detected"} {
+		_, ok := got[want]
+		assert.True(t, ok, "expected token %q in set", want)
+	}
+}
+
+func TestTokenize_DropsShortAndStopwords(t *testing.T) {
+	got := Tokenize("the err is not nil")
+	// "the" is a stopword, "is" / "not" too short or stopword, "nil" passes (3 chars, not stopword)
+	_, hasErr := got["err"]
+	_, hasNil := got["nil"]
+	assert.True(t, hasErr, "expected 'err' to be tokenized")
+	assert.True(t, hasNil, "expected 'nil' to be tokenized")
+	_, hasThe := got["the"]
+	assert.False(t, hasThe, "'the' should be dropped as a stopword")
+}
+
+func TestTokenize_EmptyInput(t *testing.T) {
+	got := Tokenize("")
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestTokenize_NonAlphanumericSeparators(t *testing.T) {
+	got := Tokenize("error.handling/missing-check")
+	for _, want := range []string{"error", "handling", "missing", "check"} {
+		_, ok := got[want]
+		assert.True(t, ok, "expected token %q", want)
+	}
+}
+
+func TestJaccard_Identical(t *testing.T) {
+	a := Tokenize("missing error check")
+	assert.InDelta(t, 1.0, Jaccard(a, a), 1e-9)
+}
+
+func TestJaccard_Disjoint(t *testing.T) {
+	a := Tokenize("database connection leak")
+	b := Tokenize("button label spelling")
+	assert.InDelta(t, 0.0, Jaccard(a, b), 1e-9)
+}
+
+func TestJaccard_PartialOverlap(t *testing.T) {
+	a := Tokenize("missing error check return")  // 4
+	b := Tokenize("unchecked error return value") // 4 (unchecked, error, return, value)
+	// intersection: {error, return} = 2
+	// union: {missing, error, check, return, unchecked, value} = 6
+	got := Jaccard(a, b)
+	assert.InDelta(t, 2.0/6.0, got, 1e-9)
+}
+
+func TestJaccard_EmptyInputs(t *testing.T) {
+	assert.Equal(t, 0.0, Jaccard(TokenSet{}, TokenSet{}))
+	assert.Equal(t, 0.0, Jaccard(Tokenize("anything"), TokenSet{}))
+}
+
+func TestRuleWordBag_MergesPatternAndCheck(t *testing.T) {
+	r := Rule{Pattern: "missing error check", Check: "verify error handling"}
+	bag := RuleWordBag(r)
+	for _, tok := range []string{"missing", "error", "check", "verify", "handling"} {
+		_, ok := bag[tok]
+		assert.True(t, ok, "expected token %q in bag", tok)
+	}
+}
+
+func TestClusterByJaccard_SingleCluster(t *testing.T) {
+	rules := []Rule{
+		{ID: "r1", Pattern: "missing error check", Check: "verify error handling"},
+		{ID: "r2", Pattern: "unchecked error return", Check: "verify error handling on returns"},
+	}
+	clusters := ClusterByJaccard(rules, 0.3)
+	require := assert.New(t)
+	require.Len(clusters, 1)
+	require.Len(clusters[0].Rules, 2)
+	require.Greater(clusters[0].MaxSimilarity, 0.3)
+}
+
+func TestClusterByJaccard_MultipleClusters(t *testing.T) {
+	rules := []Rule{
+		{ID: "r1", Pattern: "missing error check", Check: "error handling"},
+		{ID: "r2", Pattern: "unchecked error", Check: "error handling on return"},
+		{ID: "r3", Pattern: "spelling mistake", Check: "verify spelling in button"},
+		{ID: "r4", Pattern: "button label typo", Check: "spelling consistency button"},
+	}
+	clusters := ClusterByJaccard(rules, 0.3)
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(clusters))
+	}
+	// Cluster order is by first occurrence: r1's cluster, then r3's.
+	assert.Equal(t, "r1", clusters[0].Rules[0].ID)
+	assert.Equal(t, "r3", clusters[1].Rules[0].ID)
+}
+
+func TestClusterByJaccard_NoMerge(t *testing.T) {
+	rules := []Rule{
+		{ID: "r1", Pattern: "alpha beta", Check: "gamma"},
+		{ID: "r2", Pattern: "delta", Check: "epsilon"},
+	}
+	clusters := ClusterByJaccard(rules, 0.5)
+	assert.Empty(t, clusters, "non-overlapping rules should not form clusters")
+}
+
+func TestClusterByJaccard_BoundaryThreshold(t *testing.T) {
+	// Two rules whose Jaccard is exactly the threshold should cluster.
+	rules := []Rule{
+		{ID: "r1", Pattern: "alpha beta", Check: "gamma delta"},   // {alpha, beta, gamma, delta}
+		{ID: "r2", Pattern: "alpha epsilon", Check: "zeta gamma"}, // {alpha, epsilon, zeta, gamma}
+	}
+	// intersection: {alpha, gamma} = 2; union: 6; jaccard = 2/6 ≈ 0.333
+	clusters := ClusterByJaccard(rules, 0.33)
+	assert.Len(t, clusters, 1, "boundary case should still cluster when sim >= threshold")
+	clusters = ClusterByJaccard(rules, 0.5)
+	assert.Empty(t, clusters)
+}
+
+func TestClusterByJaccard_TransitiveMerge(t *testing.T) {
+	// r1<->r2 similar, r2<->r3 similar, but r1<->r3 not necessarily.
+	rules := []Rule{
+		{ID: "r1", Pattern: "alpha beta gamma", Check: "delta"},
+		{ID: "r2", Pattern: "alpha beta", Check: "epsilon zeta"},
+		{ID: "r3", Pattern: "epsilon zeta", Check: "eta theta"},
+	}
+	clusters := ClusterByJaccard(rules, 0.20)
+	assert.Len(t, clusters, 1, "transitive matches should land in one cluster")
+	assert.Len(t, clusters[0].Rules, 3)
+}
+
+func TestClusterByJaccard_EmptyOrSingle(t *testing.T) {
+	assert.Nil(t, ClusterByJaccard(nil, 0.5))
+	assert.Nil(t, ClusterByJaccard([]Rule{{ID: "only"}}, 0.5))
+}
+
+func TestGroupRulesByCategory(t *testing.T) {
+	rules := []Rule{
+		{ID: "r1", Category: "style"},
+		{ID: "r2", Category: "security"},
+		{ID: "r3", Category: "style"},
+		{ID: "r4", Category: ""},
+	}
+	order, byCat := GroupRulesByCategory(rules)
+	assert.Equal(t, []string{"style", "security", ""}, order)
+	assert.Len(t, byCat["style"], 2)
+	assert.Len(t, byCat["security"], 1)
+	assert.Len(t, byCat[""], 1)
+}

--- a/internal/warden/similarity_test.go
+++ b/internal/warden/similarity_test.go
@@ -92,7 +92,10 @@ func TestClusterByJaccard_MultipleClusters(t *testing.T) {
 		{ID: "r3", Pattern: "spelling mistake", Check: "verify spelling in button"},
 		{ID: "r4", Pattern: "button label typo", Check: "spelling consistency button"},
 	}
-	clusters := ClusterByJaccard(rules, 0.3)
+	// Threshold chosen so r1<->r2 (J ≈ 0.333) and r3<->r4 (J ≈ 0.286) both
+	// cluster, while cross-cluster pairs (J = 0) stay separate. Boundary
+	// behavior is exercised by TestClusterByJaccard_BoundaryThreshold.
+	clusters := ClusterByJaccard(rules, 0.25)
 	if len(clusters) != 2 {
 		t.Fatalf("expected 2 clusters, got %d", len(clusters))
 	}


### PR DESCRIPTION
## Changes

- **Smelter Pass 1 near-duplicate consolidation** - The Smelter now clusters active warden rules by category, scores pairwise Jaccard similarity over their pattern+check word bags, and asks the warden-stage provider to merge each cluster (>= `warden.dedup_threshold`) into a single canonical rule. Superseded rules move to the per-anvil archive with reason `duplicate` and `superseded_by` set, and the consolidation summary is appended to the Smelter PR commit message. (Forge-f3iv)

## Original Issue (task): Pass 1: Smelter near-duplicate consolidation

Extend internal/smelter/smelter.go merge step (pre-commit/pre-PR) to add Pass 1: group active rules by category, compute pairwise Jaccard similarity on word-bag of (pattern+check) text, cluster rules where similarity >= warden.dedup_threshold (use union-find or greedy clustering). For each cluster of size >1, call the warden-stage provider once with the cluster contents and ask for a canonical merged Rule (concatenated deduped source list, oldest added timestamp, single merged check+pattern). Replace cluster members in the active rules file with the merged rule; move originals to archive via the archive store from sub-task 1 with reason='duplicate' and superseded_by=<new-id>. Add a tokenize/jaccard helper (likely internal/warden/similarity.go). Emit a structured summary of consolidations for the commit message. Depends on sub-task 1's archive store.

---
Bead: Forge-f3iv | Branch: forge/Forge-f3iv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->