### PR TITLE
Pass 2: Staleness detection and archive (Forge-ep74)

### DIFF
--- a/changelog.d/Forge-ep74.md
+++ b/changelog.d/Forge-ep74.md
@@ -1,0 +1,2 @@
+category: Added
+- **Smelter staleness pass (Pass 2)** - After the consolidation pass, the Smelter now sweeps the active warden rules and moves entries older than `settings.warden.archive_after_days` (default 180) into `.forge/warden-rules.archive.yaml` with `archive_reason: stale`. The commit subject and `smelter_flushed` events surface how many rules aged out per anvil. (Forge-ep74)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -486,11 +486,12 @@ type WardenSettings struct {
 	// Rule.Pattern against the diff. Pointer so unset means "use default
 	// (true)".
 	FilterPatternGrep *bool `mapstructure:"filter_pattern_grep" yaml:"filter_pattern_grep,omitempty"`
-	// ArchiveAfterDays controls the staleness threshold (in days) that a
-	// future archive/dedup pass will use to retire inactive rules. Rule
-	// entries do not yet carry a last-seen timestamp; when that tracking is
-	// added, this value will gate the archive pass. Zero falls back to the
-	// default of 180 days.
+	// ArchiveAfterDays controls the staleness threshold (in days) used by
+	// the Smelter's Pass 2 staleness sweep. A rule whose Added date is
+	// older than this threshold and has had no recent source activity is
+	// moved to the archive store with reason="stale". Zero falls back to
+	// the default of 180 days; a negative value disables the pass
+	// (callers may use it to mean "never archive").
 	ArchiveAfterDays int `mapstructure:"archive_after_days" yaml:"archive_after_days,omitempty"`
 	// DedupThreshold is the similarity score (0.0–1.0) above which two
 	// active rules are considered duplicates and the older entry is moved to

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1078,6 +1078,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 			smelter.WithDedupThreshold(func() float64 {
 				return d.config().Settings.Warden.ResolvedDedupThreshold()
 			}),
+			smelter.WithArchiveAfterDays(func() int {
+				return d.config().Settings.Warden.ResolvedArchiveAfterDays()
+			}),
 		)
 		go func() {
 			if err := d.smelterWorker.Run(ctx); err != nil && err != context.Canceled {

--- a/internal/smelter/smelter.go
+++ b/internal/smelter/smelter.go
@@ -74,6 +74,9 @@ type Smelter struct {
 	// dedupThreshold returns the active similarity threshold. When nil or it
 	// returns <= 0, consolidation is skipped.
 	dedupThreshold func() float64
+	// archiveAfterDays returns the staleness threshold in days for Pass 2.
+	// When nil or it returns <= 0, the staleness pass is skipped.
+	archiveAfterDays func() int
 }
 
 // Option configures a Smelter at construction time.
@@ -93,6 +96,14 @@ func WithConsolidator(runner warden.ConsolidationRunner) Option {
 // the smelter. A nil function or one returning <= 0 disables consolidation.
 func WithDedupThreshold(fn func() float64) Option {
 	return func(s *Smelter) { s.dedupThreshold = fn }
+}
+
+// WithArchiveAfterDays supplies a function the Smelter calls at flush time
+// to resolve the staleness threshold (in days) used by Pass 2. A function
+// is used so config hot-reload can take effect without restarting. A nil
+// function or one returning <= 0 disables the staleness pass.
+func WithArchiveAfterDays(fn func() int) Option {
+	return func(s *Smelter) { s.archiveAfterDays = fn }
 }
 
 // New creates a Smelter. interval controls how often Flush is called;
@@ -360,9 +371,18 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 		log.Printf("[smelter] consolidation error for %s: %v", anvilName, err)
 	}
 
-	if added == 0 && len(consolidationSummary) == 0 {
+	// 2c. Pass 2 staleness archive: move rules that have aged past the
+	//     configured threshold and have had no recent source activity into
+	//     the archive store with reason="stale". Runs after Pass 1 so the
+	//     newly-merged rules in rf.Rules are still candidates for staleness
+	//     in future flushes. Pass 3 only operates on whatever remains in
+	//     rf.Rules after this step.
+	staleArchived := s.runStaleness(anvilName, rf)
+
+	if added == 0 && len(consolidationSummary) == 0 && len(staleArchived) == 0 {
 		// All rules were duplicates (already in the file) or malformed AND
-		// nothing was consolidated. Delete from DB and emit a flush event.
+		// nothing was consolidated AND nothing aged out. Delete from DB and
+		// emit a flush event.
 		log.Printf("[smelter] All %d pending rule(s) for %s were duplicates or malformed — cleaning up", len(rules), anvilName)
 		if err := s.db.DeletePendingRules(flushedIDs); err != nil {
 			return err
@@ -380,12 +400,12 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 	//    archive entry for the rules it replaced (the bead contract). If
 	//    either step fails we abort before staging/commit/push, leaving the
 	//    pending queue intact for the next flush.
-	if err := s.persistRulesAndArchive(wt.Path, rf, archived, consolidationSummary); err != nil {
+	if err := s.persistRulesAndArchive(wt.Path, rf, archived, consolidationSummary, staleArchived); err != nil {
 		return fmt.Errorf("persisting warden rules for %s: %w", anvilName, err)
 	}
 
 	// 4. Commit and force-push from the worktree.
-	if err := s.commitAndPush(ctx, wt.Path, branch, added, consolidationSummary); err != nil {
+	if err := s.commitAndPush(ctx, wt.Path, branch, added, consolidationSummary, staleArchived); err != nil {
 		return fmt.Errorf("commit/push for %s: %w", anvilName, err)
 	}
 
@@ -439,16 +459,42 @@ func (s *Smelter) runConsolidation(ctx context.Context, wtPath, anvilName string
 	return summary, replaced, combined
 }
 
+// runStaleness invokes warden.ArchiveStale on the active rules slice when an
+// archive-after threshold is configured. Stale rules are removed from rf in
+// place and returned as ArchivedRule entries so the caller can persist them
+// to the archive store and surface the count in the commit message.
+//
+// When archiveAfterDays is nil or returns <= 0, the pass is a no-op and the
+// returned slice is empty — rf.Rules is left untouched.
+func (s *Smelter) runStaleness(anvilName string, rf *warden.RulesFile) []warden.ArchivedRule {
+	if s.archiveAfterDays == nil {
+		return nil
+	}
+	threshold := s.archiveAfterDays()
+	if threshold <= 0 {
+		return nil
+	}
+	active, stale := warden.ArchiveStale(rf.Rules, threshold, time.Now().UTC())
+	if len(stale) == 0 {
+		return nil
+	}
+	rf.Rules = active
+	log.Printf("[smelter] archived %d stale rule(s) for %s (threshold=%dd)", len(stale), anvilName, threshold)
+	_ = s.db.LogEvent(state.EventSmelterFlushed,
+		fmt.Sprintf("Archived %d stale rule(s) for %s", len(stale), anvilName), "", anvilName)
+	return stale
+}
+
 // persistRulesAndArchive writes the archive entries (when any) and then
 // saves the active rules file. Ordering is load-bearing: the archive must
 // land before the active rules file so a partial failure can never leave
 // the rules file on disk without a matching archive record for the rules
 // it superseded. Any error from either step is returned so callers can
 // abort the flush before staging/commit/push.
-func (s *Smelter) persistRulesAndArchive(wtPath string, rf *warden.RulesFile, archived []warden.Rule, summary []warden.MergeResult) error {
-	if len(archived) > 0 {
-		if err := s.archiveRules(wtPath, archived, summary); err != nil {
-			return fmt.Errorf("archiving consolidated rules: %w", err)
+func (s *Smelter) persistRulesAndArchive(wtPath string, rf *warden.RulesFile, archived []warden.Rule, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
+	if len(archived) > 0 || len(stale) > 0 {
+		if err := s.archiveRules(wtPath, archived, summary, stale); err != nil {
+			return fmt.Errorf("archiving rules: %w", err)
 		}
 	}
 	if err := warden.SaveRules(wtPath, rf); err != nil {
@@ -457,12 +503,13 @@ func (s *Smelter) persistRulesAndArchive(wtPath string, rf *warden.RulesFile, ar
 	return nil
 }
 
-// archiveRules persists the superseded rules to the per-anvil archive store
-// with reason="duplicate" and superseded_by set to the merged rule's ID.
-// summary is consulted so each archived rule is tagged with the correct
-// superseder.
-func (s *Smelter) archiveRules(wtPath string, archived []warden.Rule, summary []warden.MergeResult) error {
-	// Build map: originalID -> mergedID.
+// archiveRules persists archive entries from Pass 1 (duplicates) and Pass 2
+// (stale) to the per-anvil archive store. Pass 1 entries are added with
+// reason="duplicate" and superseded_by set to the merged rule's ID. Pass 2
+// entries are appended verbatim, preserving the LastSeen and ArchiveReason
+// values supplied by ArchiveStale.
+func (s *Smelter) archiveRules(wtPath string, archived []warden.Rule, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
+	// Build map: originalID -> mergedID for the Pass 1 entries.
 	supersededBy := make(map[string]string, len(archived))
 	for _, m := range summary {
 		for _, id := range m.ReplacedIDs {
@@ -478,14 +525,18 @@ func (s *Smelter) archiveRules(wtPath string, archived []warden.Rule, summary []
 	for _, r := range archived {
 		archive.Add(r, warden.ArchiveReasonDuplicate, supersededBy[r.ID])
 	}
+	for _, ar := range stale {
+		archive.AddArchived(ar)
+	}
 	return archive.Save(archivePath)
 }
 
 // commitAndPush stages the rules file, commits, and force-pushes from the
 // worktree. The worktree is already on the correct branch. When summary is
 // non-empty it is appended to the commit message body so reviewers can see
-// which clusters were merged.
-func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, ruleCount int, summary []warden.MergeResult) error {
+// which clusters were merged. When stale is non-empty its count is included
+// in the commit subject so reviewers can see how many rules aged out.
+func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, ruleCount int, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
 	gitEnv := cleanGitEnv()
 	git := func(args ...string) error {
 		cmdCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -512,17 +563,27 @@ func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, rule
 		}
 	}
 
-	// Build the commit message: keep the existing single-line subject for
-	// backwards compatibility, then append a structured consolidation
-	// summary body when Pass 1 merged any clusters.
+	// Build the commit message subject from the work that was actually
+	// performed. The subject ends in "[no-changelog]" so the changelog
+	// validator skips it.
+	var parts []string
+	if ruleCount > 0 {
+		parts = append(parts, fmt.Sprintf("learn %d warden rule(s)", ruleCount))
+	}
+	if len(summary) > 0 {
+		parts = append(parts, fmt.Sprintf("consolidate %d cluster(s)", len(summary)))
+	}
+	if len(stale) > 0 {
+		parts = append(parts, fmt.Sprintf("archive %d stale rule(s)", len(stale)))
+	}
 	var subject string
-	switch {
-	case ruleCount > 0 && len(summary) > 0:
-		subject = fmt.Sprintf("forge: learn %d warden rule(s), consolidate %d cluster(s) [no-changelog]", ruleCount, len(summary))
-	case len(summary) > 0:
-		subject = fmt.Sprintf("forge: consolidate %d warden rule cluster(s) [no-changelog]", len(summary))
-	default:
+	if len(parts) == 0 {
+		// Defensive fallback: callers only reach commitAndPush when at least
+		// one of the three counts is positive, but keep the legacy form to
+		// avoid an empty subject if invariants ever shift.
 		subject = fmt.Sprintf("forge: learn %d warden rule(s) from pending queue [no-changelog]", ruleCount)
+	} else {
+		subject = "forge: " + strings.Join(parts, ", ") + " [no-changelog]"
 	}
 	commitMsg := subject
 	if body := warden.FormatConsolidationSummary(summary); body != "" {

--- a/internal/smelter/smelter_test.go
+++ b/internal/smelter/smelter_test.go
@@ -373,7 +373,7 @@ func TestArchiveRules_WritesSupersededByCorrectly(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.archiveRules(dir, archived, summary))
+	require.NoError(t, s.archiveRules(dir, archived, summary, nil))
 
 	a, err := warden.LoadArchive(warden.ArchivePath(dir))
 	require.NoError(t, err)
@@ -405,7 +405,7 @@ func TestPersistRulesAndArchive_ArchiveFirstThenRules(t *testing.T) {
 		Category:    "style",
 	}}
 
-	require.NoError(t, s.persistRulesAndArchive(dir, rf, archived, summary))
+	require.NoError(t, s.persistRulesAndArchive(dir, rf, archived, summary, nil))
 
 	rulesData, err := os.ReadFile(filepath.Join(dir, warden.RulesFileName))
 	require.NoError(t, err)
@@ -445,14 +445,179 @@ func TestPersistRulesAndArchive_ArchiveFailureAbortsRulesSave(t *testing.T) {
 		Category:    "style",
 	}}
 
-	err := s.persistRulesAndArchive(dir, rf, archived, summary)
+	err := s.persistRulesAndArchive(dir, rf, archived, summary, nil)
 	require.Error(t, err, "archive failure must propagate")
-	assert.Contains(t, err.Error(), "archiving consolidated rules")
+	assert.Contains(t, err.Error(), "archiving rules")
 
 	// Critical: the active rules file must not have been written.
 	_, statErr := os.Stat(filepath.Join(dir, warden.RulesFileName))
 	assert.True(t, os.IsNotExist(statErr),
 		"active rules file must not be saved when archive write fails (got stat err: %v)", statErr)
+}
+
+// TestRunStaleness_DisabledByDefault verifies that without an
+// archive-after-days option configured the staleness pass is a no-op.
+func TestRunStaleness_DisabledByDefault(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Category: "style", Pattern: "p", Check: "c", Added: "2020-01-01"},
+	}}
+
+	archived := s.runStaleness("anvil-a", rf)
+	assert.Empty(t, archived)
+	assert.Len(t, rf.Rules, 1, "rf.Rules must be untouched when the staleness pass is disabled")
+}
+
+// TestRunStaleness_ZeroThresholdSkipsPass verifies that a threshold of zero
+// or negative disables the staleness pass even when WithArchiveAfterDays is
+// configured.
+func TestRunStaleness_ZeroThresholdSkipsPass(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{},
+		WithArchiveAfterDays(func() int { return 0 }),
+	)
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Added: "2020-01-01"},
+	}}
+
+	archived := s.runStaleness("anvil-a", rf)
+	assert.Empty(t, archived)
+	assert.Len(t, rf.Rules, 1)
+}
+
+// TestRunStaleness_MovesOldRulesAndUpdatesRulesFile verifies the staleness
+// pass partitions rules correctly, mutates rf.Rules in place so Pass 3 only
+// operates on actives, and returns ArchivedRule entries with reason=stale.
+func TestRunStaleness_MovesOldRulesAndUpdatesRulesFile(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{},
+		WithArchiveAfterDays(func() int { return 180 }),
+	)
+
+	fresh := warden.Rule{ID: "fresh", Category: "style", Pattern: "p1", Check: "c1",
+		Added: time.Now().UTC().AddDate(0, 0, -10).Format("2006-01-02")}
+	stale := warden.Rule{ID: "stale", Category: "style", Pattern: "p2", Check: "c2",
+		Added: "2020-01-01"}
+	rf := &warden.RulesFile{Rules: []warden.Rule{fresh, stale}}
+
+	archived := s.runStaleness("anvil-a", rf)
+	require.Len(t, archived, 1)
+	assert.Equal(t, "stale", archived[0].ID)
+	assert.Equal(t, warden.ArchiveReasonStale, archived[0].ArchiveReason)
+	assert.False(t, archived[0].LastSeen.IsZero(), "LastSeen should be set on archived stale entries")
+
+	// rf.Rules should now contain only the fresh rule so Pass 3 sees only actives.
+	require.Len(t, rf.Rules, 1)
+	assert.Equal(t, "fresh", rf.Rules[0].ID)
+}
+
+// TestArchiveRules_WritesStaleEntries verifies that archiveRules persists
+// Pass 2 stale entries into the archive store alongside Pass 1 duplicates,
+// preserving their pre-built reason and LastSeen values.
+func TestArchiveRules_WritesStaleEntries(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+	staleAt := time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC)
+	staleArchived := []warden.ArchivedRule{
+		{
+			Rule:          warden.Rule{ID: "old", Category: "style", Pattern: "p", Check: "c", Added: "2020-01-01"},
+			LastSeen:      staleAt,
+			ArchivedAt:    staleAt,
+			ArchiveReason: warden.ArchiveReasonStale,
+		},
+	}
+
+	require.NoError(t, s.archiveRules(dir, nil, nil, staleArchived))
+
+	a, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, a.Rules, 1)
+	assert.Equal(t, "old", a.Rules[0].ID)
+	assert.Equal(t, warden.ArchiveReasonStale, a.Rules[0].ArchiveReason)
+	assert.Equal(t, "", a.Rules[0].SupersededBy)
+	assert.Equal(t, staleAt, a.Rules[0].LastSeen)
+}
+
+// TestArchiveRules_CombinesPass1AndPass2Entries verifies that a single
+// archive write captures both duplicates (Pass 1) and stale entries (Pass 2).
+func TestArchiveRules_CombinesPass1AndPass2Entries(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+
+	dupArchived := []warden.Rule{
+		{ID: "dup1", Category: "style", Pattern: "p1", Check: "c1"},
+	}
+	summary := []warden.MergeResult{{
+		Merged:      warden.Rule{ID: "merged-1", Category: "style"},
+		ReplacedIDs: []string{"dup1"},
+		Category:    "style",
+	}}
+	staleArchived := []warden.ArchivedRule{
+		{
+			Rule:          warden.Rule{ID: "stale1", Category: "style", Added: "2020-01-01"},
+			LastSeen:      time.Now().UTC(),
+			ArchivedAt:    time.Now().UTC(),
+			ArchiveReason: warden.ArchiveReasonStale,
+		},
+	}
+
+	require.NoError(t, s.archiveRules(dir, dupArchived, summary, staleArchived))
+
+	a, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, a.Rules, 2)
+
+	byID := make(map[string]warden.ArchivedRule, len(a.Rules))
+	for _, r := range a.Rules {
+		byID[r.ID] = r
+	}
+	require.Contains(t, byID, "dup1")
+	assert.Equal(t, warden.ArchiveReasonDuplicate, byID["dup1"].ArchiveReason)
+	assert.Equal(t, "merged-1", byID["dup1"].SupersededBy)
+
+	require.Contains(t, byID, "stale1")
+	assert.Equal(t, warden.ArchiveReasonStale, byID["stale1"].ArchiveReason)
+	assert.Equal(t, "", byID["stale1"].SupersededBy)
+}
+
+// TestPersistRulesAndArchive_StaleOnlyWritesArchive verifies the load-bearing
+// invariant for Pass 2: when only stale rules need archiving (no Pass 1
+// activity), both the archive file and the active rules file are written.
+func TestPersistRulesAndArchive_StaleOnlyWritesArchive(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, time.Hour, map[string]string{})
+
+	dir := t.TempDir()
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "kept", Category: "style", Pattern: "p", Check: "c"},
+	}}
+	staleArchived := []warden.ArchivedRule{
+		{
+			Rule:          warden.Rule{ID: "old", Category: "style", Added: "2020-01-01"},
+			LastSeen:      time.Now().UTC(),
+			ArchivedAt:    time.Now().UTC(),
+			ArchiveReason: warden.ArchiveReasonStale,
+		},
+	}
+
+	require.NoError(t, s.persistRulesAndArchive(dir, rf, nil, nil, staleArchived))
+
+	rulesData, err := os.ReadFile(filepath.Join(dir, warden.RulesFileName))
+	require.NoError(t, err)
+	assert.Contains(t, string(rulesData), "kept")
+
+	a, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, a.Rules, 1)
+	assert.Equal(t, "old", a.Rules[0].ID)
+	assert.Equal(t, warden.ArchiveReasonStale, a.Rules[0].ArchiveReason)
 }
 
 // TestPersistRulesAndArchive_NoArchiveSkipsArchiveStep verifies that when
