### PR TITLE
CLI subcommands: consolidate + restore (Forge-59jt)

### DIFF
--- a/changelog.d/Forge-59jt.md
+++ b/changelog.d/Forge-59jt.md
@@ -1,0 +1,3 @@
+category: Added
+- **`forge warden consolidate <anvil>`** - Off-cycle CLI trigger for the three-pass smelter consolidation (cluster merge, staleness archive, paths backfill) against a named anvil. Writes both `.forge/warden-rules.yaml` and `.forge/warden-rules.archive.yaml` in place so the caller can review and commit. (Forge-59jt)
+- **`forge warden restore <rule-id> --anvil <name>`** - Move an archived warden rule back into the active rules file. The embedded Rule (id/category/pattern/check/source/added/paths) is preserved verbatim so a subsequent consolidate pass would re-archive the same content; archive bookkeeping (archived_at/last_seen/archive_reason/superseded_by) is dropped on restore. (Forge-59jt)

--- a/cmd/forge/warden.go
+++ b/cmd/forge/warden.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/smelter"
 	"github.com/Robin831/Forge/internal/warden"
 	"github.com/spf13/cobra"
 )
@@ -24,9 +25,14 @@ func init() {
 	wardenListCmd.Flags().StringP("anvil", "a", "", "Anvil name (required)")
 	_ = wardenListCmd.MarkFlagRequired("anvil")
 
+	wardenRestoreCmd.Flags().StringP("anvil", "a", "", "Anvil name (required)")
+	_ = wardenRestoreCmd.MarkFlagRequired("anvil")
+
 	wardenCmd.AddCommand(wardenLearnCmd)
 	wardenCmd.AddCommand(wardenForgetCmd)
 	wardenCmd.AddCommand(wardenListCmd)
+	wardenCmd.AddCommand(wardenConsolidateCmd)
+	wardenCmd.AddCommand(wardenRestoreCmd)
 	rootCmd.AddCommand(wardenCmd)
 }
 
@@ -256,4 +262,155 @@ func truncateStr(s string, max int) string {
 		return s
 	}
 	return s[:max-3] + "..."
