### PR TITLE
Make turn timeout configurable with 5min default and timeout sentinel message (Forge-5yn0)

### DIFF
--- a/changelog.d/Forge-5yn0.md
+++ b/changelog.d/Forge-5yn0.md
@@ -1,0 +1,2 @@
+category: Changed
+- **Configurable Beads-Forge turn timeout** - Replaced the hardcoded 90s per-turn fallback in `forgechat.ClaudeRunner` with a 5-minute default and a new `settings.forgechat.turn_timeout` config (hard-capped at 15m). On timeout the runner now returns a clear sentinel chat message and emits a structured `slog.Warn` (session id, turn stage, elapsed) instead of parsing the truncated streaming preamble. (Forge-5yn0)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -504,6 +504,7 @@ anvils:
 | `wicket_needs_human_label` | string | `"forge-needs-human"` | | GitHub label applied to issues flagged for human review. |
 | `wicket_bead_created_label` | string | `"forge-bead-created"` | | GitHub label applied to issues for which a bead was created. |
 | `wicket_trigger_label` | string | `""` | | When non-empty, only issues carrying this label are processed (pull model). When empty (default), Wicket processes all issues without a trigger-label gate (push model). |
+| `forgechat.turn_timeout` | duration | `5m` | (cap `15m`) | Wall-clock budget for a single Beads-Forge AI turn (drafter, grilling, plan, emit). When the budget is exceeded, the runner returns a sentinel chat message instead of the truncated streamed preamble and logs a warning. Values above `15m` are clamped on load. |
 
 Duration values use Go syntax: `30s`, `5m`, `1h30m`, `168h`, etc.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -603,8 +603,9 @@ func durationString(d time.Duration) string {
 }
 
 // forgeChatShadow renders ForgeChatSettings with the duration field as a
-// human-readable string ("5m0s") instead of nanoseconds. Empty turn_timeout
-// is omitted so the file stays clean when only defaults are used.
+// human-readable string ("5m0s") instead of nanoseconds. turn_timeout is
+// omitted when it equals the default so the file stays clean unless the
+// operator has explicitly changed it.
 type forgeChatShadow struct {
 	TurnTimeout string `yaml:"turn_timeout,omitempty"`
 }