@@ -467,7 +632,7 @@ func TestPersistRulesAndArchive_NoArchiveSkipsArchiveStep(t *testing.T) {
 		{ID: "r1", Category: "style", Pattern: "p", Check: "c"},
 	}}
 
-	require.NoError(t, s.persistRulesAndArchive(dir, rf, nil, nil))
+	require.NoError(t, s.persistRulesAndArchive(dir, rf, nil, nil, nil))
 
 	_, err := os.Stat(filepath.Join(dir, warden.RulesFileName))
 	assert.NoError(t, err, "rules file should be saved")
@@ -563,6 +728,6 @@ func TestCommitAndPush_FreshWorktreeWithExistingRemoteBranch(t *testing.T) {
 
 	// commitAndPush must succeed: the fetch populates the remote-tracking ref
 	// so --force-with-lease can verify the lease and allow the push.
-	err = s.commitAndPush(ctx, localDir, branch, 1, nil)
+	err = s.commitAndPush(ctx, localDir, branch, 1, nil, nil)
 	require.NoError(t, err, "commitAndPush should succeed after fetching remote-tracking ref")
 }

--- a/internal/warden/archive.go
+++ b/internal/warden/archive.go
@@ -158,6 +158,22 @@ func (a *Archive) Add(rule Rule, reason, supersededBy string) {
 	a.Rules = append(a.Rules, entry)
 }
 
