### PR TITLE
Backfill: title-heuristic admin command for legacy empty-anvil sessions (Forge-7tzz)

### DIFF
--- a/changelog.d/Forge-7tzz.md
+++ b/changelog.d/Forge-7tzz.md
@@ -1,0 +1,2 @@
+category: Added
+- **`forge backfill-anvils` admin command** - Heuristically populates empty `anvil` on legacy `forge_sessions` rows by case-insensitive substring matching of the session title against registered anvil names. Supports `--dry-run`; skips rows with zero or multiple matches and prints a summary. (Forge-7tzz)

--- a/cmd/forge/backfill_anvils.go
+++ b/cmd/forge/backfill_anvils.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	backfillAnvilsCmd.Flags().Bool("dry-run", false, "Show what would change without writing to the database")
+	rootCmd.AddCommand(backfillAnvilsCmd)
+}
+
+var backfillAnvilsCmd = &cobra.Command{
+	Use:     "backfill-anvils",
+	Short:   "Heuristically populate empty anvil on legacy forge_sessions",
+	GroupID: "config",
+	Long: `Scans forge_sessions rows where anvil = '' and tries to populate the
+anvil column by case-insensitive substring matching of the session title
+against the registered anvil names from forge.yaml.
+
+Behavior per row:
+  - exactly one anvil name matches the title → UPDATE the row
+  - multiple anvil names match              → leave untouched, log as ambiguous
+  - no anvil names match                    → leave untouched, log as no-match
+
+Prints a summary of scanned / updated / skipped rows at the end. Use
+--dry-run to preview without writing.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		if cfg == nil {
+			loaded, err := config.Load(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			cfg = loaded
+		}
+		anvilNames := sortedAnvilNames(cfg.Anvils)
+		if len(anvilNames) == 0 {
+			return fmt.Errorf("no anvils registered; nothing to match against")
+		}
+
+		db, err := state.Open("")
+		if err != nil {
+			return fmt.Errorf("opening state database: %w", err)
+		}
+		defer db.Close()
+
+		sessions, err := db.ListForgeSessionsMissingAnvil()
+		if err != nil {
+			return fmt.Errorf("listing sessions with empty anvil: %w", err)
+		}
+
+		type result struct {
+			ID      int64    `json:"id"`
+			Title   string   `json:"title"`
+			Anvil   string   `json:"anvil,omitempty"`
+			Matches []string `json:"matches,omitempty"`
+			Outcome string   `json:"outcome"` // updated | ambiguous | no_match | error
+			Err     string   `json:"error,omitempty"`
+		}
+
+		results := make([]result, 0, len(sessions))
+		var updated, ambiguous, noMatch, errs int
+		for _, s := range sessions {
+			matches := matchAnvil(s.Title, anvilNames)
+			r := result{ID: s.ID, Title: s.Title, Matches: matches}
+			switch {
+			case len(matches) == 1:
+				r.Anvil = matches[0]
+				if dryRun {
+					r.Outcome = "updated"
+					updated++
+				} else if err := db.UpdateForgeSessionAnvil(s.ID, matches[0]); err != nil {
+					r.Outcome = "error"
+					r.Err = err.Error()
+					errs++
+				} else {
+					r.Outcome = "updated"
+					updated++
+				}
+			case len(matches) > 1:
+				r.Outcome = "ambiguous"
+				ambiguous++
+			default:
+				r.Outcome = "no_match"
+				noMatch++
+			}
+			results = append(results, r)
+		}
+
+		if jsonOutput {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(map[string]any{
+				"dry_run":            dryRun,
+				"scanned":            len(sessions),
+				"updated":            updated,
+				"skipped_ambiguous":  ambiguous,
+				"skipped_no_match":   noMatch,
+				"errors":             errs,
+				"rows":               results,
+			})
+		}
+
+		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintf(tw, "ID\tOUTCOME\tANVIL\tTITLE\n")
+		for _, r := range results {
+			detail := r.Anvil
+			switch r.Outcome {
+			case "ambiguous":
+				detail = "[" + strings.Join(r.Matches, ", ") + "]"
+			case "no_match":
+				detail = "-"
+			case "error":
+				detail = "ERR: " + r.Err
+			}
+			fmt.Fprintf(tw, "%d\t%s\t%s\t%s\n", r.ID, r.Outcome, detail, truncate(r.Title, 60))
+		}
+		tw.Flush()
+
+		mode := "applied"
+		if dryRun {
+			mode = "dry-run"
+		}
+		fmt.Printf("\nSummary (%s): scanned=%d updated=%d skipped_ambiguous=%d skipped_no_match=%d errors=%d\n",
+			mode, len(sessions), updated, ambiguous, noMatch, errs)
+
+		if errs > 0 {
+			return fmt.Errorf("%d row(s) failed to update", errs)
+		}
+		return nil
+	},
+}
+
+// matchAnvil returns the registered anvil names whose lowercase name occurs as
+// a substring of the lowercase title. The result preserves the input order of
+// anvilNames so callers get stable, sorted output.
+func matchAnvil(title string, anvilNames []string) []string {
+	lower := strings.ToLower(title)
+	out := []string{}
+	for _, name := range anvilNames {
+		if name == "" {
+			continue
+		}
+		if strings.Contains(lower, strings.ToLower(name)) {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// sortedAnvilNames extracts the keys of the anvil map in lexicographic order so
+// matchAnvil's output is stable across runs.
+func sortedAnvilNames(anvils map[string]config.AnvilConfig) []string {
+	names := make([]string, 0, len(anvils))
+	for name := range anvils {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+

--- a/cmd/forge/backfill_anvils.go
+++ b/cmd/forge/backfill_anvils.go
@@ -59,6 +59,38 @@ Prints a summary of scanned / updated / skipped rows at the end. Use
 			return fmt.Errorf("listing sessions with empty anvil: %w", err)
 		}
 
+		mode := "applied"
+		if dryRun {
+			mode = "dry-run"
+		}
+
+		// Short-circuit the empty case with a friendly message instead of
+		// printing an empty table. Still emit a structured JSON document so
+		// scripts can rely on the schema.
+		if len(sessions) == 0 {
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(map[string]any{
+					"dry_run":           dryRun,
+					"scanned":           0,
+					"updated":           0,
+					"skipped_ambiguous": 0,
+					"skipped_no_match":  0,
+					"errors":            0,
+					"anvils":            anvilNames,
+					"rows":              []any{},
+				})
+			}
+			fmt.Printf("No forge_sessions rows with empty anvil; nothing to do (%s).\n", mode)
+			return nil
+		}
+
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Scanning %d forge_sessions row(s) with empty anvil against %d registered anvil(s): %s [%s]\n",
+				len(sessions), len(anvilNames), strings.Join(anvilNames, ", "), strings.ToUpper(mode))
+		}
+
 		type result struct {
 			ID      int64    `json:"id"`
 			Title   string   `json:"title"`
@@ -100,15 +132,22 @@ Prints a summary of scanned / updated / skipped rows at the end. Use
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			return enc.Encode(map[string]any{
-				"dry_run":            dryRun,
-				"scanned":            len(sessions),
-				"updated":            updated,
-				"skipped_ambiguous":  ambiguous,
-				"skipped_no_match":   noMatch,
-				"errors":             errs,
-				"rows":               results,
-			})
+			if err := enc.Encode(map[string]any{
+				"dry_run":           dryRun,
+				"scanned":           len(sessions),
+				"updated":           updated,
+				"skipped_ambiguous": ambiguous,
+				"skipped_no_match":  noMatch,
+				"errors":            errs,
+				"anvils":            anvilNames,
+				"rows":              results,
+			}); err != nil {
+				return err
+			}
+			if errs > 0 {
+				return fmt.Errorf("%d row(s) failed to update", errs)
+			}
+			return nil
 		}
 
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
@@ -127,12 +166,11 @@ Prints a summary of scanned / updated / skipped rows at the end. Use
 		}
 		tw.Flush()
 
-		mode := "applied"
-		if dryRun {
-			mode = "dry-run"
-		}
 		fmt.Printf("\nSummary (%s): scanned=%d updated=%d skipped_ambiguous=%d skipped_no_match=%d errors=%d\n",
 			mode, len(sessions), updated, ambiguous, noMatch, errs)
+		if dryRun && updated > 0 {
+			fmt.Println("Re-run without --dry-run to apply these updates.")
+		}
 
 		if errs > 0 {
 			return fmt.Errorf("%d row(s) failed to update", errs)

--- a/cmd/forge/backfill_anvils_test.go
+++ b/cmd/forge/backfill_anvils_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMatchAnvil(t *testing.T) {
+	anvils := []string{"forge", "heimdall", "metadata"}
+
+	cases := []struct {
+		name   string
+		title  string
+		anvils []string
+		want   []string
+	}{
+		{
+			name:   "single exact match",
+			title:  "Refactor poller in Forge",
+			anvils: anvils,
+			want:   []string{"forge"},
+		},
+		{
+			name:   "case insensitive",
+			title:  "HEIMDALL crash on startup",
+			anvils: anvils,
+			want:   []string{"heimdall"},
+		},
+		{
+			name:   "substring match",
+			title:  "Improve metadata-sync error handling",
+			anvils: anvils,
+			want:   []string{"metadata"},
+		},
+		{
+			name:   "multiple matches",
+			title:  "Wire forge into heimdall pipeline",
+			anvils: anvils,
+			want:   []string{"forge", "heimdall"},
+		},
+		{
+			name:   "no match",
+			title:  "Cleanup unrelated TODOs",
+			anvils: anvils,
+			want:   []string{},
+		},
+		{
+			name:   "empty title",
+			title:  "",
+			anvils: anvils,
+			want:   []string{},
+		},
+		{
+			name:   "empty anvil names are skipped",
+			title:  "Anything goes",
+			anvils: []string{"", "forge"},
+			want:   []string{},
+		},
+		{
+			name:   "preserves input order",
+			title:  "metadata then forge",
+			anvils: []string{"forge", "heimdall", "metadata"},
+			want:   []string{"forge", "metadata"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchAnvil(tc.title, tc.anvils)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("matchAnvil(%q, %v) = %v, want %v", tc.title, tc.anvils, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/state/forge_sessions.go
+++ b/internal/state/forge_sessions.go
@@ -353,6 +353,52 @@ func (db *DB) UpdateForgeSessionStageAndPlan(id int64, stage, plan *string) (*Fo
 	return db.GetForgeSession(id)
 }
 
+// ListForgeSessionsMissingAnvil returns sessions whose anvil column is empty,
+// ordered by id ASC for stable iteration. Used by the `forge backfill-anvils`
+// admin command to repair legacy rows created before the anvil field became
+// required.
+func (db *DB) ListForgeSessionsMissingAnvil() ([]ForgeSession, error) {
+	rows, err := db.conn.Query(
+		`SELECT id, title, status, anvil, created_by, created_at, updated_at, stage, plan
+		 FROM forge_sessions WHERE anvil = '' ORDER BY id ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []ForgeSession{}
+	for rows.Next() {
+		s, err := scanForgeSessionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *s)
+	}
+	return out, rows.Err()
+}
+
+// UpdateForgeSessionAnvil sets the anvil column on a session and advances
+// updated_at. Returns ErrForgeSessionNotFound when no row matches the id so
+// the caller can distinguish a missing row from a no-op write.
+func (db *DB) UpdateForgeSessionAnvil(id int64, anvil string) error {
+	now := time.Now().UTC().Format(dbTimeLayout)
+	res, err := db.conn.Exec(
+		`UPDATE forge_sessions SET anvil = ?, updated_at = ? WHERE id = ?`,
+		anvil, now, id,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrForgeSessionNotFound
+	}
+	return nil
+}
+
 // ListForgeSessionMessages returns the messages for a session in insertion
 // order (oldest first), suitable for direct rendering in the chat view.
 func (db *DB) ListForgeSessionMessages(sessionID int64) ([]ForgeSessionMessage, error) {

--- a/internal/state/forge_sessions_test.go
+++ b/internal/state/forge_sessions_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -276,5 +277,96 @@ func TestForgeSessions_AppendValidation(t *testing.T) {
 		Content:   "no role",
 	}); err == nil {
 		t.Error("expected error for missing role")
+	}
+}
+
+func TestForgeSessions_ListMissingAnvil(t *testing.T) {
+	db := openTestDB(t)
+
+	// Three sessions with empty anvil, interleaved with two that already
+	// have one. The list should return only the empty-anvil rows, in
+	// ascending id order, leaving the populated ones untouched.
+	empty1, err := db.CreateForgeSession(ForgeSession{Title: "first empty", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateForgeSession(ForgeSession{Title: "has anvil", Anvil: "forge", CreatedBy: "alice"}); err != nil {
+		t.Fatal(err)
+	}
+	empty2, err := db.CreateForgeSession(ForgeSession{Title: "second empty", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateForgeSession(ForgeSession{Title: "also has anvil", Anvil: "heimdall", CreatedBy: "alice"}); err != nil {
+		t.Fatal(err)
+	}
+	empty3, err := db.CreateForgeSession(ForgeSession{Title: "third empty", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	missing, err := db.ListForgeSessionsMissingAnvil()
+	if err != nil {
+		t.Fatalf("ListForgeSessionsMissingAnvil: %v", err)
+	}
+	wantIDs := []int64{empty1.ID, empty2.ID, empty3.ID}
+	if len(missing) != len(wantIDs) {
+		t.Fatalf("expected %d rows, got %d", len(wantIDs), len(missing))
+	}
+	for i, want := range wantIDs {
+		if missing[i].ID != want {
+			t.Errorf("row %d: want id=%d, got id=%d", i, want, missing[i].ID)
+		}
+		if missing[i].Anvil != "" {
+			t.Errorf("row %d: expected empty anvil, got %q", i, missing[i].Anvil)
+		}
+	}
+}
+
+func TestForgeSessions_ListMissingAnvil_EmptyTable(t *testing.T) {
+	db := openTestDB(t)
+	missing, err := db.ListForgeSessionsMissingAnvil()
+	if err != nil {
+		t.Fatalf("ListForgeSessionsMissingAnvil: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("expected 0 rows on empty table, got %d", len(missing))
+	}
+}
+
+func TestForgeSessions_UpdateAnvil(t *testing.T) {
+	db := openTestDB(t)
+	s, err := db.CreateForgeSession(ForgeSession{Title: "Refactor poller", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalUpdated := s.UpdatedAt
+	// Sleep so updated_at advancement is observable across the dbTimeLayout
+	// resolution on platforms where the clock advances on ms ticks.
+	time.Sleep(2 * time.Millisecond)
+
+	if err := db.UpdateForgeSessionAnvil(s.ID, "forge"); err != nil {
+		t.Fatalf("UpdateForgeSessionAnvil: %v", err)
+	}
+	got, err := db.GetForgeSession(s.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Anvil != "forge" {
+		t.Errorf("expected anvil=forge, got %q", got.Anvil)
+	}
+	if !got.UpdatedAt.After(originalUpdated) {
+		t.Errorf("expected updated_at to advance; was %v, now %v", originalUpdated, got.UpdatedAt)
+	}
+	if got.Title != "Refactor poller" {
+		t.Errorf("title should be untouched, got %q", got.Title)
+	}
+}
+
+func TestForgeSessions_UpdateAnvil_MissingRow(t *testing.T) {
+	db := openTestDB(t)
+	err := db.UpdateForgeSessionAnvil(9999, "forge")
+	if !errors.Is(err, ErrForgeSessionNotFound) {
+		t.Errorf("expected ErrForgeSessionNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
## Changes

- **`forge backfill-anvils` admin command** - Heuristically populates empty `anvil` on legacy `forge_sessions` rows by case-insensitive substring matching of the session title against registered anvil names. Supports `--dry-run`; skips rows with zero or multiple matches and prints a summary. (Forge-7tzz)

## Original Issue (task): Backfill: title-heuristic admin command for legacy empty-anvil sessions

Add a `forge` admin subcommand (or one-shot migration in a future `bd` version) that scans `forge_sessions WHERE anvil = ''` and attempts to populate `anvil` by word-matching the session title against registered anvil names (case-insensitive substring match; if multiple match, leave untouched and log; if none match, leave untouched and log). Print a summary of updated/skipped rows. Files: likely a new file under `cmd/forge/` or wherever existing admin subcommands live, plus wiring in the root command. Low priority per the bead — included as a separate task so it can be deferred. Independent of the other two sub-tasks; the prod repro (skybert-forge id 2) has already been hand-fixed, so this is purely defensive cleanup for any other instances.

---
Bead: Forge-7tzz | Branch: forge/Forge-7tzz
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->