+}
+
+var wardenConsolidateCmd = &cobra.Command{
+	Use:   "consolidate <anvil>",
+	Short: "Run the three-pass smelter consolidation against an anvil",
+	Long: `Off-cycle manual trigger for the same three-pass merge logic the
+scheduled smelter runs:
+  Pass 1 — cluster near-duplicate rules and merge each cluster.
+  Pass 2 — archive rules whose Added date is older than archive_after_days.
+  Pass 3 — backfill the Paths field from each rule's source PR(s).
+
+Writes both .forge/warden-rules.yaml and .forge/warden-rules.archive.yaml
+in-place under the anvil so the caller can commit them. The pending warden
+rules queue in state.db is NOT consulted — this command only operates on
+what is already in the active rules file.`,
+	Args:    cobra.ExactArgs(1),
+	Example: "  forge warden consolidate munin",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		anvilName := args[0]
+
+		if cfg == nil {
+			loaded, err := config.Load(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			cfg = loaded
+		}
+
+		anvil, ok := cfg.Anvils[anvilName]
+		if !ok {
+			return fmt.Errorf("anvil %q not found in config", anvilName)
+		}
+
+		opts := smelter.ConsolidateOptions{
+			AnvilPath:        anvil.Path,
+			AnvilName:        anvilName,
+			Consolidator:     warden.DefaultConsolidationRunner(),
+			DedupThreshold:   cfg.Settings.Warden.ResolvedDedupThreshold(),
+			ArchiveAfterDays: cfg.Settings.Warden.ResolvedArchiveAfterDays(),
+		}
+
+		fmt.Fprintf(os.Stderr, "Running three-pass consolidation against %s (dedup_threshold=%.2f, archive_after_days=%d)...\n",
+			anvilName, opts.DedupThreshold, opts.ArchiveAfterDays)
+
+		result, err := smelter.ConsolidateAnvil(rootCtx, opts)
+		if err != nil {
+			return fmt.Errorf("consolidate %s: %w", anvilName, err)
+		}
+
+		// Print a structured summary.
+		fmt.Printf("Anvil:           %s\n", anvilName)
+		fmt.Printf("Active before:   %d\n", result.InitialCount)
+		fmt.Printf("Active after:    %d\n", result.FinalActive)
+		fmt.Printf("Archive size:    %d\n", result.ArchiveCount)
+		if n := len(result.Passes.Consolidated); n > 0 {
+			fmt.Printf("Consolidated:    %d cluster(s)\n", n)
+		}
+		if n := len(result.Passes.Archived); n > 0 {
+			fmt.Printf("Archived stale:  %d rule(s)\n", n)
+		}
+		if n := len(result.Passes.Backfilled); n > 0 {
+			fmt.Printf("Backfilled:      %d rule(s)\n", n)
+		}
+		if !result.Passes.HasChanges() {
+			fmt.Println("No changes — active rules file already at steady state.")
+		} else {
+			fmt.Printf("\nWrote %s\n", warden.RulesPath(anvil.Path))
+			fmt.Printf("Wrote %s\n", warden.ArchivePath(anvil.Path))
+			fmt.Println("Review and commit the changes when ready.")
+		}
+		if result.FirstError != nil {
+			fmt.Fprintf(os.Stderr, "Warning: first consolidation cluster error: %v\n", result.FirstError)
+		}
+		return nil
+	},
+}
+
+var wardenRestoreCmd = &cobra.Command{
+	Use:   "restore <rule-id>",
+	Short: "Move an archived warden rule back into the active rules file",
+	Long: `Look up rule-id in .forge/warden-rules.archive.yaml for the given
+anvil, remove it from the archive, re-insert it into .forge/warden-rules.yaml,
+and write both files. The embedded Rule (id, category, pattern, check, source,
+added, paths) is preserved verbatim so a subsequent consolidate pass would
+archive the same content.
+
+Archive bookkeeping fields (archived_at, last_seen, archive_reason,
+superseded_by) are intentionally dropped on restore — the active file does
+not carry them. Re-archiving the rule later generates fresh bookkeeping.`,
+	Args:    cobra.ExactArgs(1),
+	Example: "  forge warden restore stale-rule-id --anvil munin",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ruleID := args[0]
+		anvilName, _ := cmd.Flags().GetString("anvil")
+
+		if cfg == nil {
+			loaded, err := config.Load(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			cfg = loaded
+		}
+
+		anvil, ok := cfg.Anvils[anvilName]
+		if !ok {
+			return fmt.Errorf("anvil %q not found in config", anvilName)
+		}
+
+		archivePath := warden.ArchivePath(anvil.Path)
+		archive, err := warden.LoadArchive(archivePath)
+		if err != nil {
+			return fmt.Errorf("loading archive: %w", err)
+		}
+		if len(archive.Rules) == 0 {
+			return fmt.Errorf("archive is empty at %s", archivePath)
+		}
+
+		archived, found := archive.Remove(ruleID)
+		if !found {
+			return fmt.Errorf("rule %q not found in archive %s", ruleID, archivePath)
+		}
+
+		rf, err := warden.LoadRules(anvil.Path)
+		if err != nil {
+			return fmt.Errorf("loading active rules: %w", err)
+		}
+
+		// AddRule preserves the embedded Rule's fields verbatim (including
+		// Added) and only fills Added when empty — restore keeps the original
+		// timestamp so a subsequent consolidate sees the same Rule content.
+		if !rf.AddRule(archived.Rule) {
+			return fmt.Errorf("rule %q already exists in active rules file %s; archive entry was not removed",
+				ruleID, warden.RulesPath(anvil.Path))
+		}
+
+		// Write active rules first: if archive save then fails, the rule is
+		// duplicated rather than lost. The reverse ordering would risk losing
+		// the rule entirely if the active-file write failed mid-flight.
+		if err := warden.SaveRules(anvil.Path, rf); err != nil {
+			return fmt.Errorf("saving active rules: %w", err)
+		}
+		if err := archive.Save(archivePath); err != nil {
+			return fmt.Errorf("saving archive (active file already updated; rule duplicated): %w", err)
+		}
+
+		fmt.Printf("Restored rule %q to %s\n", ruleID, warden.RulesPath(anvil.Path))
+		fmt.Printf("Removed from %s (was archived: reason=%q, superseded_by=%q)\n",
+			archivePath, archived.ArchiveReason, archived.SupersededBy)
+		fmt.Printf("Active rules: %d  Archive: %d\n", len(rf.Rules), len(archive.Rules))
+		return nil
+	},
 }

--- a/cmd/forge/warden.go
+++ b/cmd/forge/warden.go
@@ -273,10 +273,12 @@ scheduled smelter runs:
   Pass 2 — archive rules whose Added date is older than archive_after_days.
   Pass 3 — backfill the Paths field from each rule's source PR(s).
 