+// AddArchived appends a pre-built ArchivedRule, deduplicating by ID. If an
+// entry with the same ID already exists it is replaced in place so the
+// archive stays deduplicated. Unlike Add, this preserves the supplied
+// LastSeen/ArchivedAt/ArchiveReason values rather than rewriting them —
+// used when the caller (e.g. Pass 2 staleness archiving) has already built
+// the entry with the correct bookkeeping.
+func (a *Archive) AddArchived(ar ArchivedRule) {
+	for i, existing := range a.Rules {
+		if existing.ID == ar.ID {
+			a.Rules[i] = ar
+			return
+		}
+	}
+	a.Rules = append(a.Rules, ar)
+}
+
 // Find returns the archived rule with the given ID and true when present.
 func (a *Archive) Find(id string) (*ArchivedRule, bool) {
 	for i := range a.Rules {

--- a/internal/warden/archive_test.go
+++ b/internal/warden/archive_test.go
@@ -100,3 +100,36 @@ func TestArchivePath(t *testing.T) {
 	got := ArchivePath("/anvil")
 	assert.Equal(t, filepath.Join("/anvil", ".forge", "warden-rules.archive.yaml"), got)
 }
+
+func TestArchive_AddArchived_AppendsAndDedupes(t *testing.T) {
+	a := &Archive{}
+	when := time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC)
+	ar := ArchivedRule{
+		Rule:          Rule{ID: "r1", Check: "first"},
+		LastSeen:      when,
+		ArchivedAt:    when,
+		ArchiveReason: ArchiveReasonStale,
+	}
+	a.AddArchived(ar)
+	require.Len(t, a.Rules, 1)
+	assert.Equal(t, "first", a.Rules[0].Check)
+	assert.Equal(t, when, a.Rules[0].LastSeen)
+	assert.Equal(t, ArchiveReasonStale, a.Rules[0].ArchiveReason)
+
+	// Same ID with different content should replace in place, preserving
+	// the new LastSeen/reason verbatim (no auto-rewriting like Add does).
+	when2 := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	ar2 := ArchivedRule{
+		Rule:          Rule{ID: "r1", Check: "second"},
+		LastSeen:      when2,
+		ArchivedAt:    when2,
+		ArchiveReason: ArchiveReasonDuplicate,
+		SupersededBy:  "merged-1",
+	}
+	a.AddArchived(ar2)
+	require.Len(t, a.Rules, 1)
+	assert.Equal(t, "second", a.Rules[0].Check)
+	assert.Equal(t, when2, a.Rules[0].LastSeen)
+	assert.Equal(t, ArchiveReasonDuplicate, a.Rules[0].ArchiveReason)
+	assert.Equal(t, "merged-1", a.Rules[0].SupersededBy)
+}

--- a/internal/warden/stale.go
+++ b/internal/warden/stale.go
@@ -33,12 +33,17 @@ func IsStale(rule Rule, archiveAfterDays int, now time.Time) bool {
 	if err != nil {
 		return false
 	}
+	// Compare in whole days: Added is a date-only value parsed at midnight,
+	// so truncate now to midnight as well to keep the boundary at exact day
+	// counts (e.g. threshold=30 and added 30 days ago is not stale).
+	nowDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	elapsed := nowDay.Sub(added)
 	fullWindow := time.Duration(archiveAfterDays) * 24 * time.Hour
-	if now.Sub(added) <= fullWindow {
+	if elapsed <= fullWindow {
 		return false
 	}
 	halfWindow := fullWindow / 2
-	return now.Sub(added) > halfWindow
+	return elapsed > halfWindow
 }
 
 // ArchiveStale partitions rules into the active set (rules to keep) and a

--- a/internal/warden/stale.go
+++ b/internal/warden/stale.go
@@ -29,7 +29,10 @@ func IsStale(rule Rule, archiveAfterDays int, now time.Time) bool {
 	if rule.Added == "" {
 		return false
 	}
-	added, err := time.Parse(staleAddedLayout, rule.Added)
+	// Parse in now's location so both sides of the subtraction share the same
+	// timezone; mismatched locations (e.g. UTC vs local) would inject a fixed
+	// offset and corrupt the "whole days" boundary.
+	added, err := time.ParseInLocation(staleAddedLayout, rule.Added, now.Location())
 	if err != nil {
 		return false
 	}
@@ -42,8 +45,7 @@ func IsStale(rule Rule, archiveAfterDays int, now time.Time) bool {
 	if elapsed <= fullWindow {
 		return false
 	}
-	halfWindow := fullWindow / 2
-	return elapsed > halfWindow
+	return true
 }
 
 // ArchiveStale partitions rules into the active set (rules to keep) and a

--- a/internal/warden/stale.go
+++ b/internal/warden/stale.go
@@ -1,0 +1,76 @@
+package warden
+
+import (
+	"time"
+)
+
+// staleAddedLayout is the format used for Rule.Added timestamps.
+const staleAddedLayout = "2006-01-02"
+
+// IsStale reports whether a rule should be archived due to inactivity.
+//
+// A rule is considered stale when BOTH of the following hold:
+//  1. rule.Added is older than archiveAfterDays.
+//  2. No source entry has been recorded in the last archiveAfterDays/2 days.
+//
+// Rule source entries currently carry no per-entry timestamp, so the rule's
+// Added date is the only timestamp tracking when this rule was last touched.
+// Until per-source timestamps are introduced, Added is treated as the most
+// recent source activity for purposes of the half-window check — the second
+// condition therefore reduces to "Added is older than archiveAfterDays/2".
+//
+// Rules with no parseable Added date are conservatively treated as not
+// stale: we cannot prove inactivity without a timestamp. archiveAfterDays
+// <= 0 also disables staleness (callers may use it to mean "never archive").
+func IsStale(rule Rule, archiveAfterDays int, now time.Time) bool {
+	if archiveAfterDays <= 0 {
+		return false
+	}
+	if rule.Added == "" {
+		return false
+	}
+	added, err := time.Parse(staleAddedLayout, rule.Added)
+	if err != nil {
+		return false
+	}
+	fullWindow := time.Duration(archiveAfterDays) * 24 * time.Hour
+	if now.Sub(added) <= fullWindow {
+		return false
+	}
+	halfWindow := fullWindow / 2
+	return now.Sub(added) > halfWindow
+}
+
+// ArchiveStale partitions rules into the active set (rules to keep) and a
+// slice of ArchivedRule entries describing the stale rules that should be
+// moved to the archive store with reason="stale". The ArchivedRule entries
+// embed the original Rule unchanged and carry LastSeen and ArchivedAt set
+// to now.
+//
+// Active rules are returned in their original order. ArchiveStale does not
+// touch storage; the caller is responsible for persisting the archived
+// entries to the archive store and replacing the active rules slice.
+//
+// When archiveAfterDays <= 0 (or no rules are stale), the input slice is
+// returned as the active set and the archived slice is nil.
+func ArchiveStale(rules []Rule, archiveAfterDays int, now time.Time) (active []Rule, archived []ArchivedRule) {
+	if archiveAfterDays <= 0 || len(rules) == 0 {
+		return rules, nil
+	}
+	for _, r := range rules {
+		if IsStale(r, archiveAfterDays, now) {
+			archived = append(archived, ArchivedRule{
+				Rule:          r,
+				LastSeen:      now,
+				ArchivedAt:    now,
+				ArchiveReason: ArchiveReasonStale,
+			})
+			continue
+		}
+		active = append(active, r)
+	}
+	if archived == nil {
+		return rules, nil
+	}
+	return active, archived
+}

--- a/internal/warden/stale_test.go
+++ b/internal/warden/stale_test.go
@@ -131,14 +131,6 @@ func TestArchiveStale_EmptyInput(t *testing.T) {
 	assert.Nil(t, archived)
 }
 
-func ruleIDs(rules []Rule) []string {
-	out := make([]string, len(rules))
-	for i, r := range rules {
-		out[i] = r.ID
-	}
-	return out
-}
-
 func archivedIDs(rules []ArchivedRule) []string {
 	out := make([]string, len(rules))
 	for i, r := range rules {

--- a/internal/warden/stale_test.go
+++ b/internal/warden/stale_test.go
@@ -1,0 +1,148 @@
+package warden
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsStale_DisabledWhenThresholdNonPositive(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	r := Rule{ID: "r1", Added: "2020-01-01"}
+
+	assert.False(t, IsStale(r, 0, now))
+	assert.False(t, IsStale(r, -1, now))
+}
+
+func TestIsStale_NoAddedDate_NotStale(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	r := Rule{ID: "r1"} // Added empty
+
+	assert.False(t, IsStale(r, 30, now))
+}
+
+func TestIsStale_MalformedAddedDate_NotStale(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	r := Rule{ID: "r1", Added: "not-a-date"}
+
+	assert.False(t, IsStale(r, 30, now))
+}
+
+func TestIsStale_FreshRule_NotStale(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	r := Rule{ID: "r1", Added: "2026-05-01"} // 19 days ago
+
+	assert.False(t, IsStale(r, 30, now), "rule added within threshold should not be stale")
+}
+
+func TestIsStale_OldRule_Stale(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Added 200 days ago, threshold 180 days.
+	r := Rule{ID: "r1", Added: now.AddDate(0, 0, -200).Format("2006-01-02")}
+
+	assert.True(t, IsStale(r, 180, now), "rule added past the threshold should be stale")
+}
+
+func TestIsStale_AtBoundary_NotStale(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	// Added exactly 30 days ago — boundary is exclusive.
+	r := Rule{ID: "r1", Added: now.AddDate(0, 0, -30).Format("2006-01-02")}
+
+	assert.False(t, IsStale(r, 30, now), "boundary should be exclusive — rule equal to threshold is not stale")
+}
+
+func TestArchiveStale_PartitionsFreshAndStaleRules(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	fresh := Rule{ID: "fresh", Category: "style", Pattern: "p1", Check: "c1", Added: now.AddDate(0, 0, -10).Format("2006-01-02")}
+	stale := Rule{ID: "stale", Category: "style", Pattern: "p2", Check: "c2", Added: now.AddDate(0, 0, -400).Format("2006-01-02")}
+
+	active, archived := ArchiveStale([]Rule{fresh, stale}, 180, now)
+
+	assert.Len(t, active, 1)
+	assert.Equal(t, "fresh", active[0].ID)
+	assert.Len(t, archived, 1)
+	assert.Equal(t, "stale", archived[0].ID)
+}
+
+func TestArchiveStale_SetsLastSeenAndReason(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	r := Rule{ID: "old", Category: "style", Pattern: "p", Check: "c", Added: "2020-01-01"}
+
+	_, archived := ArchiveStale([]Rule{r}, 180, now)
+
+	require.Len(t, archived, 1)
+	assert.Equal(t, now, archived[0].LastSeen, "LastSeen must be set to now on archived stale rules")
+	assert.Equal(t, now, archived[0].ArchivedAt, "ArchivedAt must be set to now on archived stale rules")
+	assert.Equal(t, ArchiveReasonStale, archived[0].ArchiveReason)
+	assert.Equal(t, "", archived[0].SupersededBy, "stale archive entries have no superseder")
+	// The original rule data is carried through unchanged.
+	assert.Equal(t, "old", archived[0].ID)
+	assert.Equal(t, "style", archived[0].Category)
+	assert.Equal(t, "p", archived[0].Pattern)
+	assert.Equal(t, "c", archived[0].Check)
+	assert.Equal(t, "2020-01-01", archived[0].Added)
+}
+
+func TestArchiveStale_PreservesActiveOrder(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	a := Rule{ID: "a", Added: now.AddDate(0, 0, -10).Format("2006-01-02")}
+	b := Rule{ID: "b", Added: "2020-01-01"} // stale
+	c := Rule{ID: "c", Added: now.AddDate(0, 0, -5).Format("2006-01-02")}
+	d := Rule{ID: "d", Added: "2019-01-01"} // stale
+	e := Rule{ID: "e", Added: now.AddDate(0, 0, -1).Format("2006-01-02")}
+
+	active, archived := ArchiveStale([]Rule{a, b, c, d, e}, 180, now)
+
+	assert.Equal(t, []string{"a", "c", "e"}, ruleIDs(active))
+	assert.Equal(t, []string{"b", "d"}, archivedIDs(archived))
+}
+
+func TestArchiveStale_NothingStale_ReturnsOriginalSlice(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	in := []Rule{
+		{ID: "a", Added: now.AddDate(0, 0, -10).Format("2006-01-02")},
+		{ID: "b", Added: now.AddDate(0, 0, -20).Format("2006-01-02")},
+	}
+
+	active, archived := ArchiveStale(in, 180, now)
+	assert.Equal(t, in, active)
+	assert.Nil(t, archived)
+}
+
+func TestArchiveStale_DisabledWhenThresholdNonPositive(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	in := []Rule{{ID: "a", Added: "2020-01-01"}}
+
+	active, archived := ArchiveStale(in, 0, now)
+	assert.Equal(t, in, active)
+	assert.Nil(t, archived)
+
+	active, archived = ArchiveStale(in, -5, now)
+	assert.Equal(t, in, active)
+	assert.Nil(t, archived)
+}
+
+func TestArchiveStale_EmptyInput(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	active, archived := ArchiveStale(nil, 180, now)
+	assert.Nil(t, active)
+	assert.Nil(t, archived)
+}
+
+func ruleIDs(rules []Rule) []string {
+	out := make([]string, len(rules))
+	for i, r := range rules {
+		out[i] = r.ID
+	}
+	return out
+}
+
+func archivedIDs(rules []ArchivedRule) []string {
+	out := make([]string, len(rules))
+	for i, r := range rules {
+		out[i] = r.ID
+	}
+	return out
+}


### PR DESCRIPTION
## Changes

- **Smelter staleness pass (Pass 2)** - After the consolidation pass, the Smelter now sweeps the active warden rules and moves entries older than `settings.warden.archive_after_days` (default 180) into `.forge/warden-rules.archive.yaml` with `archive_reason: stale`. The commit subject and `smelter_flushed` events surface how many rules aged out per anvil. (Forge-ep74)

## Original Issue (task): Pass 2: Staleness detection and archive

In the smelter merge step (forge/smelter/merge.go or equivalent), after Pass 1 completes, add Pass 2 logic that iterates the remaining active rules slice. For each rule, check if rule.Added is older than warden.archive_after_days (config field) AND verify no entry in rule.Source has been recorded in the last archive_after_days/2 days. When both conditions hold, set rule.LastSeen to current timestamp and invoke sub-task 1's archive store function with reason='stale'. Implement helper isStale(rule, cfg) bool and archiveStale(rules []Rule) ([]Rule, []ArchivedRule). Return the filtered active set plus the archived rules list so Pass 3 only operates on remaining actives. Depends on sub-task 1's archive store API.

---
Bead: Forge-ep74 | Branch: forge/Forge-ep74
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->