@@ -732,7 +733,7 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		Warden:                 s.Warden,
 		ForgeChat: forgeChatShadow{
 			TurnTimeout: func() string {
-				if s.ForgeChat.TurnTimeout > 0 {
+				if s.ForgeChat.TurnTimeout > 0 && s.ForgeChat.TurnTimeout != DefaultForgeChatTurnTimeout {
 					return durationString(s.ForgeChat.TurnTimeout)
 				}
 				return ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -460,6 +461,44 @@ type SettingsConfig struct {
 	// learned warden rules are injected into the Warden review prompt and
 	// which filter passes are applied.
 	Warden WardenSettings `mapstructure:"warden" yaml:"warden,omitempty"`
+
+	// ForgeChat configures the Beads-Forge per-turn AI loop (drafter, grilling,
+	// plan, emit). Currently exposes turn_timeout so operators can lift the
+	// per-turn budget without recompiling.
+	ForgeChat ForgeChatSettings `mapstructure:"forgechat" yaml:"forgechat,omitempty"`
+}
+
+// MaxForgeChatTurnTimeout is the hard upper bound for settings.forgechat.turn_timeout.
+// Values above this are clamped on load and a warning is logged. Picked so that
+// even a worst-case grilling turn returns to the user before the browser /
+// reverse-proxy gives up on the long-poll HTTP request.
+const MaxForgeChatTurnTimeout = 15 * time.Minute
+
+// DefaultForgeChatTurnTimeout is the default wall-clock budget for a single
+// forgechat turn. Mirrored as forgechat.defaultTurnTimeout — keep the two in
+// sync if either is changed.
+const DefaultForgeChatTurnTimeout = 5 * time.Minute
+
+// ForgeChatSettings configures the Beads-Forge per-turn AI loop.
+type ForgeChatSettings struct {
+	// TurnTimeout caps the wall-clock duration of a single forgechat turn.
+	// Defaults to DefaultForgeChatTurnTimeout (5m). Values above
+	// MaxForgeChatTurnTimeout (15m) are clamped on load with a slog.Warn.
+	// Zero/unset falls back to the default at runtime.
+	TurnTimeout time.Duration `mapstructure:"turn_timeout" yaml:"turn_timeout,omitempty"`
+}
+
+// ResolvedTurnTimeout returns the effective per-turn timeout after applying
+// the default and the hard cap. Callers (e.g. NewClaudeRunner wiring) should
+// use this rather than reading TurnTimeout directly.
+func (f ForgeChatSettings) ResolvedTurnTimeout() time.Duration {
+	if f.TurnTimeout <= 0 {
+		return DefaultForgeChatTurnTimeout
+	}
+	if f.TurnTimeout > MaxForgeChatTurnTimeout {
+		return MaxForgeChatTurnTimeout
+	}
+	return f.TurnTimeout
 }
 
 // WardenSettings configures the review-time rule filter applied to the
@@ -563,6 +602,13 @@ func durationString(d time.Duration) string {
 	return d.String()
 }
 
+// forgeChatShadow renders ForgeChatSettings with the duration field as a
+// human-readable string ("5m0s") instead of nanoseconds. Empty turn_timeout
+// is omitted so the file stays clean when only defaults are used.
+type forgeChatShadow struct {
+	TurnTimeout string `yaml:"turn_timeout,omitempty"`
+}
+
 // MarshalYAML serialises SettingsConfig with time.Duration fields as
 // human-readable strings (e.g. "30s", "5m0s") instead of nanosecond ints.
 func (s SettingsConfig) MarshalYAML() (interface{}, error) {
@@ -626,6 +672,7 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		CruciblePollInterval     string         `yaml:"crucible_poll_interval,omitempty"`
 		ForgeID                  string         `yaml:"forge_id,omitempty"`
 		Warden                   WardenSettings `yaml:"warden,omitempty"`
+		ForgeChat                forgeChatShadow `yaml:"forgechat,omitempty"`
 	}
 
 	sh := shadow{
@@ -683,6 +730,14 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		BdReadyLimit:           s.BdReadyLimit,
 		ForgeID:                s.ForgeID,
 		Warden:                 s.Warden,
+		ForgeChat: forgeChatShadow{
+			TurnTimeout: func() string {
+				if s.ForgeChat.TurnTimeout > 0 {
+					return durationString(s.ForgeChat.TurnTimeout)
+				}
+				return ""
+			}(),
+		},
 	}
 
 	if s.CruciblePollInterval > 0 {
@@ -933,6 +988,9 @@ func Defaults() Config {
 				ArchiveAfterDays:  180,
 				DedupThreshold:    0.6,
 			},
+			ForgeChat: ForgeChatSettings{
+				TurnTimeout: DefaultForgeChatTurnTimeout,
+			},
 		},
 	}
 }
@@ -987,6 +1045,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("settings.warden.filter_pattern_grep", true)
 	v.SetDefault("settings.warden.archive_after_days", 180)
 	v.SetDefault("settings.warden.dedup_threshold", 0.6)
+	v.SetDefault("settings.forgechat.turn_timeout", DefaultForgeChatTurnTimeout.String())
 
 	// Environment variable support: FORGE_SETTINGS_POLL_INTERVAL etc.
 	// SetEnvKeyReplacer maps dotted config keys (settings.auto_learn_rules) to
@@ -1137,6 +1196,22 @@ func Load(configFile string) (*Config, error) {
 			return nil, fmt.Errorf("invalid crucible_poll_interval %q: %w", raw, err)
 		}
 		cfg.Settings.CruciblePollInterval = d
+	}
+	if raw := v.GetString("settings.forgechat.turn_timeout"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid forgechat.turn_timeout %q: %w", raw, err)
+		}
+		cfg.Settings.ForgeChat.TurnTimeout = d
+	}
+	if cfg.Settings.ForgeChat.TurnTimeout <= 0 {
+		cfg.Settings.ForgeChat.TurnTimeout = DefaultForgeChatTurnTimeout
+	} else if cfg.Settings.ForgeChat.TurnTimeout > MaxForgeChatTurnTimeout {
+		slog.Warn("forgechat.turn_timeout exceeds hard cap; clamping",
+			"configured", cfg.Settings.ForgeChat.TurnTimeout,
+			"clamped", MaxForgeChatTurnTimeout,
+		)
+		cfg.Settings.ForgeChat.TurnTimeout = MaxForgeChatTurnTimeout
 	}
 
 	// Decrypt any enc:-prefixed webhook URLs written by Hytte.

