### PR TITLE
Pass 3: Paths backfill via GitHub PR changed files (Forge-abrp)

### DIFF
--- a/changelog.d/Forge-abrp.md
+++ b/changelog.d/Forge-abrp.md
@@ -1,0 +1,2 @@
+category: Added
+- **Smelter paths backfill pass (Pass 3)** - After the staleness pass, the Smelter now backfills `Paths` on active warden rules whose Paths field is empty and whose Source carries a `copilot:PR#N` token. The pass calls the GitHub API for the referenced PR(s), unions the changed file extensions, and writes them as doublestar globs (e.g. `.go` → `**/*.go`). The pass is idempotent — rules with non-empty Paths are skipped. The commit subject and `smelter_flushed` events surface how many rules picked up new Paths per anvil. (Forge-abrp)

--- a/internal/smelter/paths.go
+++ b/internal/smelter/paths.go
@@ -1,0 +1,184 @@
+package smelter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Robin831/Forge/internal/executil"
+	"github.com/Robin831/Forge/internal/warden"
+)
+
+// prNumberPattern matches the "copilot:PR#N" token embedded in a rule source.
+// Only the literal copilot prefix is recognized — other source kinds (manual
+// entries, quench fixes) do not have a remote PR with discoverable files.
+var prNumberPattern = regexp.MustCompile(`copilot:PR#(\d+)`)
+
+// extractPRNumber parses the PR number from a single source token. Returns
+// (n, true) when the source contains a copilot:PR#N reference; (0, false)
+// otherwise.
+func extractPRNumber(source string) (int, bool) {
+	m := prNumberPattern.FindStringSubmatch(source)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// fetchChangedFiles is the package-level entry point used by runPathsBackfill
+// to look up the files changed by a PR. It is a variable so tests can stub
+// out the gh CLI invocation. The default implementation shells out to gh.
+var fetchChangedFiles = fetchChangedFilesViaGH
+
+// fetchChangedFilesViaGH calls `gh api repos/{owner}/{repo}/pulls/N/files`
+// (paginated) and returns the changed file paths. repoDir must be inside a
+// gh-recognized git repository so the {owner}/{repo} placeholders resolve.
+func fetchChangedFilesViaGH(ctx context.Context, repoDir string, prNum int) ([]string, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	endpoint := fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/files", prNum)
+	cmd := executil.HideWindow(exec.CommandContext(fetchCtx, "gh", "api", endpoint, "--paginate"))
+	cmd.Dir = repoDir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh api: %s (%w)", strings.TrimSpace(stderr.String()), err)
+	}
+
+	type ghPRFile struct {
+		Filename string `json:"filename"`
+	}
+
+	// gh --paginate concatenates one JSON array per page (e.g. [..][..]). A
+	// plain Unmarshal cannot handle that; loop the decoder until EOF.
+	var all []ghPRFile
+	dec := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	for {
+		var page []ghPRFile
+		if err := dec.Decode(&page); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("parsing gh response: %w", err)
+		}
+		all = append(all, page...)
+	}
+
+	files := make([]string, 0, len(all))
+	for _, f := range all {
+		if f.Filename != "" {
+			files = append(files, f.Filename)
+		}
+	}
+	return files, nil
+}
+
+// globsFromExtensions returns the unique doublestar globs derived from the
+// extensions of files. Files without an extension are skipped. The result is
+// sorted so the field encoded into warden-rules.yaml is deterministic across
+// runs — this keeps the smelter PR's diff stable when nothing material has
+// changed.
+func globsFromExtensions(files []string) []string {
+	seen := make(map[string]struct{})
+	for _, f := range files {
+		ext := filepath.Ext(f)
+		if ext == "" || ext == "." {
+			continue
+		}
+		seen["**/*"+ext] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	globs := make([]string, 0, len(seen))
+	for g := range seen {
+		globs = append(globs, g)
+	}
+	sort.Strings(globs)
+	return globs
+}
+
+// runPathsBackfill iterates the active rules in rf and, for each rule whose
+// Paths field is empty and whose Source carries one or more copilot:PR#N
+// tokens, fetches the changed files for those PRs and populates Paths with
+// the derived file-extension globs.
+//
+// Idempotency: rules whose Paths is already populated are skipped, so a
+// repeated flush is a no-op for the same rule.
+//
+// Best-effort: a fetch failure for a single PR is logged and the next PR is
+// tried. A rule is only modified when at least one fetch succeeded and
+// produced at least one glob.
+//
+// Returns the number of rules whose Paths was populated.
+func (s *Smelter) runPathsBackfill(ctx context.Context, wtPath, anvilName string, rf *warden.RulesFile) int {
+	var updated int
+	for i := range rf.Rules {
+		if ctx.Err() != nil {
+			return updated
+		}
+		rule := &rf.Rules[i]
+		if len(rule.Paths) > 0 {
+			continue
+		}
+
+		// Collect unique PR numbers referenced by this rule's sources.
+		var prNums []int
+		seenPR := make(map[int]struct{})
+		for _, src := range rule.Source {
+			n, ok := extractPRNumber(src)
+			if !ok {
+				continue
+			}
+			if _, dup := seenPR[n]; dup {
+				continue
+			}
+			seenPR[n] = struct{}{}
+			prNums = append(prNums, n)
+		}
+		if len(prNums) == 0 {
+			continue
+		}
+
+		var allFiles []string
+		var anySuccess bool
+		for _, prNum := range prNums {
+			files, err := fetchChangedFiles(ctx, wtPath, prNum)
+			if err != nil {
+				log.Printf("[smelter] paths backfill: PR#%d for rule %s on %s: %v", prNum, rule.ID, anvilName, err)
+				continue
+			}
+			anySuccess = true
+			allFiles = append(allFiles, files...)
+		}
+		if !anySuccess {
+			continue
+		}
+
+		globs := globsFromExtensions(allFiles)
+		if len(globs) == 0 {
+			continue
+		}
+		rule.Paths = globs
+		updated++
+	}
+	return updated
+}

--- a/internal/smelter/paths.go
+++ b/internal/smelter/paths.go
@@ -27,7 +27,8 @@ var prNumberPattern = regexp.MustCompile(`copilot:PR#(\d+)`)
 
 // extractPRNumber parses the PR number from a single source token. Returns
 // (n, true) when the source contains a copilot:PR#N reference; (0, false)
-// otherwise.
+// otherwise. Only the first match is returned — use extractPRNumbers when a
+// source string may contain multiple copilot:PR#N tokens.
 func extractPRNumber(source string) (int, bool) {
 	m := prNumberPattern.FindStringSubmatch(source)
 	if m == nil {
@@ -38,6 +39,30 @@ func extractPRNumber(source string) (int, bool) {
 		return 0, false
 	}
 	return n, true
+}
+
+// extractPRNumbers returns all unique PR numbers found in a single source
+// string. A source like "copilot:PR#1, copilot:PR#2" yields [1, 2]. Results
+// are deduplicated but preserve order of first appearance.
+func extractPRNumbers(source string) []int {
+	matches := prNumberPattern.FindAllStringSubmatch(source, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	var nums []int
+	for _, m := range matches {
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		nums = append(nums, n)
+	}
+	return nums
 }
 
 // fetchChangedFiles is the package-level entry point used by runPathsBackfill
@@ -129,7 +154,17 @@ func globsFromExtensions(files []string) []string {
 // produced at least one glob.
 //
 // Returns the number of rules whose Paths was populated.
+// prFetchResult caches the outcome of a single gh API call for one PR.
+type prFetchResult struct {
+	files []string
+	err   error
+}
+
 func (s *Smelter) runPathsBackfill(ctx context.Context, wtPath, anvilName string, rf *warden.RulesFile) int {
+	// Cache fetched file lists per PR number so that multiple rules referencing
+	// the same PR number do not trigger redundant gh API calls.
+	prCache := make(map[int]prFetchResult)
+
 	var updated int
 	for i := range rf.Rules {
 		if ctx.Err() != nil {
@@ -141,18 +176,18 @@ func (s *Smelter) runPathsBackfill(ctx context.Context, wtPath, anvilName string
 		}
 
 		// Collect unique PR numbers referenced by this rule's sources.
+		// extractPRNumbers handles source strings that contain multiple
+		// copilot:PR#N tokens (e.g. "copilot:PR#1, copilot:PR#2").
 		var prNums []int
 		seenPR := make(map[int]struct{})
 		for _, src := range rule.Source {
-			n, ok := extractPRNumber(src)
-			if !ok {
-				continue
+			for _, n := range extractPRNumbers(src) {
+				if _, dup := seenPR[n]; dup {
+					continue
+				}
+				seenPR[n] = struct{}{}
+				prNums = append(prNums, n)
 			}
-			if _, dup := seenPR[n]; dup {
-				continue
-			}
-			seenPR[n] = struct{}{}
-			prNums = append(prNums, n)
 		}
 		if len(prNums) == 0 {
 			continue
@@ -161,13 +196,18 @@ func (s *Smelter) runPathsBackfill(ctx context.Context, wtPath, anvilName string
 		var allFiles []string
 		var anySuccess bool
 		for _, prNum := range prNums {
-			files, err := fetchChangedFiles(ctx, wtPath, prNum)
-			if err != nil {
-				log.Printf("[smelter] paths backfill: PR#%d for rule %s on %s: %v", prNum, rule.ID, anvilName, err)
+			result, cached := prCache[prNum]
+			if !cached {
+				files, err := fetchChangedFiles(ctx, wtPath, prNum)
+				result = prFetchResult{files: files, err: err}
+				prCache[prNum] = result
+			}
+			if result.err != nil {
+				log.Printf("[smelter] paths backfill: PR#%d for rule %s on %s: %v", prNum, rule.ID, anvilName, result.err)
 				continue
 			}
 			anySuccess = true
-			allFiles = append(allFiles, files...)
+			allFiles = append(allFiles, result.files...)
 		}
 		if !anySuccess {
 			continue

--- a/internal/smelter/paths_test.go
+++ b/internal/smelter/paths_test.go
@@ -1,0 +1,299 @@
+package smelter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/warden"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPRNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		wantN   int
+		wantOK  bool
+	}{
+		{"plain copilot ref", "copilot:PR#130", 130, true},
+		{"larger number", "copilot:PR#1024", 1024, true},
+		{"with surrounding text", "from copilot:PR#42 (merged 2026-01-01)", 42, true},
+		{"quench source is not copilot", "quench:PR#7", 0, false},
+		{"manual entry", "manual", 0, false},
+		{"empty string", "", 0, false},
+		{"missing number", "copilot:PR#", 0, false},
+		{"wrong delimiter", "copilot:PR/130", 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, ok := extractPRNumber(tc.source)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantN, n)
+		})
+	}
+}
+
+func TestGlobsFromExtensions(t *testing.T) {
+	t.Run("derives unique globs sorted", func(t *testing.T) {
+		files := []string{
+			"cmd/forge/main.go",
+			"internal/smelter/smelter.go",
+			"web/src/app.ts",
+			"web/src/components/Foo.ts",
+			"docs/README.md",
+		}
+		globs := globsFromExtensions(files)
+		// Deduped and sorted.
+		assert.Equal(t, []string{"**/*.go", "**/*.md", "**/*.ts"}, globs)
+	})
+
+	t.Run("ignores files without an extension", func(t *testing.T) {
+		files := []string{"Makefile", "LICENSE", ".gitignore"}
+		// ".gitignore" returns ".gitignore" from filepath.Ext (treated as extension),
+		// but we intentionally accept any leading-dot extension. The bare files
+		// (Makefile, LICENSE) have no extension and should be skipped. The
+		// dotfile contributes a glob.
+		globs := globsFromExtensions(files)
+		assert.Equal(t, []string{"**/*.gitignore"}, globs)
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		assert.Nil(t, globsFromExtensions(nil))
+		assert.Nil(t, globsFromExtensions([]string{}))
+	})
+
+	t.Run("all files extensionless returns nil", func(t *testing.T) {
+		assert.Nil(t, globsFromExtensions([]string{"Makefile", "Dockerfile"}))
+	})
+
+	t.Run("dot-only filename is skipped", func(t *testing.T) {
+		// filepath.Ext("foo.") returns ".", which is a degenerate extension.
+		assert.Nil(t, globsFromExtensions([]string{"foo."}))
+	})
+}
+
+// withStubFetcher temporarily replaces the package fetchChangedFiles hook so
+// tests do not invoke the gh CLI. Restored on test cleanup.
+func withStubFetcher(t *testing.T, fn func(context.Context, string, int) ([]string, error)) {
+	t.Helper()
+	prev := fetchChangedFiles
+	fetchChangedFiles = fn
+	t.Cleanup(func() { fetchChangedFiles = prev })
+}
+
+func TestRunPathsBackfill_SkipsRulesWithExistingPaths(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	var calls int
+	withStubFetcher(t, func(_ context.Context, _ string, _ int) ([]string, error) {
+		calls++
+		return []string{"a.go"}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#1"}, Paths: []string{"**/*.go"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 0, updated, "rule with existing Paths must be skipped")
+	assert.Equal(t, 0, calls, "stub fetcher must not be invoked for rules with existing Paths")
+	assert.Equal(t, []string{"**/*.go"}, rf.Rules[0].Paths, "Paths must not be mutated")
+}
+
+func TestRunPathsBackfill_PopulatesPathsFromPR(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	withStubFetcher(t, func(_ context.Context, _ string, prNum int) ([]string, error) {
+		assert.Equal(t, 42, prNum)
+		return []string{
+			"cmd/forge/main.go",
+			"internal/smelter/paths.go",
+			"web/src/app.ts",
+		}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#42"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 1, updated)
+	assert.Equal(t, []string{"**/*.go", "**/*.ts"}, rf.Rules[0].Paths)
+}
+
+func TestRunPathsBackfill_UnionsAcrossMultiplePRs(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	withStubFetcher(t, func(_ context.Context, _ string, prNum int) ([]string, error) {
+		switch prNum {
+		case 1:
+			return []string{"a.go", "b.go"}, nil
+		case 2:
+			return []string{"c.ts", "d.ts"}, nil
+		}
+		t.Fatalf("unexpected PR #%d", prNum)
+		return nil, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#1", "copilot:PR#2"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 1, updated)
+	assert.Equal(t, []string{"**/*.go", "**/*.ts"}, rf.Rules[0].Paths)
+}
+
+func TestRunPathsBackfill_SkipsNonCopilotSources(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	var calls int
+	withStubFetcher(t, func(_ context.Context, _ string, _ int) ([]string, error) {
+		calls++
+		return []string{"a.go"}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"quench:PR#7"}},
+		{ID: "r2", Source: warden.SourceList{"manual"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 0, updated)
+	assert.Equal(t, 0, calls, "rules without copilot sources must not trigger fetcher")
+	assert.Empty(t, rf.Rules[0].Paths)
+	assert.Empty(t, rf.Rules[1].Paths)
+}
+
+func TestRunPathsBackfill_FetchErrorLeavesRuleUnchanged(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	withStubFetcher(t, func(_ context.Context, _ string, _ int) ([]string, error) {
+		return nil, errors.New("gh exploded")
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#42"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 0, updated, "fetch errors must not count as successful backfills")
+	assert.Empty(t, rf.Rules[0].Paths, "Paths must stay empty on error so a future flush can retry")
+}
+
+func TestRunPathsBackfill_PartialFetchSucceedsWhenOnePRWorks(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	withStubFetcher(t, func(_ context.Context, _ string, prNum int) ([]string, error) {
+		if prNum == 1 {
+			return nil, errors.New("gh exploded")
+		}
+		return []string{"foo.go"}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#1", "copilot:PR#2"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 1, updated)
+	assert.Equal(t, []string{"**/*.go"}, rf.Rules[0].Paths)
+}
+
+func TestRunPathsBackfill_NoExtensionsLeavesRuleUnchanged(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	withStubFetcher(t, func(_ context.Context, _ string, _ int) ([]string, error) {
+		return []string{"Makefile", "LICENSE"}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#42"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 0, updated)
+	assert.Empty(t, rf.Rules[0].Paths)
+}
+
+func TestRunPathsBackfill_Idempotency_RepeatedRunIsNoop(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	var calls int
+	withStubFetcher(t, func(_ context.Context, _ string, _ int) ([]string, error) {
+		calls++
+		return []string{"foo.go"}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#1"}},
+	}}
+
+	// First run: populates Paths.
+	first := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	require.Equal(t, 1, first)
+	require.Equal(t, []string{"**/*.go"}, rf.Rules[0].Paths)
+
+	// Second run: rule has Paths, so the pass must skip it entirely — the
+	// stub fetcher must not be called a second time.
+	prevCalls := calls
+	second := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 0, second, "second run must report no updates")
+	assert.Equal(t, prevCalls, calls, "second run must not invoke the fetcher")
+}
+
+func TestRunPathsBackfill_HonorsCanceledContext(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	var calls int
+	withStubFetcher(t, func(_ context.Context, _ string, _ int) ([]string, error) {
+		calls++
+		return []string{"a.go"}, nil
+	})
+
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#1"}},
+		{ID: "r2", Source: warden.SourceList{"copilot:PR#2"}},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	updated := s.runPathsBackfill(ctx, t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 0, updated)
+	assert.Equal(t, 0, calls, "canceled context must short-circuit before any fetch")
+}
+
+func TestRunPathsBackfill_DedupesSameSourceRepeated(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	var calls int
+	withStubFetcher(t, func(_ context.Context, _ string, prNum int) ([]string, error) {
+		calls++
+		assert.Equal(t, 7, prNum)
+		return []string{"x.go"}, nil
+	})
+
+	// Two entries for the same PR should only trigger one fetch.
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#7", "copilot:PR#7"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 1, updated)
+	assert.Equal(t, 1, calls, "duplicate PR references must be deduplicated")
+	assert.Equal(t, []string{"**/*.go"}, rf.Rules[0].Paths)
+}

--- a/internal/smelter/paths_test.go
+++ b/internal/smelter/paths_test.go
@@ -36,6 +36,29 @@ func TestExtractPRNumber(t *testing.T) {
 	}
 }
 
+func TestExtractPRNumbers(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   []int
+	}{
+		{"single ref", "copilot:PR#130", []int{130}},
+		{"comma-separated two refs", "copilot:PR#1, copilot:PR#2", []int{1, 2}},
+		{"space-separated two refs", "copilot:PR#10 copilot:PR#20", []int{10, 20}},
+		{"three refs mixed delimiters", "copilot:PR#3, copilot:PR#5 copilot:PR#7", []int{3, 5, 7}},
+		{"deduplicated when same token repeated", "copilot:PR#42, copilot:PR#42", []int{42}},
+		{"no copilot tokens", "quench:PR#7", nil},
+		{"empty string", "", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractPRNumbers(tc.source)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestGlobsFromExtensions(t *testing.T) {
 	t.Run("derives unique globs sorted", func(t *testing.T) {
 		files := []string{
@@ -274,6 +297,55 @@ func TestRunPathsBackfill_HonorsCanceledContext(t *testing.T) {
 	updated := s.runPathsBackfill(ctx, t.TempDir(), "anvil-a", rf)
 	assert.Equal(t, 0, updated)
 	assert.Equal(t, 0, calls, "canceled context must short-circuit before any fetch")
+}
+
+func TestRunPathsBackfill_MultiTokenSourceString(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	withStubFetcher(t, func(_ context.Context, _ string, prNum int) ([]string, error) {
+		switch prNum {
+		case 10:
+			return []string{"cmd/main.go"}, nil
+		case 20:
+			return []string{"web/app.ts"}, nil
+		}
+		t.Fatalf("unexpected PR #%d", prNum)
+		return nil, nil
+	})
+
+	// Single source string containing two copilot:PR#N tokens separated by a comma.
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#10, copilot:PR#20"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 1, updated)
+	assert.Equal(t, []string{"**/*.go", "**/*.ts"}, rf.Rules[0].Paths)
+}
+
+func TestRunPathsBackfill_CachesResultsAcrossRules(t *testing.T) {
+	db := openTestDB(t)
+	s := New(db, 0, map[string]string{})
+
+	var calls int
+	withStubFetcher(t, func(_ context.Context, _ string, prNum int) ([]string, error) {
+		calls++
+		assert.Equal(t, 99, prNum)
+		return []string{"a.go"}, nil
+	})
+
+	// Two rules both reference the same PR — the fetcher must only be called once.
+	rf := &warden.RulesFile{Rules: []warden.Rule{
+		{ID: "r1", Source: warden.SourceList{"copilot:PR#99"}},
+		{ID: "r2", Source: warden.SourceList{"copilot:PR#99"}},
+	}}
+
+	updated := s.runPathsBackfill(context.Background(), t.TempDir(), "anvil-a", rf)
+	assert.Equal(t, 2, updated)
+	assert.Equal(t, 1, calls, "fetch result must be cached and reused across rules")
+	assert.Equal(t, []string{"**/*.go"}, rf.Rules[0].Paths)
+	assert.Equal(t, []string{"**/*.go"}, rf.Rules[1].Paths)
 }
 
 func TestRunPathsBackfill_DedupesSameSourceRepeated(t *testing.T) {

--- a/internal/smelter/smelter.go
+++ b/internal/smelter/smelter.go
@@ -379,10 +379,22 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 	//     rf.Rules after this step.
 	staleArchived := s.runStaleness(anvilName, rf)
 
-	if added == 0 && len(consolidationSummary) == 0 && len(staleArchived) == 0 {
+	// 2d. Pass 3 paths backfill: for each active rule whose Paths field is
+	//     empty and whose Source carries a copilot:PR#N token, fetch the
+	//     PR's changed files and derive file-extension globs. Idempotent:
+	//     rules with non-empty Paths are skipped. Pass 3 only mutates
+	//     existing rules in rf, so no archive write is required.
+	pathsBackfilled := s.runPathsBackfill(ctx, wt.Path, anvilName, rf)
+	if pathsBackfilled > 0 {
+		log.Printf("[smelter] paths backfilled on %d rule(s) for %s", pathsBackfilled, anvilName)
+		_ = s.db.LogEvent(state.EventSmelterFlushed,
+			fmt.Sprintf("Backfilled paths on %d rule(s) for %s", pathsBackfilled, anvilName), "", anvilName)
+	}
+
+	if added == 0 && len(consolidationSummary) == 0 && len(staleArchived) == 0 && pathsBackfilled == 0 {
 		// All rules were duplicates (already in the file) or malformed AND
-		// nothing was consolidated AND nothing aged out. Delete from DB and
-		// emit a flush event.
+		// nothing was consolidated, aged out, or path-backfilled. Delete
+		// from DB and emit a flush event.
 		log.Printf("[smelter] All %d pending rule(s) for %s were duplicates or malformed — cleaning up", len(rules), anvilName)
 		if err := s.db.DeletePendingRules(flushedIDs); err != nil {
 			return err
@@ -405,7 +417,7 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 	}
 
 	// 4. Commit and force-push from the worktree.
-	if err := s.commitAndPush(ctx, wt.Path, branch, added, consolidationSummary, staleArchived); err != nil {
+	if err := s.commitAndPush(ctx, wt.Path, branch, added, consolidationSummary, staleArchived, pathsBackfilled); err != nil {
 		return fmt.Errorf("commit/push for %s: %w", anvilName, err)
 	}
 
@@ -535,8 +547,10 @@ func (s *Smelter) archiveRules(wtPath string, archived []warden.Rule, summary []
 // worktree. The worktree is already on the correct branch. When summary is
 // non-empty it is appended to the commit message body so reviewers can see
 // which clusters were merged. When stale is non-empty its count is included
-// in the commit subject so reviewers can see how many rules aged out.
-func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, ruleCount int, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
+// in the commit subject so reviewers can see how many rules aged out. When
+// pathsBackfilled is positive its count is included in the commit subject
+// so reviewers can see how many existing rules picked up new Paths.
+func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, ruleCount int, summary []warden.MergeResult, stale []warden.ArchivedRule, pathsBackfilled int) error {
 	gitEnv := cleanGitEnv()
 	git := func(args ...string) error {
 		cmdCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -575,6 +589,9 @@ func (s *Smelter) commitAndPush(ctx context.Context, wtPath, branch string, rule
 	}
 	if len(stale) > 0 {
 		parts = append(parts, fmt.Sprintf("archive %d stale rule(s)", len(stale)))
+	}
+	if pathsBackfilled > 0 {
+		parts = append(parts, fmt.Sprintf("backfill paths on %d rule(s)", pathsBackfilled))
 	}
 	var subject string
 	if len(parts) == 0 {

--- a/internal/smelter/smelter_test.go
+++ b/internal/smelter/smelter_test.go
@@ -728,6 +728,6 @@ func TestCommitAndPush_FreshWorktreeWithExistingRemoteBranch(t *testing.T) {
 
 	// commitAndPush must succeed: the fetch populates the remote-tracking ref
 	// so --force-with-lease can verify the lease and allow the push.
-	err = s.commitAndPush(ctx, localDir, branch, 1, nil, nil)
+	err = s.commitAndPush(ctx, localDir, branch, 1, nil, nil, 0)
 	require.NoError(t, err, "commitAndPush should succeed after fetching remote-tracking ref")
 }


### PR DESCRIPTION
## Changes

- **Smelter paths backfill pass (Pass 3)** - After the staleness pass, the Smelter now backfills `Paths` on active warden rules whose Paths field is empty and whose Source carries a `copilot:PR#N` token. The pass calls the GitHub API for the referenced PR(s), unions the changed file extensions, and writes them as doublestar globs (e.g. `.go` → `**/*.go`). The pass is idempotent — rules with non-empty Paths are skipped. The commit subject and `smelter_flushed` events surface how many rules picked up new Paths per anvil. (Forge-abrp)

## Original Issue (task): Pass 3: Paths backfill via GitHub PR changed files

After Pass 2, implement Pass 3 in the same merge step. Iterate active rules and skip any whose Paths field (added by Half A) is already populated (idempotency requirement). For rules with empty Paths whose Source contains a 'copilot:PR#N' token, parse N, call the GitHub API (gh.PullRequests.ListFiles or equivalent) to fetch changed files, derive unique file extensions, and map them to glob patterns ('.go' → '**/*.go', '.ts' → '**/*.ts'). Populate rule.Paths with the derived globs. Implement extractPRNumber(source string) (int, bool), fetchChangedFiles(ctx, prNum) ([]string, error), and globsFromExtensions(files []string) []string. Depends on Half A's Rule.Paths field.

---
Bead: Forge-abrp | Branch: forge/Forge-abrp
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->