### PR TITLE
Add runner_claude_test.go timeout-sentinel test and config validation test (Forge-rjad)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1178,4 +1180,134 @@ func TestTemperStepConfig_VerifyNoConflictMarkersRoundTrip(t *testing.T) {
 	assert.Equal(t,
 		[]string{"internal/web/dist", "internal/web/static"},
 		roundTripped.Steps[0].VerifyNoConflictMarkers)
+}
+
+// captureSlog swaps the default slog logger for one writing to a buffer for
+// the duration of the test. Returns the buffer so callers can assert on the
+// captured output, and restores the original logger via t.Cleanup so a
+// failure mid-test does not poison sibling tests.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestLoad_ForgeChatTurnTimeout_DefaultWhenUnset asserts that when forge.yaml
+// omits settings.forgechat.turn_timeout the loader falls back to
+// DefaultForgeChatTurnTimeout (5 minutes). This is the contract the runner
+// relies on when it reads cfg.Settings.ForgeChat.TurnTimeout directly.
+func TestLoad_ForgeChatTurnTimeout_DefaultWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "forge.yaml")
+	content := `
+settings:
+  max_total_smiths: 2
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, cfg.Settings.ForgeChat.TurnTimeout,
+		"unset turn_timeout should resolve to the 5m default")
+	assert.Equal(t, DefaultForgeChatTurnTimeout, cfg.Settings.ForgeChat.TurnTimeout,
+		"unset turn_timeout should equal DefaultForgeChatTurnTimeout")
+}
+
+// TestLoad_ForgeChatTurnTimeout_PreservesValueWithinRange asserts that any
+// value between (0, MaxForgeChatTurnTimeout] is preserved verbatim, with no
+// clamping and no warning emitted.
+func TestLoad_ForgeChatTurnTimeout_PreservesValueWithinRange(t *testing.T) {
+	buf := captureSlog(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "forge.yaml")
+	content := `
+settings:
+  forgechat:
+    turn_timeout: 10m
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Minute, cfg.Settings.ForgeChat.TurnTimeout,
+		"in-range turn_timeout must be preserved as-is")
+	assert.NotContains(t, buf.String(), "exceeds hard cap",
+		"in-range turn_timeout must not emit the clamp warning")
+}
+
+// TestLoad_ForgeChatTurnTimeout_ClampedAboveMax asserts that values above the
+// 15-minute hard cap are clamped to MaxForgeChatTurnTimeout and that a
+// slog.Warn is emitted so operators see why their configured value did not
+// take effect.
+func TestLoad_ForgeChatTurnTimeout_ClampedAboveMax(t *testing.T) {
+	buf := captureSlog(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "forge.yaml")
+	content := `
+settings:
+  forgechat:
+    turn_timeout: 30m
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 15*time.Minute, cfg.Settings.ForgeChat.TurnTimeout,
+		"turn_timeout above the cap must be clamped to MaxForgeChatTurnTimeout")
+	assert.Equal(t, MaxForgeChatTurnTimeout, cfg.Settings.ForgeChat.TurnTimeout)
+
+	// Verify the operator-facing warning landed in the log. Match on key
+	// substrings rather than the full formatted line so future tweaks to
+	// the log format don't break the regression.
+	logged := buf.String()
+	assert.Contains(t, logged, "forgechat.turn_timeout exceeds hard cap",
+		"clamping must emit a slog warning so operators can diagnose it")
+	assert.Contains(t, logged, "clamping",
+		"warning must mention that the value was clamped")
+}
+
+// TestLoad_ForgeChatTurnTimeout_InvalidDuration verifies that a malformed
+// duration string surfaces as an error rather than silently falling back to
+// the default. This guards against typos like "5min" silently becoming 5m.
+func TestLoad_ForgeChatTurnTimeout_InvalidDuration(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "forge.yaml")
+	content := `
+settings:
+  forgechat:
+    turn_timeout: notaduration
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+
+	_, err := Load(cfgPath)
+	assert.ErrorContains(t, err, "forgechat.turn_timeout")
+}
+
+// TestForgeChatSettings_ResolvedTurnTimeout exercises the resolver function
+// directly so the default/clamp logic is covered even for callers that
+// construct a ForgeChatSettings in code (e.g. tests) without going through
+// Load.
+func TestForgeChatSettings_ResolvedTurnTimeout(t *testing.T) {
+	cases := []struct {
+		name  string
+		input time.Duration
+		want  time.Duration
+	}{
+		{"zero falls back to default", 0, DefaultForgeChatTurnTimeout},
+		{"negative falls back to default", -1 * time.Second, DefaultForgeChatTurnTimeout},
+		{"value within range preserved", 7 * time.Minute, 7 * time.Minute},
+		{"value at cap preserved", MaxForgeChatTurnTimeout, MaxForgeChatTurnTimeout},
+		{"value above cap clamped", 1 * time.Hour, MaxForgeChatTurnTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := ForgeChatSettings{TurnTimeout: tc.input}
+			assert.Equal(t, tc.want, f.ResolvedTurnTimeout())
+		})
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1197,8 +1197,9 @@ func captureSlog(t *testing.T) *bytes.Buffer {
 
 // TestLoad_ForgeChatTurnTimeout_DefaultWhenUnset asserts that when forge.yaml
 // omits settings.forgechat.turn_timeout the loader falls back to
-// DefaultForgeChatTurnTimeout (5 minutes). This is the contract the runner
-// relies on when it reads cfg.Settings.ForgeChat.TurnTimeout directly.
+// DefaultForgeChatTurnTimeout (5 minutes). The runner accesses the effective
+// value via cfg.Settings.ForgeChat.ResolvedTurnTimeout(), which applies the
+// default and clamping rules on top of the raw TurnTimeout field.
 func TestLoad_ForgeChatTurnTimeout_DefaultWhenUnset(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "forge.yaml")

--- a/internal/forgechat/runner_claude_test.go
+++ b/internal/forgechat/runner_claude_test.go
@@ -1,0 +1,99 @@
+package forgechat
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Forge/internal/provider"
+)
+
+// TestClaudeRunner_Turn_TimeoutReturnsSentinel exercises the timeout path of
+// ClaudeRunner.Turn without spawning a real claude session. The Provider is
+// pointed at a binary that does not exist so smith.SpawnWithProvider fails
+// fast at cmd.Start(); by the time Turn checks turnCtx.Err(), the 1ms
+// deadline has long since fired (mkdtemp + git rev-parse inside
+// ValidateWorktreeDir + exec setup each take more than a millisecond), so we
+// reliably hit the sentinel path and never need to wait on real I/O.
+//
+// The three assertions track the contract from Forge-rjad: (1) Messages is
+// exactly the templated sentinel, (2) no truncated stream-json preamble
+// leaks into the body, (3) the call returns nil error because the sentinel
+// is a non-error completion — the chat UI renders it as a normal assistant
+// message rather than surfacing a backend failure.
+func TestClaudeRunner_Turn_TimeoutReturnsSentinel(t *testing.T) {
+	runner := &ClaudeRunner{
+		Provider: provider.Provider{
+			Kind:    provider.Claude,
+			Command: "/this/binary/intentionally/does/not/exist/claude-fake",
+		},
+		MaxTurns: 1,
+		Timeout:  1 * time.Millisecond,
+	}
+
+	resp, err := runner.Turn(context.Background(), TurnRequest{
+		Stage:    StageDrafting,
+		Mode:     ModeChat,
+		UserText: "hello",
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error on timeout (sentinel is a non-error completion path), got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response on timeout, got nil")
+	}
+	if len(resp.Messages) != 1 {
+		t.Fatalf("expected exactly one sentinel message, got %d: %+v", len(resp.Messages), resp.Messages)
+	}
+
+	msg := resp.Messages[0]
+	if msg.Kind != "text" {
+		t.Errorf("sentinel message kind: want %q, got %q", "text", msg.Kind)
+	}
+
+	// The sentinel template is:
+	//   "_(Drafter timed out after <elapsed>. Try a more focused follow-up
+	//    question, or bump settings.forgechat.turn_timeout.)_"
+	// The elapsed segment is rounded to seconds, so pin only the
+	// stable prefix and suffix — a future tweak to the rounding granularity
+	// must not break this test.
+	const wantPrefix = "_(Drafter timed out after"
+	const wantSuffix = "settings.forgechat.turn_timeout.)_"
+	if !strings.HasPrefix(msg.Content, wantPrefix) {
+		t.Errorf("sentinel prefix mismatch:\n  want prefix: %q\n  got: %q", wantPrefix, msg.Content)
+	}
+	if !strings.HasSuffix(msg.Content, wantSuffix) {
+		t.Errorf("sentinel suffix mismatch:\n  want suffix: %q\n  got: %q", wantSuffix, msg.Content)
+	}
+
+	// Assertion (2): no truncated stream-json preamble bleeds through into
+	// the sentinel body. Any of these substrings would indicate that the
+	// runner parsed a partial claude response instead of returning the
+	// sentinel template verbatim.
+	for _, leak := range []string{
+		"{",            // any JSON envelope
+		`"type":`,      // stream-json event field
+		"assistant",    // claude role marker
+		"stream-json",  // CLI flag echo
+		"tool_use",     // tool invocation event
+	} {
+		if strings.Contains(msg.Content, leak) {
+			t.Errorf("sentinel body leaked claude output (found %q):\n  body: %q", leak, msg.Content)
+		}
+	}
+
+	// A timeout must not advance the session stage or produce a plan — the
+	// caller should be free to retry the same turn without any state having
+	// shifted underneath it.
+	if resp.NewStage != "" {
+		t.Errorf("timeout must not advance stage, got NewStage=%q", resp.NewStage)
+	}
+	if resp.NewPlan != "" {
+		t.Errorf("timeout must not produce a plan, got NewPlan=%q", resp.NewPlan)
+	}
+	if resp.Emission != nil {
+		t.Errorf("timeout must not produce an emission envelope, got %+v", resp.Emission)
+	}
+}

--- a/internal/forgechat/runner_claude_test.go
+++ b/internal/forgechat/runner_claude_test.go
@@ -2,6 +2,7 @@ package forgechat
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,12 +11,12 @@ import (
 )
 
 // TestClaudeRunner_Turn_TimeoutReturnsSentinel exercises the timeout path of
-// ClaudeRunner.Turn without spawning a real claude session. The Provider is
-// pointed at a binary that does not exist so smith.SpawnWithProvider fails
-// fast at cmd.Start(); by the time Turn checks turnCtx.Err(), the 1ms
-// deadline has long since fired (mkdtemp + git rev-parse inside
-// ValidateWorktreeDir + exec setup each take more than a millisecond), so we
-// reliably hit the sentinel path and never need to wait on real I/O.
+// ClaudeRunner.Turn without spawning a real claude session. The parent context
+// is created with a deadline in the past so turnCtx is already expired when
+// Turn begins — the sentinel path fires deterministically without relying on
+// any wall-clock race. The Provider is pointed at a guaranteed-missing path
+// under t.TempDir() so smith.SpawnWithProvider fails at cmd.Start() and the
+// DeadlineExceeded check is the first thing evaluated afterwards.
 //
 // The three assertions track the contract from Forge-rjad: (1) Messages is
 // exactly the templated sentinel, (2) no truncated stream-json preamble
@@ -23,16 +24,21 @@ import (
 // is a non-error completion — the chat UI renders it as a normal assistant
 // message rather than surfacing a backend failure.
 func TestClaudeRunner_Turn_TimeoutReturnsSentinel(t *testing.T) {
+	// Pre-expire the context so the deadline is guaranteed to have already
+	// fired before Turn even starts — no reliance on setup latency.
+	expiredCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
 	runner := &ClaudeRunner{
 		Provider: provider.Provider{
 			Kind:    provider.Claude,
-			Command: "/this/binary/intentionally/does/not/exist/claude-fake",
+			Command: filepath.Join(t.TempDir(), "claude-fake"),
 		},
 		MaxTurns: 1,
-		Timeout:  1 * time.Millisecond,
+		Timeout:  5 * time.Minute, // large; pre-expired parent ctx triggers sentinel
 	}
 
-	resp, err := runner.Turn(context.Background(), TurnRequest{
+	resp, err := runner.Turn(expiredCtx, TurnRequest{
 		Stage:    StageDrafting,
 		Mode:     ModeChat,
 		UserText: "hello",


### PR DESCRIPTION
## Reviewer's approval notes

Could not parse structured verdict; defaulting to approve for human review

## Original Issue (task): Add runner_claude_test.go timeout-sentinel test and config validation test

Add a test in `internal/forgechat/runner_claude_test.go` that constructs a `ClaudeRunner` with `Timeout: 1 * time.Millisecond` using a fake/stub claude binary (or injected exec), calls `Turn`, and asserts: (1) returned `TurnResponse.Messages` is exactly the timeout sentinel text, (2) no truncated preamble bleeds through, (3) error is nil (sentinel is a non-error completion path). Add a config test in `internal/config/config_test.go` (or equivalent) covering: zero/unset → 5m default, value > 15m → clamped to 15m with warning, valid value within range → preserved. Depends on the runner_claude.go + config.go changes from sibling sub-task 1.

---
Bead: Forge-rjad | Branch: forge/Forge-rjad
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->