--- a/internal/daemon/web.go
+++ b/internal/daemon/web.go
@@ -106,7 +106,9 @@ func (d *Daemon) buildForgeChatRunner() forgechat.Runner {
 	if len(providers) == 0 {
 		return nil
 	}
-	return forgechat.NewClaudeRunner(providers[0], cfg.Settings.ClaudeFlags)
+	runner := forgechat.NewClaudeRunner(providers[0], cfg.Settings.ClaudeFlags)
+	runner.Timeout = cfg.Settings.ForgeChat.ResolvedTurnTimeout()
+	return runner
 }
 
 // webEnabled reports whether FORGE_WEB_ENABLED requests the web UI.

--- a/internal/forgechat/forgechat.go
+++ b/internal/forgechat/forgechat.go
@@ -82,6 +82,10 @@ type TurnRequest struct {
 	// the codebase via Read / Grep / Glob. Nil leaves the anvil context out
 	// of the prompt (the AI then has to ask, which is what we're fixing).
 	Anvil *AnvilTarget
+	// SessionID identifies the originating Beads-Forge session and is logged
+	// when a turn fails (e.g. on timeout). Zero is acceptable for callers
+	// that don't have a persistent session (tests, one-off runs).
+	SessionID int64
 }
 
 // AnvilTarget is the resolved name + on-disk path of the anvil that owns a

--- a/internal/forgechat/runner_claude.go
+++ b/internal/forgechat/runner_claude.go
@@ -14,6 +14,14 @@ import (
 	"github.com/Robin831/Forge/internal/smith"
 )
 
+// defaultTurnTimeout is the wall-clock budget for a single forgechat turn
+// when ClaudeRunner.Timeout is unset. Sized to cover a Claude session that
+// actually does codebase grep/read work (the previous 90s fallback timed
+// out before the agent had finished its first pass). Mirrored by
+// config.ForgeChatSettings.TurnTimeout, which lets operators tune it from
+// forge.yaml without recompiling.
+const defaultTurnTimeout = 5 * time.Minute
+
 // ClaudeRunner is the production Runner implementation. It spawns a
 // short-lived claude (or fallback) session in a temp directory for each
 // turn and parses the response into messages and stage transitions. The
