### PR TITLE
SSE streaming and polling endpoints (Forge-ivgo)

### DIFF
--- a/changelog.d/Forge-ivgo.md
+++ b/changelog.d/Forge-ivgo.md
@@ -1,0 +1,2 @@
+category: Added
+- **Beads-Forge turn SSE and polling endpoints** - `GET /api/forge/sessions/{id}/turn/{turn_id}/stream` streams the in-flight TurnState's events (text_delta, tool_use, tool_result, message, complete, error) as Server-Sent Events; `GET /api/forge/sessions/{id}/turn/{turn_id}` returns the current TurnState snapshot as JSON for clients that don't consume SSE. Both endpoints validate session ownership and gracefully handle late-connecting consumers by synthesising a terminal frame from the snapshot. (Forge-ivgo)

--- a/internal/web/forge_chat.go
+++ b/internal/web/forge_chat.go
@@ -251,9 +251,10 @@ func (s *Server) runTurnAsync(st *TurnState, req forgechat.TurnRequest) {
 			st.Emit(TurnEvent{Type: TurnEventError, Data: err.Error()})
 		}
 		// Close Done first so callers waiting on it see terminal status
-		// before Events drains; matches TurnState docs ("Events... after Done").
+		// before subscriber channels drain; then closeAll so each SSE
+		// consumer's per-client channel is closed and the handler exits.
 		close(st.Done)
-		close(st.Events)
+		st.bcast.closeAll()
 	}()
 
 	ctx, cancel := context.WithTimeout(s.serverCtx, s.turnTimeout)