-Writes both .forge/warden-rules.yaml and .forge/warden-rules.archive.yaml
-in-place under the anvil so the caller can commit them. The pending warden
-rules queue in state.db is NOT consulted — this command only operates on
-what is already in the active rules file.`,
+Always writes .forge/warden-rules.yaml when any pass produced changes.
+.forge/warden-rules.archive.yaml is written only when Pass 1 or Pass 2
+produced archive entries (duplicate or stale rules); a backfill-only run
+leaves the archive file unchanged. The pending warden rules queue in
+state.db is NOT consulted — this command only operates on what is already
+in the active rules file.`,
 	Args:    cobra.ExactArgs(1),
 	Example: "  forge warden consolidate munin",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -329,7 +331,9 @@ what is already in the active rules file.`,
 			fmt.Println("No changes — active rules file already at steady state.")
 		} else {
 			fmt.Printf("\nWrote %s\n", warden.RulesPath(anvil.Path))
-			fmt.Printf("Wrote %s\n", warden.ArchivePath(anvil.Path))
+			if len(result.Passes.Consolidated) > 0 || len(result.Passes.Archived) > 0 {
+				fmt.Printf("Wrote %s\n", warden.ArchivePath(anvil.Path))
+			}
 			fmt.Println("Review and commit the changes when ready.")
 		}
 		if result.FirstError != nil {

--- a/internal/smelter/consolidate_anvil.go
+++ b/internal/smelter/consolidate_anvil.go
@@ -70,9 +70,9 @@ type ConsolidateResult struct {
 // ConsolidateAnvil loads the warden rules file under opts.AnvilPath, runs
 // the three smelter passes (Pass 1 cluster consolidation, Pass 2 staleness
 // archive, Pass 3 paths backfill) against the in-memory rules, and persists
-// both the active rules file and the archive file when any pass produced
-// changes. Idempotent: rerunning against an already-consolidated file is a
-// no-op (Passes.HasChanges() will be false in the result).
+// the results when any pass produced changes. Idempotent: rerunning against
+// an already-consolidated file is a no-op (Passes.HasChanges() will be
+// false in the result).
 //
 // Pass 1 is skipped when opts.Consolidator is nil or opts.DedupThreshold
 // <= 0. Pass 2 is skipped when opts.ArchiveAfterDays <= 0. Pass 3 has no
@@ -80,9 +80,13 @@ type ConsolidateResult struct {
 // and whose Paths field is empty (idempotent on already-backfilled rules).
 //
 // Behaviour notes:
-//   - When persistence is required, the archive is written before the
-//     active rules so a partial failure can never leave the active file
-//     without a matching archive record.
+//   - The active rules file is always written when any pass produced changes.
+//   - The archive file is written only when Pass 1 (duplicates) or Pass 2
+//     (stale rules) produced entries to archive. A Pass 3-only run updates
+//     the active rules file but leaves the archive file untouched.
+//   - When the archive is written, it lands before the active rules file so
+//     a partial failure can never leave the active file without a matching
+//     archive record.
 //   - The pending warden rules queue in state.db is NOT consulted —
 //     ConsolidateAnvil operates only on what is already on disk. Pulling
 //     pending rules into the active file remains the smelter loop's

--- a/internal/smelter/consolidate_anvil.go
+++ b/internal/smelter/consolidate_anvil.go
@@ -1,0 +1,184 @@
+package smelter
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Robin831/Forge/internal/warden"
+)
+
+// ConsolidateOptions configures a single off-cycle three-pass consolidation
+// run against the warden rules file at AnvilPath. The same option set is
+// used by the scheduled smelter loop and by the `forge warden consolidate`
+// CLI command so both code paths share one implementation.
+type ConsolidateOptions struct {
+	// AnvilPath is the on-disk path to the anvil root. Both
+	// .forge/warden-rules.yaml and .forge/warden-rules.archive.yaml are
+	// resolved relative to it.
+	AnvilPath string
+	// AnvilName is used in log messages and event payloads.
+	AnvilName string
+	// Consolidator is the AI invocation hook used by Pass 1. When nil, Pass
+	// 1 is skipped.
+	Consolidator warden.ConsolidationRunner
+	// DedupThreshold is the Jaccard similarity threshold (0.0–1.0) above
+	// which two rules in the same category are considered duplicates. When
+	// <= 0, Pass 1 is skipped.
+	DedupThreshold float64
+	// ArchiveAfterDays is the staleness threshold in days for Pass 2. When
+	// <= 0, Pass 2 is skipped.
+	ArchiveAfterDays int
+	// Now optionally overrides the reference time used by the staleness
+	// pass. Zero defaults to time.Now().UTC().
+	Now time.Time
+	// EventLogger is an optional callback for surfacing per-pass progress
+	// to an external sink. The scheduled smelter wires this to the state
+	// DB; CLI invocations may pass nil. Called with (eventName, message).
+	EventLogger func(name, message string)
+}
+
+// ConsolidateResult bundles the structured output of a three-pass run.
+// Callers (smelter loop / CLI) use it to render a summary and (in the CLI
+// case) decide whether to print "no changes".
+type ConsolidateResult struct {
+	// Passes captures the per-pass outcomes in the standard PassResults
+	// shape so the same commit-message and summary helpers work for both
+	// scheduled and off-cycle runs.
+	Passes PassResults
+	// Pass1Archived lists the original rules superseded by Pass 1 merges.
+	// Surfaced so callers that drive the smelter flushAnvil path (which
+	// writes them to the archive store) can reuse the same result.
+	Pass1Archived []warden.Rule
+	// InitialCount is the rule count loaded from the active file before
+	// any pass ran.
+	InitialCount int
+	// FinalActive is the rule count in the active file after all passes
+	// completed and persistence (when any pass produced changes) ran.
+	FinalActive int
+	// ArchiveCount is the entry count in the archive file after the run.
+	// Zero when no archive file exists.
+	ArchiveCount int
+	// FirstError is the first non-fatal error encountered during Pass 1
+	// (typically an AI runner failure for a single cluster). The run
+	// proceeds despite this; callers may choose to surface it in their
+	// summary.
+	FirstError error
+}
+
+// ConsolidateAnvil loads the warden rules file under opts.AnvilPath, runs
+// the three smelter passes (Pass 1 cluster consolidation, Pass 2 staleness
+// archive, Pass 3 paths backfill) against the in-memory rules, and persists
+// both the active rules file and the archive file when any pass produced
+// changes. Idempotent: rerunning against an already-consolidated file is a
+// no-op (Passes.HasChanges() will be false in the result).
+//
+// Pass 1 is skipped when opts.Consolidator is nil or opts.DedupThreshold
+// <= 0. Pass 2 is skipped when opts.ArchiveAfterDays <= 0. Pass 3 has no
+// threshold and runs over rules whose Source carries a copilot:PR#N token
+// and whose Paths field is empty (idempotent on already-backfilled rules).
+//
+// Behaviour notes:
+//   - When persistence is required, the archive is written before the
+//     active rules so a partial failure can never leave the active file
+//     without a matching archive record.
+//   - The pending warden rules queue in state.db is NOT consulted —
+//     ConsolidateAnvil operates only on what is already on disk. Pulling
+//     pending rules into the active file remains the smelter loop's
+//     responsibility.
+//   - When opts.Consolidator returns errors for individual clusters they
+//     are aggregated and the first one is reported in the result; the
+//     remaining clusters still merge.
+func ConsolidateAnvil(ctx context.Context, opts ConsolidateOptions) (ConsolidateResult, error) {
+	rf, err := warden.LoadRules(opts.AnvilPath)
+	if err != nil {
+		return ConsolidateResult{}, fmt.Errorf("loading warden rules: %w", err)
+	}
+	initialCount := len(rf.Rules)
+
+	var (
+		summary       []warden.MergeResult
+		replaced      []warden.Rule
+		firstPassErr  error
+	)
+	if opts.Consolidator != nil && opts.DedupThreshold > 0 {
+		var errs []error
+		replaced, summary, errs = warden.Consolidate(ctx, opts.AnvilPath, rf, opts.DedupThreshold, opts.Consolidator)
+		for i, e := range errs {
+			if i == 0 {
+				firstPassErr = e
+				continue
+			}
+			log.Printf("[smelter] additional consolidation error for %s: %v", opts.AnvilName, e)
+		}
+		if len(summary) > 0 {
+			log.Printf("[smelter] consolidated %d cluster(s) for %s", len(summary), opts.AnvilName)
+			if opts.EventLogger != nil {
+				opts.EventLogger("smelter_flushed",
+					fmt.Sprintf("Consolidated %d cluster(s) for %s", len(summary), opts.AnvilName))
+			}
+		}
+	}
+
+	var stale []warden.ArchivedRule
+	if opts.ArchiveAfterDays > 0 {
+		now := opts.Now
+		if now.IsZero() {
+			now = time.Now().UTC()
+		}
+		var active []warden.Rule
+		active, stale = warden.ArchiveStale(rf.Rules, opts.ArchiveAfterDays, now)
+		if len(stale) > 0 {
+			rf.Rules = active
+			log.Printf("[smelter] archived %d stale rule(s) for %s (threshold=%dd)", len(stale), opts.AnvilName, opts.ArchiveAfterDays)
+			if opts.EventLogger != nil {
+				opts.EventLogger("smelter_flushed",
+					fmt.Sprintf("Archived %d stale rule(s) for %s", len(stale), opts.AnvilName))
+			}
+		}
+	}
+
+	backfilled := pathsBackfill(ctx, opts.AnvilPath, opts.AnvilName, rf)
+	if len(backfilled) > 0 {
+		log.Printf("[smelter] paths backfilled on %d rule(s) for %s", len(backfilled), opts.AnvilName)
+		if opts.EventLogger != nil {
+			opts.EventLogger("smelter_flushed",
+				fmt.Sprintf("Backfilled paths on %d rule(s) for %s", len(backfilled), opts.AnvilName))
+		}
+	}
+
+	passes := PassResults{
+		Consolidated: summary,
+		Archived:     stale,
+		Backfilled:   backfilled,
+	}
+
+	result := ConsolidateResult{
+		Passes:        passes,
+		Pass1Archived: replaced,
+		InitialCount:  initialCount,
+		FinalActive:   len(rf.Rules),
+		FirstError:    firstPassErr,
+	}
+
+	if !passes.HasChanges() {
+		// Even with no changes, surface the archive size so the CLI can
+		// report the file is already at steady state.
+		if a, err := warden.LoadArchive(warden.ArchivePath(opts.AnvilPath)); err == nil && a != nil {
+			result.ArchiveCount = len(a.Rules)
+		}
+		return result, nil
+	}
+
+	if err := persistRulesAndArchive(opts.AnvilPath, rf, replaced, summary, stale); err != nil {
+		return result, fmt.Errorf("persisting warden rules: %w", err)
+	}
+
+	// Re-read the archive after writing so the reported size reflects what
+	// landed on disk (deduplicated by ID).
+	if a, err := warden.LoadArchive(warden.ArchivePath(opts.AnvilPath)); err == nil && a != nil {
+		result.ArchiveCount = len(a.Rules)
+	}
+	return result, nil
+}

--- a/internal/smelter/consolidate_anvil_test.go
+++ b/internal/smelter/consolidate_anvil_test.go
@@ -1,0 +1,184 @@
+package smelter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Forge/internal/warden"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeRulesFile renders a RulesFile to .forge/warden-rules.yaml under anvilPath.
+func writeRulesFile(t *testing.T, anvilPath string, rf *warden.RulesFile) {
+	t.Helper()
+	require.NoError(t, warden.SaveRules(anvilPath, rf))
+}
+
+func TestConsolidateAnvil_NoChanges_LeavesFilesUntouched(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, &warden.RulesFile{
+		Rules: []warden.Rule{
+			{ID: "r1", Category: "style", Pattern: "p1", Check: "c1", Source: warden.SourceList{"manual"}, Added: "2026-05-01"},
+		},
+	})
+	rulesPath := warden.RulesPath(dir)
+	before, err := os.ReadFile(rulesPath)
+	require.NoError(t, err)
+
+	res, err := ConsolidateAnvil(context.Background(), ConsolidateOptions{
+		AnvilPath: dir,
+		AnvilName: "test",
+		// Pass 1 disabled (no consolidator), Pass 2 disabled (no threshold),
+		// Pass 3 yields nothing because the only rule has no copilot:PR#N source.
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Passes.HasChanges())
+	assert.Equal(t, 1, res.InitialCount)
+	assert.Equal(t, 1, res.FinalActive)
+
+	// Archive file should not be created when no pass produced changes.
+	_, statErr := os.Stat(warden.ArchivePath(dir))
+	assert.True(t, os.IsNotExist(statErr), "archive must not be created when nothing changed")
+
+	// Active rules file must be byte-identical to the input.
+	after, err := os.ReadFile(rulesPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "active file must not be rewritten when no pass produced changes")
+}
+
+func TestConsolidateAnvil_StalenessPersistsArchive(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, &warden.RulesFile{
+		Rules: []warden.Rule{
+			{ID: "ancient", Category: "style", Pattern: "p", Check: "c", Source: warden.SourceList{"manual"}, Added: "2020-01-01"},
+			{ID: "fresh", Category: "style", Pattern: "p2", Check: "c2", Source: warden.SourceList{"manual"}, Added: "2026-05-01"},
+		},
+	})
+
+	now := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	res, err := ConsolidateAnvil(context.Background(), ConsolidateOptions{
+		AnvilPath:        dir,
+		AnvilName:        "test",
+		ArchiveAfterDays: 30,
+		Now:              now,
+	})
+	require.NoError(t, err)
+	require.True(t, res.Passes.HasChanges())
+	assert.Len(t, res.Passes.Archived, 1)
+	assert.Equal(t, "ancient", res.Passes.Archived[0].ID)
+	assert.Equal(t, 1, res.FinalActive)
+	assert.Equal(t, 1, res.ArchiveCount)
+
+	// Active file no longer contains the stale rule.
+	active, err := warden.LoadRules(dir)
+	require.NoError(t, err)
+	require.Len(t, active.Rules, 1)
+	assert.Equal(t, "fresh", active.Rules[0].ID)
+
+	// Archive file contains the stale rule with reason="stale".
+	archive, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, archive.Rules, 1)
+	assert.Equal(t, "ancient", archive.Rules[0].ID)
+	assert.Equal(t, warden.ArchiveReasonStale, archive.Rules[0].ArchiveReason)
+}
+
+func TestConsolidateAnvil_RoundTripPreservesContent(t *testing.T) {
+	// Verifies the bead's contract: archive→active (restore) → archive
+	// (consolidate) preserves the embedded Rule's content (ID, Category,
+	// Pattern, Check, Source, Added, Paths) byte-for-byte.
+	dir := t.TempDir()
+
+	// Start: a single rule sits in the archive, active is empty.
+	original := warden.Rule{
+		ID:       "round-trip-rule",
+		Category: "style",
+		Pattern:  "a long pattern about something",
+		Check:    "verify the thing",
+		Source:   warden.SourceList{"manual", "copilot:PR#42"},
+		Added:    "2020-01-01",
+		Paths:    []string{"**/*.go"},
+	}
+	archive := &warden.Archive{}
+	archive.Add(original, warden.ArchiveReasonStale, "")
+	require.NoError(t, archive.Save(warden.ArchivePath(dir)))
+	writeRulesFile(t, dir, &warden.RulesFile{})
+
+	// Simulate restore: pull the rule out of the archive into active.
+	loadedArchive, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	restored, ok := loadedArchive.Remove(original.ID)
+	require.True(t, ok)
+	rf, err := warden.LoadRules(dir)
+	require.NoError(t, err)
+	require.True(t, rf.AddRule(restored.Rule))
+	require.NoError(t, warden.SaveRules(dir, rf))
+	require.NoError(t, loadedArchive.Save(warden.ArchivePath(dir)))
+
+	// Confirm the active file now holds the restored rule with identical content.
+	afterRestore, err := warden.LoadRules(dir)
+	require.NoError(t, err)
+	require.Len(t, afterRestore.Rules, 1)
+	assert.Equal(t, original, afterRestore.Rules[0],
+		"restored rule must be byte-equivalent to the original Rule content")
+
+	// Re-archive via consolidate (using a far-future "now" so the stale pass picks it up).
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	res, err := ConsolidateAnvil(context.Background(), ConsolidateOptions{
+		AnvilPath:        dir,
+		AnvilName:        "test",
+		ArchiveAfterDays: 30,
+		Now:              now,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Passes.Archived, 1)
+
+	// The archive must contain a rule whose embedded Rule equals the original.
+	finalArchive, err := warden.LoadArchive(warden.ArchivePath(dir))
+	require.NoError(t, err)
+	require.Len(t, finalArchive.Rules, 1)
+	assert.Equal(t, original, finalArchive.Rules[0].Rule,
+		"archive→active→archive must preserve the embedded Rule content")
+}
+
+func TestConsolidateAnvil_LoadError(t *testing.T) {
+	// Pointing AnvilPath at a non-existent directory should NOT error —
+	// LoadRules returns empty for missing files. The run becomes a no-op.
+	dir := filepath.Join(t.TempDir(), "missing")
+	res, err := ConsolidateAnvil(context.Background(), ConsolidateOptions{
+		AnvilPath: dir,
+		AnvilName: "missing",
+	})
+	require.NoError(t, err)
+	assert.False(t, res.Passes.HasChanges())
+	assert.Equal(t, 0, res.InitialCount)
+}
+
+func TestConsolidateAnvil_EventLoggerInvoked(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, &warden.RulesFile{
+		Rules: []warden.Rule{
+			{ID: "ancient", Category: "style", Pattern: "p", Check: "c", Source: warden.SourceList{"manual"}, Added: "2020-01-01"},
+		},
+	})
+
+	var events []string
+	now := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	_, err := ConsolidateAnvil(context.Background(), ConsolidateOptions{
+		AnvilPath:        dir,
+		AnvilName:        "test",
+		ArchiveAfterDays: 30,
+		Now:              now,
+		EventLogger: func(name, msg string) {
+			events = append(events, name+":"+msg)
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Contains(t, events[0], "smelter_flushed:")
+	assert.Contains(t, events[0], "Archived 1 stale rule(s)")
+}

--- a/internal/smelter/paths.go
+++ b/internal/smelter/paths.go
@@ -163,6 +163,13 @@ type prFetchResult struct {
 }
 
 func (s *Smelter) runPathsBackfill(ctx context.Context, wtPath, anvilName string, rf *warden.RulesFile) []string {
+	return pathsBackfill(ctx, wtPath, anvilName, rf)
+}
+
+// pathsBackfill is the free-function form of runPathsBackfill. It carries no
+// dependency on Smelter state so the off-cycle CLI consolidate command can
+// share the same Pass 3 implementation as the scheduled smelter loop.
+func pathsBackfill(ctx context.Context, wtPath, anvilName string, rf *warden.RulesFile) []string {
 	// Cache fetched file lists per PR number so that multiple rules referencing
 	// the same PR number do not trigger redundant gh API calls.
 	prCache := make(map[int]prFetchResult)

--- a/internal/smelter/smelter.go
+++ b/internal/smelter/smelter.go
@@ -419,7 +419,7 @@ func (s *Smelter) flushAnvil(ctx context.Context, anvilName, anvilPath string, r
 	//    archive entry for the rules it replaced (the bead contract). If
 	//    either step fails we abort before staging/commit/push, leaving the
 	//    pending queue intact for the next flush.
-	if err := s.persistRulesAndArchive(wt.Path, rf, archived, consolidationSummary, staleArchived); err != nil {
+	if err := persistRulesAndArchive(wt.Path, rf, archived, consolidationSummary, staleArchived); err != nil {
 		return fmt.Errorf("persisting warden rules for %s: %w", anvilName, err)
 	}
 
@@ -510,9 +510,12 @@ func (s *Smelter) runStaleness(anvilName string, rf *warden.RulesFile) []warden.
 // the rules file on disk without a matching archive record for the rules
 // it superseded. Any error from either step is returned so callers can
 // abort the flush before staging/commit/push.
-func (s *Smelter) persistRulesAndArchive(wtPath string, rf *warden.RulesFile, archived []warden.Rule, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
+//
+// This is a free function (not a method) so the off-cycle CLI consolidate
+// command shares the same persistence path as the scheduled smelter loop.
+func persistRulesAndArchive(wtPath string, rf *warden.RulesFile, archived []warden.Rule, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
 	if len(archived) > 0 || len(stale) > 0 {
-		if err := s.archiveRules(wtPath, archived, summary, stale); err != nil {
+		if err := archiveRules(wtPath, archived, summary, stale); err != nil {
 			return fmt.Errorf("archiving rules: %w", err)
 		}
 	}
@@ -527,7 +530,7 @@ func (s *Smelter) persistRulesAndArchive(wtPath string, rf *warden.RulesFile, ar
 // reason="duplicate" and superseded_by set to the merged rule's ID. Pass 2
 // entries are appended verbatim, preserving the LastSeen and ArchiveReason
 // values supplied by ArchiveStale.
-func (s *Smelter) archiveRules(wtPath string, archived []warden.Rule, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
+func archiveRules(wtPath string, archived []warden.Rule, summary []warden.MergeResult, stale []warden.ArchivedRule) error {
 	// Build map: originalID -> mergedID for the Pass 1 entries.
 	supersededBy := make(map[string]string, len(archived))
 	for _, m := range summary {

--- a/internal/smelter/smelter_test.go
+++ b/internal/smelter/smelter_test.go
@@ -357,9 +357,6 @@ func TestRunConsolidation_ZeroThresholdSkipsPass(t *testing.T) {
 // TestArchiveRules_WritesSupersededByCorrectly verifies the smelter archives
 // each replaced rule with reason=duplicate and the correct superseded_by ID.
 func TestArchiveRules_WritesSupersededByCorrectly(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 	archived := []warden.Rule{
 		{ID: "r1", Category: "style", Pattern: "p1", Check: "c1"},
@@ -373,7 +370,7 @@ func TestArchiveRules_WritesSupersededByCorrectly(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.archiveRules(dir, archived, summary, nil))
+	require.NoError(t, archiveRules(dir, archived, summary, nil))
 
 	a, err := warden.LoadArchive(warden.ArchivePath(dir))
 	require.NoError(t, err)
@@ -389,9 +386,6 @@ func TestArchiveRules_WritesSupersededByCorrectly(t *testing.T) {
 // TestPersistRulesAndArchive_ArchiveFirstThenRules verifies the happy path:
 // when both archive and rules-file writes succeed, both files land on disk.
 func TestPersistRulesAndArchive_ArchiveFirstThenRules(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 	rf := &warden.RulesFile{Rules: []warden.Rule{
 		{ID: "merged-1", Category: "style", Pattern: "p", Check: "c"},
@@ -405,7 +399,7 @@ func TestPersistRulesAndArchive_ArchiveFirstThenRules(t *testing.T) {
 		Category:    "style",
 	}}
 
-	require.NoError(t, s.persistRulesAndArchive(dir, rf, archived, summary, nil))
+	require.NoError(t, persistRulesAndArchive(dir, rf, archived, summary, nil))
 
 	rulesData, err := os.ReadFile(filepath.Join(dir, warden.RulesFileName))
 	require.NoError(t, err)
@@ -423,9 +417,6 @@ func TestPersistRulesAndArchive_ArchiveFirstThenRules(t *testing.T) {
 // file must NOT be written. Otherwise the smelter would commit a rules file
 // whose superseded entries have no archive record (bead-contract violation).
 func TestPersistRulesAndArchive_ArchiveFailureAbortsRulesSave(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 
 	// Force archive write to fail by creating a *directory* at the archive
@@ -445,7 +436,7 @@ func TestPersistRulesAndArchive_ArchiveFailureAbortsRulesSave(t *testing.T) {
 		Category:    "style",
 	}}
 
-	err := s.persistRulesAndArchive(dir, rf, archived, summary, nil)
+	err := persistRulesAndArchive(dir, rf, archived, summary, nil)
 	require.Error(t, err, "archive failure must propagate")
 	assert.Contains(t, err.Error(), "archiving rules")
 
@@ -518,9 +509,6 @@ func TestRunStaleness_MovesOldRulesAndUpdatesRulesFile(t *testing.T) {
 // Pass 2 stale entries into the archive store alongside Pass 1 duplicates,
 // preserving their pre-built reason and LastSeen values.
 func TestArchiveRules_WritesStaleEntries(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 	staleAt := time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC)
 	staleArchived := []warden.ArchivedRule{
@@ -532,7 +520,7 @@ func TestArchiveRules_WritesStaleEntries(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.archiveRules(dir, nil, nil, staleArchived))
+	require.NoError(t, archiveRules(dir, nil, nil, staleArchived))
 
 	a, err := warden.LoadArchive(warden.ArchivePath(dir))
 	require.NoError(t, err)
@@ -546,9 +534,6 @@ func TestArchiveRules_WritesStaleEntries(t *testing.T) {
 // TestArchiveRules_CombinesPass1AndPass2Entries verifies that a single
 // archive write captures both duplicates (Pass 1) and stale entries (Pass 2).
 func TestArchiveRules_CombinesPass1AndPass2Entries(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 
 	dupArchived := []warden.Rule{
@@ -568,7 +553,7 @@ func TestArchiveRules_CombinesPass1AndPass2Entries(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.archiveRules(dir, dupArchived, summary, staleArchived))
+	require.NoError(t, archiveRules(dir, dupArchived, summary, staleArchived))
 
 	a, err := warden.LoadArchive(warden.ArchivePath(dir))
 	require.NoError(t, err)
@@ -591,9 +576,6 @@ func TestArchiveRules_CombinesPass1AndPass2Entries(t *testing.T) {
 // invariant for Pass 2: when only stale rules need archiving (no Pass 1
 // activity), both the archive file and the active rules file are written.
 func TestPersistRulesAndArchive_StaleOnlyWritesArchive(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 	rf := &warden.RulesFile{Rules: []warden.Rule{
 		{ID: "kept", Category: "style", Pattern: "p", Check: "c"},
@@ -607,7 +589,7 @@ func TestPersistRulesAndArchive_StaleOnlyWritesArchive(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.persistRulesAndArchive(dir, rf, nil, nil, staleArchived))
+	require.NoError(t, persistRulesAndArchive(dir, rf, nil, nil, staleArchived))
 
 	rulesData, err := os.ReadFile(filepath.Join(dir, warden.RulesFileName))
 	require.NoError(t, err)
@@ -624,15 +606,12 @@ func TestPersistRulesAndArchive_StaleOnlyWritesArchive(t *testing.T) {
 // there are no consolidated rules to archive, the archive file is not
 // created — only the active rules file is written.
 func TestPersistRulesAndArchive_NoArchiveSkipsArchiveStep(t *testing.T) {
-	db := openTestDB(t)
-	s := New(db, time.Hour, map[string]string{})
-
 	dir := t.TempDir()
 	rf := &warden.RulesFile{Rules: []warden.Rule{
 		{ID: "r1", Category: "style", Pattern: "p", Check: "c"},
 	}}
 
-	require.NoError(t, s.persistRulesAndArchive(dir, rf, nil, nil, nil))
+	require.NoError(t, persistRulesAndArchive(dir, rf, nil, nil, nil))
 
 	_, err := os.Stat(filepath.Join(dir, warden.RulesFileName))
 	assert.NoError(t, err, "rules file should be saved")


### PR DESCRIPTION
## Changes

- **`forge warden consolidate <anvil>`** - Off-cycle CLI trigger for the three-pass smelter consolidation (cluster merge, staleness archive, paths backfill) against a named anvil. Writes both `.forge/warden-rules.yaml` and `.forge/warden-rules.archive.yaml` in place so the caller can review and commit. (Forge-59jt)
- **`forge warden restore <rule-id> --anvil <name>`** - Move an archived warden rule back into the active rules file. The embedded Rule (id/category/pattern/check/source/added/paths) is preserved verbatim so a subsequent consolidate pass would re-archive the same content; archive bookkeeping (archived_at/last_seen/archive_reason/superseded_by) is dropped on restore. (Forge-59jt)

## Original Issue (task): CLI subcommands: consolidate + restore

Add to cmd/forge/warden.go two new subcommands. (1) `forge warden consolidate <anvil>` — off-cycle manual trigger that invokes the same three-pass merge logic from the smelter sub-tasks against the named anvil without waiting for the regular learn cycle; should share the implementation, not duplicate it (extract a callable function from smelter if needed). (2) `forge warden restore <rule-id> --anvil <name>` — looks up rule-id in .forge/warden-rules.archive.yaml via sub-task 1's archive store, removes it from archive, re-inserts into the active rules file for the given anvil, and writes both files. Must round-trip cleanly: archive→active→archive should preserve content. Include acceptance check guidance (Munin 971→<500, archive file committed, restore round-trips) in the test plan. Depends on sub-tasks 1–3.

---
Bead: Forge-59jt | Branch: forge/Forge-59jt
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->