@@ -28,7 +36,8 @@ type ClaudeRunner struct {
 	// prompt asks for a single JSON envelope, so a low budget is fine.
 	MaxTurns int
 	// Timeout caps the wall-clock duration of a single turn. Defaults to
-	// 90 seconds. Kept short so the HTTP handler isn't held open forever.
+	// defaultTurnTimeout (5m). Override at construction from
+	// settings.forgechat.turn_timeout.
 	Timeout time.Duration
 	// ExtraFlags are passed through to claude (e.g. --model).
 	ExtraFlags []string
@@ -39,8 +48,29 @@ func NewClaudeRunner(pv provider.Provider, extraFlags []string) *ClaudeRunner {
 	return &ClaudeRunner{
 		Provider:   pv,
 		MaxTurns:   10,
-		Timeout:    90 * time.Second,
+		Timeout:    defaultTurnTimeout,
 		ExtraFlags: extraFlags,
+	}
+}
+
+// turnStageLabel returns the human-readable stage label used in timeout
+// logs. The four labels (drafter/grilling/plan/emit) match the user-facing
+// modes so an operator reading the warning can map it back to what the
+// session was doing.
+func turnStageLabel(req TurnRequest) string {
+	if req.Mode == ModeEmit {
+		return "emit"
+	}
+	switch req.Stage {
+	case StageGrilling:
+		return "grilling"
+	case StageDrafting:
+		if req.Mode == ModePlan {
+			return "plan"
+		}
+		return "drafter"
+	default:
+		return "drafter"
 	}
 }
 
@@ -51,7 +81,7 @@ func (r *ClaudeRunner) Turn(ctx context.Context, req TurnRequest) (*TurnResponse
 	}
 	timeout := r.Timeout
 	if timeout <= 0 {
-		timeout = 90 * time.Second
+		timeout = defaultTurnTimeout
 	}
 	maxTurns := r.MaxTurns
 	if maxTurns <= 0 {
@@ -60,6 +90,8 @@ func (r *ClaudeRunner) Turn(ctx context.Context, req TurnRequest) (*TurnResponse
 
 	turnCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	turnStart := time.Now()
+	stage := turnStageLabel(req)
 
 	// os.MkdirTemp("", ...) creates the directory under os.TempDir() (/tmp on
 	// Linux), which is outside any git repository. smith.SpawnWithProvider calls
@@ -83,10 +115,18 @@ func (r *ClaudeRunner) Turn(ctx context.Context, req TurnRequest) (*TurnResponse
 	flags := append([]string{"--max-turns", fmt.Sprintf("%d", maxTurns)}, r.ExtraFlags...)
 	proc, err := smith.SpawnWithProvider(turnCtx, workDir, prompt, logDir, r.Provider, flags)
 	if err != nil {
+		if timedOut := timeoutResponse(turnCtx, req, stage, turnStart, timeout); timedOut != nil {
+			return timedOut, nil
+		}
 		return nil, fmt.Errorf("spawning %s session: %w", r.Provider.Label(), err)
 	}
 
 	res := proc.Wait()
+	if timedOut := timeoutResponse(turnCtx, req, stage, turnStart, timeout); timedOut != nil {
+		// The context deadline fired during the session — return the sentinel
+		// rather than parsing the truncated streamed preamble.
+		return timedOut, nil
+	}
 	if res == nil {
 		return nil, errors.New("forgechat: nil result from claude session")
 	}
@@ -103,6 +143,30 @@ func (r *ClaudeRunner) Turn(ctx context.Context, req TurnRequest) (*TurnResponse
 	}
 
 	return interpretResponse(req, output, res.CostUSD)
+}
+
+// timeoutResponse returns the sentinel TurnResponse when turnCtx has hit
+// its deadline, and nil otherwise. Centralising the check keeps the
+// happy/sad paths in Turn easy to read and ensures the same warning fires
+// for every exit point (spawn error, partial output, full Wait).
+func timeoutResponse(turnCtx context.Context, req TurnRequest, stage string, start time.Time, timeout time.Duration) *TurnResponse {
+	if !errors.Is(turnCtx.Err(), context.DeadlineExceeded) {
+		return nil
+	}
+	elapsed := time.Since(start)
+	slog.Warn("forgechat: turn timed out",
+		"session_id", req.SessionID,
+		"turn_stage", stage,
+		"elapsed", elapsed,
+		"timeout", timeout,
+	)
+	body := fmt.Sprintf(
+		"_(Drafter timed out after %s. Try a more focused follow-up question, or bump settings.forgechat.turn_timeout.)_",
+		timeout,
+	)
+	return &TurnResponse{
+		Messages: []EmittedMessage{{Kind: "text", Content: body}},
+	}
 }
 
 // interpretResponse converts raw claude output into a TurnResponse based on

--- a/internal/forgechat/runner_claude.go
+++ b/internal/forgechat/runner_claude.go
@@ -149,11 +149,17 @@ func (r *ClaudeRunner) Turn(ctx context.Context, req TurnRequest) (*TurnResponse
 // its deadline, and nil otherwise. Centralising the check keeps the
 // happy/sad paths in Turn easy to read and ensures the same warning fires
 // for every exit point (spawn error, partial output, full Wait).
+//
+// The sentinel body reports the *actual elapsed time* (not the configured
+// timeout) so that when the outer HTTP handler cancels before the runner's
+// deadline — or when the deadline fires slightly off-budget — the user sees
+// the wall-clock duration they actually waited rather than a misleading
+// "after 5m0s" when only 2m elapsed.
 func timeoutResponse(turnCtx context.Context, req TurnRequest, stage string, start time.Time, timeout time.Duration) *TurnResponse {
 	if !errors.Is(turnCtx.Err(), context.DeadlineExceeded) {
 		return nil
 	}
-	elapsed := time.Since(start)
+	elapsed := time.Since(start).Round(time.Second)
 	slog.Warn("forgechat: turn timed out",
 		"session_id", req.SessionID,
 		"turn_stage", stage,
@@ -162,7 +168,7 @@ func timeoutResponse(turnCtx context.Context, req TurnRequest, stage string, sta
 	)
 	body := fmt.Sprintf(
 		"_(Drafter timed out after %s. Try a more focused follow-up question, or bump settings.forgechat.turn_timeout.)_",
-		timeout,
+		elapsed,
 	)
 	return &TurnResponse{
 		Messages: []EmittedMessage{{Kind: "text", Content: body}},

--- a/internal/web/forge_chat.go
+++ b/internal/web/forge_chat.go
@@ -1,13 +1,11 @@
 package web
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/Robin831/Forge/internal/forgechat"
 	"github.com/Robin831/Forge/internal/state"
@@ -215,10 +213,9 @@ func (s *Server) handleForgeSessionTurn(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
-	// Run the AI turn. Use the request context with a generous floor so a
-	// slow client cannot interrupt the claude call mid-stream.
-	turnCtx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
-	defer cancel()
+	// Run the AI turn. Rely on ClaudeRunner's own timeout (configured via
+	// settings.forgechat.turn_timeout) rather than imposing a separate
+	// handler-level deadline that would shadow the operator's setting.
 	turnReq := forgechat.TurnRequest{
 		Stage:     forgechat.Stage(stage),
 		Mode:      mode,
@@ -228,7 +225,7 @@ func (s *Server) handleForgeSessionTurn(w http.ResponseWriter, r *http.Request) 
 		Anvil:     s.resolveSessionAnvil(row.Anvil),
 		SessionID: id,
 	}
-	turnResp, err := s.chatRunner.Turn(turnCtx, turnReq)
+	turnResp, err := s.chatRunner.Turn(r.Context(), turnReq)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "AI turn failed: "+err.Error())
 		return

--- a/internal/web/forge_chat.go
+++ b/internal/web/forge_chat.go
@@ -220,12 +220,13 @@ func (s *Server) handleForgeSessionTurn(w http.ResponseWriter, r *http.Request) 
 	turnCtx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
 	defer cancel()
 	turnReq := forgechat.TurnRequest{
-		Stage:   forgechat.Stage(stage),
-		Mode:    mode,
-		Title:   row.Title,
-		Plan:    row.Plan,
-		History: history,
-		Anvil:   s.resolveSessionAnvil(row.Anvil),
+		Stage:     forgechat.Stage(stage),
+		Mode:      mode,
+		Title:     row.Title,
+		Plan:      row.Plan,
+		History:   history,
+		Anvil:     s.resolveSessionAnvil(row.Anvil),
+		SessionID: id,
 	}
 	turnResp, err := s.chatRunner.Turn(turnCtx, turnReq)
 	if err != nil {

--- a/internal/web/forge_emit.go
+++ b/internal/web/forge_emit.go
@@ -1,13 +1,11 @@
 package web
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/Robin831/Forge/internal/forgechat"
 	"github.com/Robin831/Forge/internal/state"
@@ -106,10 +104,8 @@ func (s *Server) handleForgeSessionCreateBeads(w http.ResponseWriter, r *http.Re
 		})
 	}
 
-	// Generous turn timeout: emission is small (one JSON envelope) but the
-	// claude subprocess + provider negotiation can stretch.
-	turnCtx, cancel := context.WithTimeout(r.Context(), 3*time.Minute)
-	defer cancel()
+	// Rely on ClaudeRunner's own timeout (settings.forgechat.turn_timeout)
+	// rather than a hardcoded handler deadline that would shadow it.
 	turnReq := forgechat.TurnRequest{
 		Stage:     forgechat.StageReady,
 		Mode:      forgechat.ModeEmit,
@@ -119,7 +115,7 @@ func (s *Server) handleForgeSessionCreateBeads(w http.ResponseWriter, r *http.Re
 		History:   hist,
 		SessionID: id,
 	}
-	turnResp, err := s.chatRunner.Turn(turnCtx, turnReq)
+	turnResp, err := s.chatRunner.Turn(r.Context(), turnReq)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "AI emission failed: "+err.Error())
 		return

--- a/internal/web/forge_emit.go
+++ b/internal/web/forge_emit.go
@@ -111,12 +111,13 @@ func (s *Server) handleForgeSessionCreateBeads(w http.ResponseWriter, r *http.Re
 	turnCtx, cancel := context.WithTimeout(r.Context(), 3*time.Minute)
 	defer cancel()
 	turnReq := forgechat.TurnRequest{
-		Stage:  forgechat.StageReady,
-		Mode:   forgechat.ModeEmit,
-		Title:  row.Title,
-		Plan:   row.Plan,
-		Anvils: forgechat.AnvilContext(toHints(anvils)),
-		History: hist,
+		Stage:     forgechat.StageReady,
+		Mode:      forgechat.ModeEmit,
+		Title:     row.Title,
+		Plan:      row.Plan,
+		Anvils:    forgechat.AnvilContext(toHints(anvils)),
+		History:   hist,
+		SessionID: id,
 	}
 	turnResp, err := s.chatRunner.Turn(turnCtx, turnReq)
 	if err != nil {


### PR DESCRIPTION
## Changes

- **Configurable Beads-Forge turn timeout** - Replaced the hardcoded 90s per-turn fallback in `forgechat.ClaudeRunner` with a 5-minute default and a new `settings.forgechat.turn_timeout` config (hard-capped at 15m). On timeout the runner now returns a clear sentinel chat message and emits a structured `slog.Warn` (session id, turn stage, elapsed) instead of parsing the truncated streaming preamble. (Forge-5yn0)

## Original Issue (task): Make turn timeout configurable with 5min default and timeout sentinel message

Modify `internal/forgechat/runner_claude.go` (around lines 30-55): replace the hardcoded 90s fallback with `const defaultTurnTimeout = 5 * time.Minute`. Update `ClaudeRunner.Turn` so when `turnCtx.Err()` is `context.DeadlineExceeded`, it returns a `TurnResponse` containing a single text `EmittedMessage` with the sentinel `_(Drafter timed out after <duration>. Try a more focused follow-up question, or bump settings.forgechat.turn_timeout.)_` instead of the truncated streamed preamble. Add a `slog.Warn` log line on timeout including session id, turn stage (drafter/grilling/plan/emit), and elapsed time. Add `settings.forgechat.turn_timeout` field to `internal/config/config.go` (type `time.Duration`, default 5m, hard cap 15m — clamp on load and warn if exceeded). Wire the configured value through to `ClaudeRunner.Timeout` at runner construction. This is the foundation for the sibling test sub-task and the SSE streaming work in Step 2.

---
Bead: Forge-5yn0 | Branch: forge/Forge-5yn0
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->