--- a/internal/web/forge_turn_stream.go
+++ b/internal/web/forge_turn_stream.go
@@ -26,15 +26,14 @@ import (
 
 // handleForgeSessionTurnStream serves SSE for one async turn. It writes the
 // usual text/event-stream headers, flushes immediately so reverse proxies
-// don't buffer the response, then forwards every TurnEvent it receives on
-// the TurnState.Events channel. When the channel closes (the runner
-// goroutine has reached a terminal state) the handler returns.
+// don't buffer the response, then subscribes to the TurnState broadcaster
+// to receive a dedicated per-client event channel. Multiple concurrent SSE
+// consumers each get their own channel so no events are stolen by a sibling.
 //
-// Clients that connect after the turn has already terminated would otherwise
-// see an empty stream — the Events channel is already closed and the
-// terminal event has been drained. We catch that case up front and emit a
-// synthesised complete/error event from the snapshot so late SSE consumers
-// still observe a deterministic terminal frame before the connection ends.
+// Clients that connect after the turn has already terminated see an
+// immediately-closed subscriber channel and we detect this via Done, then
+// synthesise a terminal frame from the snapshot so they observe a
+// deterministic complete/error event before the connection ends.
 func (s *Server) handleForgeSessionTurnStream(w http.ResponseWriter, r *http.Request) {
 	st, ok := s.lookupTurn(w, r)
 	if !ok {
@@ -54,8 +53,14 @@ func (s *Server) handleForgeSessionTurnStream(w http.ResponseWriter, r *http.Req
 	fmt.Fprint(w, "retry: 3000\n\n")
 	flusher.Flush()
 
-	// Late-connect: the runner goroutine has already exited and closed both
-	// channels. Synthesise a terminal frame from the snapshot so the client
+	// Subscribe before checking Done to avoid the race where the turn
+	// completes between the Done check and the subscribe call. If the turn
+	// is already done, Subscribe returns an immediately-closed channel and
+	// the broadcaster marks itself closed atomically under its mutex.
+	subCh := st.Subscribe(r.Context())
+
+	// Late-connect: Done is closed (and therefore the broadcaster is also
+	// closed). Synthesise a terminal frame from the snapshot so the client
 	// observes a complete/error event rather than an immediately-closed
 	// stream with no payload.
 	select {
@@ -68,6 +73,12 @@ func (s *Server) handleForgeSessionTurnStream(w http.ResponseWriter, r *http.Req
 	keepalive := time.NewTicker(30 * time.Second)
 	defer keepalive.Stop()
 
+	// sawTerminal tracks whether a TurnEventComplete or TurnEventError was
+	// delivered through subCh. If the channel closes without one (a rare
+	// race where the turn ends between Subscribe and the Done check above),
+	// we synthesise the terminal frame from the snapshot so the client is
+	// never left without a closing event.
+	var sawTerminal bool
 	for {
 		select {
 		case <-r.Context().Done():
@@ -75,9 +86,15 @@ func (s *Server) handleForgeSessionTurnStream(w http.ResponseWriter, r *http.Req
 		case <-keepalive.C:
 			fmt.Fprint(w, ": keepalive\n\n")
 			flusher.Flush()
-		case ev, ok := <-st.Events:
+		case ev, ok := <-subCh:
 			if !ok {
+				if !sawTerminal {
+					emitTerminalTurnSSE(w, flusher, st.Snapshot())
+				}
 				return
+			}
+			if ev.Type == TurnEventComplete || ev.Type == TurnEventError {
+				sawTerminal = true
 			}
 			writeTurnSSEEvent(w, flusher, ev)
 		}

--- a/internal/web/forge_turn_stream.go
+++ b/internal/web/forge_turn_stream.go
@@ -1,0 +1,158 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Beads-Forge per-turn streaming and polling endpoints.
+//
+// These siblings of POST /api/forge/sessions/{id}/turn surface the in-flight
+// TurnState created by that handler:
+//
+//   - GET /api/forge/sessions/{id}/turn/{turn_id}/stream
+//     Server-Sent Events feed. Subscribes to the TurnState's Events channel
+//     and forwards each event (text_delta, tool_use, tool_result, message,
+//     complete, error) as a typed SSE event. Closes when the goroutine
+//     terminates or the client disconnects.
+//
+//   - GET /api/forge/sessions/{id}/turn/{turn_id}
+//     JSON snapshot of the current TurnState. Intended for clients that
+//     cannot consume SSE (curl, integration tests, slow polling fallbacks).
+
+// handleForgeSessionTurnStream serves SSE for one async turn. It writes the
+// usual text/event-stream headers, flushes immediately so reverse proxies
+// don't buffer the response, then forwards every TurnEvent it receives on
+// the TurnState.Events channel. When the channel closes (the runner
+// goroutine has reached a terminal state) the handler returns.
+//
+// Clients that connect after the turn has already terminated would otherwise
+// see an empty stream — the Events channel is already closed and the
+// terminal event has been drained. We catch that case up front and emit a
+// synthesised complete/error event from the snapshot so late SSE consumers
+// still observe a deterministic terminal frame before the connection ends.
+func (s *Server) handleForgeSessionTurnStream(w http.ResponseWriter, r *http.Request) {
+	st, ok := s.lookupTurn(w, r)
+	if !ok {
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	fmt.Fprint(w, "retry: 3000\n\n")
+	flusher.Flush()
+
+	// Late-connect: the runner goroutine has already exited and closed both
+	// channels. Synthesise a terminal frame from the snapshot so the client
+	// observes a complete/error event rather than an immediately-closed
+	// stream with no payload.
+	select {
+	case <-st.Done:
+		emitTerminalTurnSSE(w, flusher, st.Snapshot())
+		return
+	default:
+	}
+
+	keepalive := time.NewTicker(30 * time.Second)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepalive.C:
+			fmt.Fprint(w, ": keepalive\n\n")
+			flusher.Flush()
+		case ev, ok := <-st.Events:
+			if !ok {
+				return
+			}
+			writeTurnSSEEvent(w, flusher, ev)
+		}
+	}
+}
+
+// handleForgeSessionTurnGet serves a JSON snapshot of the TurnState. The
+// snapshot is a point-in-time copy — clients that want incremental updates
+// should use the /stream sibling instead of polling this endpoint in a tight
+// loop.
+func (s *Server) handleForgeSessionTurnGet(w http.ResponseWriter, r *http.Request) {
+	st, ok := s.lookupTurn(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, st.Snapshot())
+}
+
+// lookupTurn resolves the {id, turn_id} URL params, validates that the
+// signed-in user owns the session, and returns the registered TurnState.
+// Writes the appropriate 4xx/5xx response and returns ok=false on any
+// failure so callers can return immediately.
+func (s *Server) lookupTurn(w http.ResponseWriter, r *http.Request) (*TurnState, bool) {
+	sess := SessionFromContext(r.Context())
+	if sess == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return nil, false
+	}
+	id, ok := parseForgeSessionID(w, r)
+	if !ok {
+		return nil, false
+	}
+	row, err := s.db.GetForgeSession(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load session: "+err.Error())
+		return nil, false
+	}
+	if row == nil || !forgeSessionVisibleTo(row, sess.Username) {
+		writeError(w, http.StatusNotFound, "session not found")
+		return nil, false
+	}
+	turnID := chi.URLParam(r, "turn_id")
+	if turnID == "" {
+		writeError(w, http.StatusBadRequest, "turn_id is required")
+		return nil, false
+	}
+	st, ok := s.turnStore.Get(turnID)
+	if !ok || st.SessionID != id {
+		writeError(w, http.StatusNotFound, "turn not found")
+		return nil, false
+	}
+	return st, true
+}
+
+// writeTurnSSEEvent encodes one TurnEvent as `event: <type>\ndata: <json>\n\n`
+// and flushes. JSON marshalling failure is unexpected (Data is set by the
+// runner from concrete types) but falls back to a null payload rather than
+// dropping the frame entirely.
+func writeTurnSSEEvent(w http.ResponseWriter, flusher http.Flusher, ev TurnEvent) {
+	data, err := json.Marshal(ev.Data)
+	if err != nil {
+		data = []byte("null")
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, data)
+	flusher.Flush()
+}
+
+// emitTerminalTurnSSE writes a synthesised complete/error frame from the
+// snapshot. Used when the SSE consumer connects after the runner goroutine
+// has already closed the Events channel.
+func emitTerminalTurnSSE(w http.ResponseWriter, flusher http.Flusher, snap TurnSnapshot) {
+	switch snap.Status {
+	case TurnStatusComplete:
+		writeTurnSSEEvent(w, flusher, TurnEvent{Type: TurnEventComplete, Data: snap.FinalMessageID})
+	case TurnStatusError:
+		writeTurnSSEEvent(w, flusher, TurnEvent{Type: TurnEventError, Data: snap.Error})
+	}
+}

--- a/internal/web/forge_turn_stream_test.go
+++ b/internal/web/forge_turn_stream_test.go
@@ -1,0 +1,404 @@
+package web
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Robin831/Forge/internal/forgechat"
+)
+
+// sseFrame is one decoded `event:`/`data:` block emitted by the turn stream.
+type sseFrame struct {
+	Event string
+	Data  string
+}
+
+// readSSEFrames scans the body for up to maxFrames complete frames (separated
+// by blank lines). Returns whatever it accumulated within the deadline; the
+// caller is responsible for any further assertions on length.
+func readSSEFrames(t *testing.T, r *http.Response, maxFrames int, deadline time.Duration) []sseFrame {
+	t.Helper()
+	out := make(chan []sseFrame, 1)
+	go func() {
+		scanner := bufio.NewScanner(r.Body)
+		scanner.Buffer(make([]byte, 64*1024), 1<<20)
+		var (
+			frames []sseFrame
+			cur    sseFrame
+		)
+		flush := func() {
+			if cur.Event != "" || cur.Data != "" {
+				frames = append(frames, cur)
+			}
+			cur = sseFrame{}
+		}
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case line == "":
+				flush()
+				if len(frames) >= maxFrames {
+					out <- frames
+					return
+				}
+			case strings.HasPrefix(line, "event: "):
+				cur.Event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				if cur.Data != "" {
+					cur.Data += "\n"
+				}
+				cur.Data += strings.TrimPrefix(line, "data: ")
+			}
+		}
+		flush()
+		out <- frames
+	}()
+	select {
+	case f := <-out:
+		return f
+	case <-time.After(deadline):
+		return nil
+	}
+}
+
+// turnStreamRequest opens an authenticated SSE connection for the given
+// session/turn. The caller is responsible for closing the response body.
+func turnStreamRequest(t *testing.T, srv *Server, sessionID int64, turnID string) (*http.Response, context.CancelFunc) {
+	t.Helper()
+	cookie := loginAndGetCookie(t, srv)
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	url := ts.URL + "/api/forge/sessions/" + itoa(sessionID) + "/turn/" + turnID + "/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("new request: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("do request: %v", err)
+	}
+	return resp, cancel
+}
+
+func TestForgeTurnGet_ReturnsSnapshot(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{
+		response: &forgechat.TurnResponse{
+			Messages: []forgechat.EmittedMessage{{Kind: "text", Content: "claude says hi"}},
+		},
+	}
+	srv.SetChatRunner(runner)
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"hello"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+	waitForTurn(t, srv, turnID)
+
+	get := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions/"+itoa(id)+"/turn/"+turnID, "", cookie)
+	if get.Code != http.StatusOK {
+		t.Fatalf("get: %d body=%s", get.Code, get.Body.String())
+	}
+	var snap TurnSnapshot
+	if err := json.Unmarshal(get.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("decode snapshot: %v body=%s", err, get.Body.String())
+	}
+	if snap.ID != turnID {
+		t.Fatalf("snapshot id mismatch: got %q want %q", snap.ID, turnID)
+	}
+	if snap.SessionID != id {
+		t.Fatalf("snapshot session_id mismatch: got %d want %d", snap.SessionID, id)
+	}
+	if snap.Status != TurnStatusComplete {
+		t.Fatalf("expected complete, got %s", snap.Status)
+	}
+	if snap.Text != "claude says hi" {
+		t.Fatalf("expected accumulated text, got %q", snap.Text)
+	}
+	if snap.FinalMessageID == 0 {
+		t.Fatalf("expected non-zero final_message_id, got %d", snap.FinalMessageID)
+	}
+}
+
+func TestForgeTurnGet_UnknownTurnReturns404(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	srv.SetChatRunner(&stubRunner{})
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start"}`)
+
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions/"+itoa(id)+"/turn/does-not-exist", "", cookie)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestForgeTurnGet_WrongSessionReturns404(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	srv.SetChatRunner(&stubRunner{})
+	cookie := loginAndGetCookie(t, srv)
+	idA := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"a"}`)
+	idB := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"b"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(idA)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+	waitForTurn(t, srv, turnID)
+
+	// The turn belongs to idA — requesting it under idB must 404 so a
+	// client cannot enumerate / cross-read turns from other sessions.
+	get := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions/"+itoa(idB)+"/turn/"+turnID, "", cookie)
+	if get.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-session turn, got %d body=%s", get.Code, get.Body.String())
+	}
+}
+
+func TestForgeTurnGet_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions/1/turn/abc", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+// When the turn has already terminated by the time the SSE consumer opens
+// the connection, the handler must synthesise a terminal frame from the
+// snapshot so the client observes a deterministic complete/error event
+// before the stream closes.
+func TestForgeTurnStream_LateConnectEmitsTerminalEvent(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{
+		response: &forgechat.TurnResponse{
+			Messages: []forgechat.EmittedMessage{{Kind: "text", Content: "all done"}},
+		},
+	}
+	srv.SetChatRunner(runner)
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+	st := waitForTurn(t, srv, turnID)
+	if st.Status() != TurnStatusComplete {
+		t.Fatalf("expected complete, got %s", st.Status())
+	}
+
+	resp, cancel := turnStreamRequest(t, srv, id, turnID)
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Content-Type: got %q want text/event-stream", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control: got %q want no-cache", got)
+	}
+	if got := resp.Header.Get("Connection"); got != "keep-alive" {
+		t.Errorf("Connection: got %q want keep-alive", got)
+	}
+
+	frames := readSSEFrames(t, resp, 1, 2*time.Second)
+	if len(frames) == 0 {
+		t.Fatalf("expected at least one terminal frame, got none")
+	}
+	found := false
+	for _, f := range frames {
+		if f.Event == string(TurnEventComplete) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a complete event, got frames=%+v", frames)
+	}
+}
+
+// SSE consumers that connect while the runner is still working must receive
+// the events live: text_delta for the chunk, message for the persisted row,
+// complete for the terminal frame. The gated stub blocks the runner so the
+// SSE connection is established before any event is emitted.
+func TestForgeTurnStream_ForwardsLiveEvents(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	gate := make(chan struct{})
+	runner := &stubRunner{
+		gate: gate,
+		response: &forgechat.TurnResponse{
+			Messages: []forgechat.EmittedMessage{{Kind: "text", Content: "streamed reply"}},
+		},
+	}
+	srv.SetChatRunner(runner)
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+
+	resp, cancel := turnStreamRequest(t, srv, id, turnID)
+	defer cancel()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Now unblock the runner — events should flow through to the SSE stream.
+	close(gate)
+
+	frames := readSSEFrames(t, resp, 3, 5*time.Second)
+	if len(frames) < 1 {
+		t.Fatalf("expected at least one streamed frame, got %+v", frames)
+	}
+
+	eventTypes := make(map[string]int)
+	var textDeltaData string
+	for _, f := range frames {
+		eventTypes[f.Event]++
+		if f.Event == string(TurnEventTextDelta) {
+			textDeltaData = f.Data
+		}
+	}
+	if eventTypes[string(TurnEventTextDelta)] == 0 {
+		t.Fatalf("expected text_delta event, got %+v", frames)
+	}
+	if eventTypes[string(TurnEventComplete)] == 0 {
+		t.Fatalf("expected complete event, got %+v", frames)
+	}
+	// The text_delta payload is JSON-encoded — the runner emits the raw
+	// chunk string so the JSON value is a quoted string.
+	if textDeltaData != `"streamed reply"` {
+		t.Fatalf("text_delta data wrong: got %q want \"\"streamed reply\"\"", textDeltaData)
+	}
+}
+
+// Runner errors land on the TurnState as an error event. The SSE consumer
+// must receive an `error` frame before the channel closes.
+func TestForgeTurnStream_RunnerErrorEmitsErrorFrame(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	runner := &stubRunner{err: errors.New("upstream down")}
+	srv.SetChatRunner(runner)
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+	waitForTurn(t, srv, turnID)
+
+	resp, cancel := turnStreamRequest(t, srv, id, turnID)
+	defer cancel()
+	defer resp.Body.Close()
+
+	frames := readSSEFrames(t, resp, 1, 2*time.Second)
+	if len(frames) == 0 {
+		t.Fatalf("expected an error frame, got none")
+	}
+	found := false
+	for _, f := range frames {
+		if f.Event == string(TurnEventError) && strings.Contains(f.Data, "upstream down") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected error frame containing 'upstream down', got frames=%+v", frames)
+	}
+}
+
+// Unknown turn ids on the stream endpoint return 404 instead of opening a
+// half-broken SSE connection.
+func TestForgeTurnStream_UnknownTurnReturns404(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	srv.SetChatRunner(&stubRunner{})
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start"}`)
+
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions/"+itoa(id)+"/turn/does-not-exist/stream", "", cookie)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// Cross-session reads must 404 — same rule as the polling endpoint.
+func TestForgeTurnStream_WrongSessionReturns404(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	srv.SetChatRunner(&stubRunner{})
+	cookie := loginAndGetCookie(t, srv)
+	idA := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"a"}`)
+	idB := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"b"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(idA)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+	waitForTurn(t, srv, turnID)
+
+	get := forgeRequest(t, srv, http.MethodGet, "/api/forge/sessions/"+itoa(idB)+"/turn/"+turnID+"/stream", "", cookie)
+	if get.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-session stream, got %d body=%s", get.Code, get.Body.String())
+	}
+}
+
+// Closing the client's request context must release the SSE handler so the
+// goroutine doesn't leak. We verify by closing the body and waiting for the
+// runner's gate to be safe to close.
+func TestForgeTurnStream_ClientDisconnectReleasesHandler(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	gate := make(chan struct{})
+	t.Cleanup(func() { close(gate) })
+	runner := &stubRunner{gate: gate}
+	srv.SetChatRunner(runner)
+	cookie := loginAndGetCookie(t, srv)
+	id := createForgeSessionHelper(t, srv, cookie, `{"initial_message":"start"}`)
+
+	rec := forgeRequest(t, srv, http.MethodPost, "/api/forge/sessions/"+itoa(id)+"/turn", `{"content":"hi"}`, cookie)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("turn: %d body=%s", rec.Code, rec.Body.String())
+	}
+	turnID := decodeAccepted(t, rec.Body.Bytes())
+
+	resp, cancel := turnStreamRequest(t, srv, id, turnID)
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		cancel()
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Tear down the client side — the handler's r.Context().Done() select
+	// case must fire and return. We confirm the body actually closes.
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = resp.Body.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE handler did not release on client disconnect within 2s")
+	}
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -100,6 +100,8 @@ func (s *Server) routes() http.Handler {
 		r.Delete("/forge/sessions/{id}", s.handleForgeSessionDelete)
 		r.Post("/forge/sessions/{id}/messages", s.handleForgeSessionAppend)
 		r.Post("/forge/sessions/{id}/turn", s.handleForgeSessionTurn)
+		r.Get("/forge/sessions/{id}/turn/{turn_id}", s.handleForgeSessionTurnGet)
+		r.Get("/forge/sessions/{id}/turn/{turn_id}/stream", s.handleForgeSessionTurnStream)
 		r.Post("/forge/sessions/{id}/create-beads", s.handleForgeSessionCreateBeads)
 
 		// Hearth 2.0 resolve-needs-attention page. The POST endpoint is a

--- a/internal/web/turnstate.go
+++ b/internal/web/turnstate.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"strings"
 	"sync"
 )
@@ -46,12 +47,81 @@ type TurnEvent struct {
 	Data any           `json:"data,omitempty"`
 }
 
+// turnBroadcaster fans out events to per-client subscriber channels so
+// multiple concurrent SSE consumers each receive a complete, independent
+// copy of the event stream rather than competing for a single shared channel.
+type turnBroadcaster struct {
+	mu     sync.Mutex
+	subs   map[int]chan TurnEvent
+	next   int
+	closed bool
+}
+
+func newTurnBroadcaster() turnBroadcaster {
+	return turnBroadcaster{subs: make(map[int]chan TurnEvent)}
+}
+
+// subscribe registers a new per-client channel with the given buffer size and
+// returns its id + channel. If the broadcaster is already closed (the turn is
+// done) the returned channel is immediately closed so callers can detect the
+// terminal state without missing a closing notification.
+func (b *turnBroadcaster) subscribe(bufSize int) (int, chan TurnEvent) {
+	ch := make(chan TurnEvent, bufSize)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		close(ch)
+		return -1, ch
+	}
+	id := b.next
+	b.next++
+	b.subs[id] = ch
+	return id, ch
+}
+
+// unsubscribe removes a previously registered subscriber. id=-1 (returned when
+// subscribing to a closed broadcaster) is a no-op.
+func (b *turnBroadcaster) unsubscribe(id int) {
+	if id < 0 {
+		return
+	}
+	b.mu.Lock()
+	delete(b.subs, id)
+	b.mu.Unlock()
+}
+
+// emit delivers ev to every registered subscriber without blocking; events are
+// dropped for any subscriber whose buffer is full.
+func (b *turnBroadcaster) emit(ev TurnEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.subs {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+// closeAll marks the broadcaster closed, closes every registered subscriber
+// channel, and clears the subscriber map. Any subsequent subscribe call will
+// receive an immediately-closed channel.
+func (b *turnBroadcaster) closeAll() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	for _, ch := range b.subs {
+		close(ch)
+	}
+	b.subs = make(map[int]chan TurnEvent)
+}
+
 // TurnState holds the in-flight state of a single Beads-Forge AI turn.
 //
 // It is created by the /turn handler before launching the background
 // goroutine, and read by the SSE / polling endpoints (sibling sub-tasks).
-// The Events channel fans out incremental updates; the Done channel signals
-// terminal status so callers can wait without polling.
+// Call Subscribe to obtain a per-client channel that receives every event
+// emitted by the runner; Done signals the terminal state.
 //
 // All mutating helpers take the mutex internally; readers should call
 // Snapshot rather than touching the unexported fields directly.
@@ -69,32 +139,46 @@ type TurnState struct {
 	finalMessageID int64
 	err            error
 
-	// Events fans out incremental updates to SSE subscribers. Closed when the
-	// goroutine exits (after Done). Buffered so a slow or absent consumer
-	// cannot block the producer indefinitely; events overflow is dropped (the
-	// SSE endpoint replays missed state via Snapshot).
-	Events chan TurnEvent
+	bcast      turnBroadcaster
+	subBufSize int
 	// Done is closed by the goroutine when the turn reaches a terminal state.
 	// Callers that need to wait for completion (tests, polling endpoints) can
 	// select on this without consuming events.
 	Done chan struct{}
 }
 
-// newTurnState constructs a TurnState in TurnStatusPending. eventsBuffer sizes
-// the events channel; <0 uses a default of 64. Pass 0 to create an unbuffered
-// channel (producer blocks until consumed — fine for tests, bad for real SSE
-// traffic).
+// newTurnState constructs a TurnState in TurnStatusPending. eventsBuffer
+// controls the per-subscriber channel buffer size returned by Subscribe; <0
+// uses a default of 64. Pass 0 to create unbuffered subscriber channels
+// (fine for tests with a synchronous consumer, not for production SSE).
 func newTurnState(id string, sessionID int64, eventsBuffer int) *TurnState {
 	if eventsBuffer < 0 {
 		eventsBuffer = 64
 	}
 	return &TurnState{
-		ID:        id,
-		SessionID: sessionID,
-		status:    TurnStatusPending,
-		Events:    make(chan TurnEvent, eventsBuffer),
-		Done:      make(chan struct{}),
+		ID:         id,
+		SessionID:  sessionID,
+		status:     TurnStatusPending,
+		bcast:      newTurnBroadcaster(),
+		subBufSize: eventsBuffer,
+		Done:       make(chan struct{}),
 	}
+}
+
+// Subscribe returns a dedicated per-client channel that receives every event
+// the runner emits. The channel is closed when the turn ends. When the turn
+// has already ended the returned channel is immediately closed so consumers
+// can detect that without missing a terminal notification.
+//
+// The goroutine launched here unsubscribes when ctx is cancelled (typically
+// when the HTTP request ends), keeping the broadcaster map tidy.
+func (t *TurnState) Subscribe(ctx context.Context) <-chan TurnEvent {
+	id, ch := t.bcast.subscribe(t.subBufSize)
+	go func() {
+		<-ctx.Done()
+		t.bcast.unsubscribe(id)
+	}()
+	return ch
 }
 
 // Status returns the current status.
@@ -201,14 +285,11 @@ func (t *TurnState) Snapshot() TurnSnapshot {
 	return snap
 }
 
-// Emit pushes an event on the Events channel without blocking. If the
-// channel is full (slow consumer or no subscriber), the event is dropped —
-// the SSE endpoint replays missed state via Snapshot on initial connect.
+// Emit broadcasts ev to all per-client subscriber channels without blocking.
+// Events are dropped for any subscriber whose buffer is full; the SSE
+// endpoint replays missed state via Snapshot on initial connect.
 func (t *TurnState) Emit(ev TurnEvent) {
-	select {
-	case t.Events <- ev:
-	default:
-	}
+	t.bcast.emit(ev)
 }
 
 // TurnStore is the process-local registry of in-flight and recently-finished

--- a/internal/web/turnstate_test.go
+++ b/internal/web/turnstate_test.go
@@ -21,8 +21,8 @@ func TestTurnStore_NewAssignsPendingStatus(t *testing.T) {
 	if st.SessionID != 42 {
 		t.Fatalf("expected session id 42, got %d", st.SessionID)
 	}
-	if st.Events == nil || st.Done == nil {
-		t.Fatal("Events/Done channels should be initialised")
+	if st.Done == nil {
+		t.Fatal("Done channel should be initialised")
 	}
 }
 


### PR DESCRIPTION
## Changes

- **Beads-Forge turn SSE and polling endpoints** - `GET /api/forge/sessions/{id}/turn/{turn_id}/stream` streams the in-flight TurnState's events (text_delta, tool_use, tool_result, message, complete, error) as Server-Sent Events; `GET /api/forge/sessions/{id}/turn/{turn_id}` returns the current TurnState snapshot as JSON for clients that don't consume SSE. Both endpoints validate session ownership and gracefully handle late-connecting consumers by synthesising a terminal frame from the snapshot. (Forge-ivgo)

## Original Issue (task): SSE streaming and polling endpoints

Add `GET /api/forge/sessions/{id}/turn/{turn_id}/stream` returning `text/event-stream` with proper headers (Content-Type, Cache-Control: no-cache, Connection: keep-alive) and SSE event types: `text_delta` (assistant text chunks), `tool_use` (compact 'Calling Grep for X' notifications), `tool_result` (compact summary), `complete` (final persisted message id), `error`. Use http.Flusher for incremental writes; subscribe to the TurnState event channel from sub-task 1. Handle client disconnects via request context. Also add `GET /api/forge/sessions/{id}/turn/{turn_id}` polling endpoint returning current TurnState as JSON snapshot for clients that don't consume SSE. Wire both routes into the existing forge router. Depends on sub-task 1's TurnState store being merged first.

---
Bead: Forge-ivgo | Branch: forge/Forge-ivgo
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->