### PR TITLE
forge: batch warden rule update [no-changelog]

### DIFF
--- a/.forge/warden-rules.yaml
+++ b/.forge/warden-rules.yaml
@@ -6,6 +6,9 @@ rules:
         Verify that the backgroundPhases constant in internal/state/db.go includes the new phase, so it is excluded from stall detection and dispatch capacity counting. Also update any doc comments that enumerate background phases (e.g. on ActiveDispatchWorkers, ActiveDispatchWorkersByAnvil, StalledWorkers).
       source: copilot:PR#130
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-render-behavior
       category: testing
       pattern: >-
@@ -14,6 +17,9 @@ rules:
         When adding new display/rendering branches (or template/prompt conditional sections) to a function with existing test coverage, verify that test cases are added for both the truthy and falsy paths of the new condition
       source: ['copilot:PR#130', 'copilot:PR#496']
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: reuse-worktree-manager
       category: other
       pattern: >-
@@ -22,6 +28,9 @@ rules:
         Verify that worktree operations use internal/worktree.Manager instead of reimplementing git worktree creation, cleanup, fetch, or branch management. This ensures consistent handling of edge cases (existing branches/worktrees, remote-only branches) and maintains the standard .workers layout across all Forge components.
       source: copilot:PR#129
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: new-logic-needs-tests
       category: testing
       pattern: >-
@@ -30,6 +39,9 @@ rules:
         Verify that new logic paths (especially those with multiple failure modes like branch resolution, external tool invocation, state-dependent behavior, handling a new input format, or adding a fallback path) have corresponding unit tests — either by injecting dependencies for isolation or by factoring decisions into pure functions that can be tested directly. Include tests for retention, ordering, and edge cases.
       source: copilot:PR#129, copilot:PR#404
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-base-branch-consistency
       category: other
       pattern: >-
@@ -38,6 +50,9 @@ rules:
         Verify that when creating a PR, the Base branch is explicitly passed to ghpr.CreateParams using the already-resolved base ref (without origin/ prefix), rather than relying on the default. This prevents PRs from targeting the wrong branch when a repo uses master instead of main.
       source: copilot:PR#129
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-creation-requires-bead-id-or-skip-flag
       category: other
       pattern: >-
@@ -46,6 +61,9 @@ rules:
         Verify that every ghpr.Create call either sets a BeadID or is explicitly excluded from bellows monitoring, to prevent untracked PRs from being treated as normal work PRs and triggering unintended side-effects (e.g., infinite auto-learn loops)
       source: copilot:PR#129
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cleanup-defer-canceled-ctx
       category: concurrency
       pattern: >-
@@ -54,6 +72,9 @@ rules:
         Verify that cleanup/teardown defers use context.Background() with a short timeout instead of the passed-in context, so cleanup still runs when the parent context is canceled (shutdown/timeout)
       source: copilot:PR#129
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: unique-branch-worktree-names
       category: error-handling
       pattern: >-
@@ -62,6 +83,9 @@ rules:
         Verify that branch names, worktree paths, and worker directory IDs include a unique per-run component (e.g., timestamp, worker ID, or random suffix) beyond any deterministic identifier, to prevent collisions on retry after a crash or when concurrent/repeated same-day runs on the same anvil contend for the same path; alternatively, verify that existing branches/worktrees are detected and reused gracefully
       source: ['copilot:PR#129', 'copilot:PR#410']
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: truncation-off-by-one
       category: ui
       pattern: >-
@@ -70,6 +94,9 @@ rules:
         Verify that any ellipsis or truncation indicator is included within the stated line limit, not appended as an extra line beyond it
       source: copilot:PR#128
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: utf8-safe-truncation
       category: ui
       pattern: String slicing by byte index (s[:n]) on user-visible text
@@ -77,6 +104,9 @@ rules:
         Verify that string truncation is rune-safe and does not slice through multi-byte UTF-8 characters. Use []rune slicing or runewidth.Truncate instead of byte-based slicing.
       source: copilot:PR#128
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: new-ui-behavior-needs-tests
       category: testing
       pattern: >-
@@ -85,6 +115,9 @@ rules:
         Verify that new or changed user-visible behavior (new fields displayed, text wrapping, truncation/ellipsis) has corresponding test coverage in the existing test file, asserting expected output format and edge cases
       source: copilot:PR#128
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-matches-implementation
       category: other
       pattern: >-
@@ -93,6 +126,9 @@ rules:
         Verify that changelog descriptions accurately reflect the actual code changes — if the changelog claims a feature applies to multiple views or components, confirm each one was actually modified to support it; also ensure the changelog does not claim full functionality (e.g., 'enables autostart') when the code only partially implements it (e.g., only runs daemon-reload without enabling the service). For entries describing caching, optimization, or performance improvements, cross-check the claim against the code to ensure the described mechanism (e.g., a cache avoiding repeated calls) is actually implemented and used in the relevant code paths.
       source: ['copilot:PR#128', 'copilot:PR#434']
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-style-frame-size
       category: ui
       pattern: >-
@@ -101,6 +137,9 @@ rules:
         Verify that content width calculations use the style's GetHorizontalFrameSize() or GetVerticalFrameSize() methods rather than hardcoded offsets, so truncation and layout stay correct if border or padding values change
       source: copilot:PR#128
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: popup-content-width-frame-size
       category: ui
       pattern: >-
@@ -109,6 +148,9 @@ rules:
         Use GetHorizontalFrameSize() (or GetVerticalFrameSize()) from the lipgloss style instead of hard-coded offsets so content width stays consistent when padding or border styles change
       source: copilot:PR#128
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: utf8-safe-string-ops
       category: ui
       pattern: >-
@@ -117,6 +159,9 @@ rules:
         Verify that string measurement and slicing uses rune-aware operations (or existing helpers like wordWrap) instead of byte-level len()/slicing, which can split multi-byte UTF-8 characters and produce incorrect width calculations
       source: copilot:PR#128
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: naming-matches-semantics
       category: style
       pattern: >-
@@ -125,6 +170,9 @@ rules:
         Verify that function/constant/type names accurately reflect their actual scope and behavior. When semantics broaden beyond the original name, rename to match (e.g. ExtractEpicBranch → ExtractParentBranch) and keep the old name as a deprecated wrapper for backward compatibility.
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-code-consistency
       category: other
       pattern: >-
@@ -133,6 +181,9 @@ rules:
         Verify that comments accurately reflect the actual code behavior and control flow. When a comment claims something is eligible, enabled, or handled, trace the execution path to confirm the code actually supports that claim. Pay special attention to comments describing guard or skip behavior near loops/conditionals — confirm the corresponding guard clause (e.g. continue, return, conditional block) actually exists and is correct. Update comments to match reality or fix the code to match the intent.
       source: ['copilot:PR#126', 'copilot:PR#444', 'copilot:PR#490']
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-matches-behavior
       category: other
       pattern: Changelog entries or documentation describing feature behavior changes
@@ -140,6 +191,9 @@ rules:
         Verify that changelog entries and documentation accurately describe the actual implemented behavior, including any exceptions or edge cases where legacy paths or special handling still apply
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-show-json-array-unwrap
       category: error-handling
       pattern: >-
@@ -148,6 +202,9 @@ rules:
         Verify that code consuming `bd show --json` output handles both single-object (`{...}`) and single-element-array (`[{...}]`) forms, and logs unmarshal failures (including stderr and raw output) instead of silently returning zero values
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: default-epic-branch-scope
       category: testing
       pattern: >-
@@ -156,6 +213,9 @@ rules:
         Verify that default epic/feature branch names are only assigned to appropriate bead types (epics, features) — not broadly to all types like tasks or bugs, which could accidentally force non-existent base branches in unrelated dependency graphs
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: epic-branch-guard
       category: other
       pattern: >-
@@ -164,6 +224,9 @@ rules:
         Verify that epic branch resolution only applies to actual parent-child (epic/feature) relationships, not ordinary task dependencies. Unconditionally deriving a feature branch name like `feature/<id>` from any related bead can cause pipelines and PRs to target non-existent base branches. Ensure there is a guard — such as checking for an explicit label, restricting to epic/feature bead types, or verifying the bead actually has children — before assigning an epic branch.
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: wrapper-preserves-original-semantics
       category: other
       pattern: >-
@@ -172,6 +235,9 @@ rules:
         Verify the wrapper actually preserves the original behavior. If the underlying function's semantics changed (e.g., new default return values), the wrapper must replicate the old behavior — not just delegate to the new function. Update comments and names to accurately reflect whether compatibility is truly maintained.
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: remove-unused-scaffolding
       category: style
       pattern: >-
@@ -180,6 +246,9 @@ rules:
         Verify that declared types, variables, and structural comments correspond to actual implemented behavior — remove scaffolding for unimplemented features or implement the implied functionality
       source: copilot:PR#126
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-show-json-unwrap-array
       category: error-handling
       pattern: >-
@@ -188,6 +257,9 @@ rules:
         Verify that `unwrapJSONArray` is called before `json.Unmarshal` when processing `bd show --json` output, since the command may return either `{...}` or `[{...}]` depending on context. Also verify that unmarshal errors are logged rather than silently ignored.
       source: copilot:PR#125
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: manual-dispatch-epic-branch-resolution
       category: other
       pattern: >-
@@ -196,6 +268,9 @@ rules:
         When manually dispatching a bead, verify that `Blocks` is resolved (e.g. via `poller.ResolveBlocks`) before calling `ResolveEpicBranches`, so that beads blocking an epic are correctly assigned an `EpicBranch` instead of creating PRs against main
       source: copilot:PR#125
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: new-detection-paths-need-tests
       category: testing
       pattern: Adding a new detection/resolution path to an existing function
@@ -203,6 +278,9 @@ rules:
         Verify that new detection paths have corresponding unit tests, especially when the path involves external calls (e.g., shelling out to CLI tools) — these should be injectable/mockable so tests don't depend on external processes
       source: copilot:PR#125
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bubbletea-cmd-must-be-dispatched
       category: ui
       pattern: >-
@@ -211,6 +289,9 @@ rules:
         Verify that every call to a function returning tea.Cmd actually dispatches the command via return or tea.Batch — a discarded Cmd means the async operation silently never executes
       source: copilot:PR#123
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nullable-bool-config-docs
       category: other
       pattern: >-
@@ -219,6 +300,8 @@ rules:
         Verify that docs accurately reflect nullable types as `type|null` with default `null (use global/default)` rather than showing them as plain non-nullable types with a hardcoded default. Document that when set, the per-scope value overrides the global setting.
       source: copilot:PR#122
       added: "2026-03-09"
+      paths:
+        - '**/*.md'
     - id: cli-docs-match-cobra-flags
       category: other
       pattern: CLI documentation or help text for a command that has flags registered in Cobra
@@ -226,6 +309,8 @@ rules:
         Verify that all flags wired in the Cobra command definition (including shorthand aliases like -p, -n) are documented in the CLI reference docs. Missing flags means the docs don't match the actual interface.
       source: copilot:PR#122
       added: "2026-03-09"
+      paths:
+        - '**/*.md'
     - id: docs-match-implementation
       category: other
       pattern: Documentation or comments describing supported tools, formats, or integrations
@@ -233,6 +318,8 @@ rules:
         Verify that documentation accurately reflects the current implementation — do not claim support for tools, formats, or integrations that are not actually implemented in the code
       source: copilot:PR#122
       added: "2026-03-09"
+      paths:
+        - '**/*.md'
     - id: exhaustive-list-completeness
       category: other
       pattern: >-
@@ -241,6 +328,8 @@ rules:
         When a list claims or appears to be comprehensive, verify all items are included. If the list is intentionally partial, ensure it says so explicitly (e.g., 'key packages include…') to avoid misleading readers into thinking unlisted items don't exist
       source: copilot:PR#122
       added: "2026-03-09"
+      paths:
+        - '**/*.md'
     - id: clamp-before-slice
       category: error-handling
       pattern: >-
@@ -249,6 +338,9 @@ rules:
         Verify the computed slice index is clamped to a safe minimum (>= 0, and >= offset+1 when subtracting further) so narrow dimensions cannot produce a negative or out-of-bounds slice bound
       source: copilot:PR#121
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hidden-panel-focus-cycle
       category: ui
       pattern: >-
@@ -257,6 +349,9 @@ rules:
         Verify that conditionally-hidden panels are excluded from the focus cycle when not visible, or are always rendered (even if empty), so focus never lands on a non-rendered element. When a focusable panel becomes invisible or disabled, ensure focus is normalized to a visible neighbor so the UI is never left with no visible focused element or keybindings for a hidden panel.
       source: ['copilot:PR#121', 'copilot:PR#453']
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-comment-accuracy
       category: style
       pattern: Function or method doc comments that describe behavior, layout, or parameters
@@ -264,6 +359,9 @@ rules:
         Verify that doc comments accurately reflect the current behavior of the function, especially after changes that add conditional paths or new UI panels
       source: copilot:PR#121
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: delayed-status-cleanup
       category: ui
       pattern: Deferred deletion of UI-visible status/state immediately after completion
@@ -271,6 +369,9 @@ rules:
         When removing a status entry that the UI displays, ensure there is an actual delay (e.g., time.AfterFunc) before deletion so the terminal state is visible for at least one refresh cycle. Do not delete immediately if a comment or intent says 'after a short delay'.
       source: copilot:PR#121
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sort-ipc-collections
       category: ui
       pattern: sync.Map.Range or map iteration results returned via IPC for display in TUI/CLI
@@ -278,6 +379,9 @@ rules:
         Verify that collections built from map/sync.Map iteration are sorted deterministically before being returned to callers, to prevent UI list jumping and cursor/viewport issues
       source: copilot:PR#121
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nullable-bool-doc-mismatch
       category: other
       pattern: >-
@@ -286,6 +390,9 @@ rules:
         Verify that documentation for nullable/pointer config fields accurately reflects the tri-state nature (true/false/null) and documents the nil behavior (e.g., 'use global setting') rather than showing a simple bool with a fixed default
       source: copilot:PR#131
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-config-behavior
       category: testing
       pattern: New config fields or flags that filter, gate, or change operational behavior
@@ -293,6 +400,9 @@ rules:
         Verify that new configuration options affecting runtime behavior (feature toggles, per-entity filters, operational flags) have unit tests covering both enabled and disabled paths to prevent regressions
       source: copilot:PR#131
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: normalize-path-once
       category: other
       pattern: >-
@@ -301,6 +411,9 @@ rules:
         When a path is normalized (e.g., via filepath.Abs or filepath.EvalSymlinks), verify the normalized value is stored back or used consistently across all operations (logging, watching, loading) to avoid mismatches if the working directory changes
       source: copilot:PR#133
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: platform-accurate-terminology
       category: style
       pattern: >-
@@ -309,6 +422,9 @@ rules:
         Verify that comments use platform-neutral terminology or explicitly qualify platform-specific terms. For example, use 'file identity' or 'file handle' instead of 'inode' when the code runs on Windows, where inodes do not exist in the Unix sense.
       source: copilot:PR#133
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-fragment-bead-id-match
       category: style
       pattern: Adding or modifying files in changelog.d/
@@ -316,6 +432,9 @@ rules:
         Verify the changelog fragment filename matches the current PR's bead ID (changelog.d/<bead-id>.md) and that the trailing bead reference in the bullet text also matches the same bead ID. Also verify the fragment file ends with a trailing blank line to maintain consistent formatting across all entries.
       source: copilot:PR#143,PR#336
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-dead-db-columns
       category: other
       pattern: >-
@@ -324,6 +443,9 @@ rules:
         Verify that every queried database column is actually written to somewhere in the codebase. A column that is never populated will always return its default value, making any read-side logic (e.g., conditional overrides) dead code. Also check that the read path does not shadow outer error variables when handling the query result.
       source: copilot:PR#147
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: new-render-paths-need-tests
       category: testing
       pattern: >-
@@ -332,6 +454,9 @@ rules:
         Verify that new rendering functions have corresponding test coverage, and that existing tests are updated to call the new function signatures rather than stale ones they replaced
       source: copilot:PR#147
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: format-precision-loss
       category: ui
       pattern: >-
@@ -340,6 +465,9 @@ rules:
         Verify that numeric formatting preserves appropriate precision — e.g. use %.1f instead of %d when dividing values for human-readable display, so 1500 renders as '1.5k' not '1k'
       source: copilot:PR#147
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: unreachable-dead-code-guard
       category: style
       pattern: >-
@@ -348,6 +476,9 @@ rules:
         When a function has an early return based on a value X, verify that subsequent guards on values derived from X are actually reachable. If a prior check guarantees X >= N, and Y is computed as X - constant, then guards like Y < M may be dead code when M <= N - constant.
       source: copilot:PR#147
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nil-map-write-guard
       category: error-handling
       pattern: Assigning into a map field without checking if the map has been initialized
@@ -355,6 +486,9 @@ rules:
         Before writing to a map field, verify the map is non-nil. If the struct can be constructed as a zero value (common in tests), lazily initialize the map before the first write (e.g., `if m.myMap == nil { m.myMap = make(map[K]V) }`) or ensure all constructors call the proper initializer.
       source: copilot:PR#156
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cursor-identity-after-clamp
       category: ui
       pattern: >-
@@ -363,6 +497,9 @@ rules:
         When the backing list changes and the cursor is clamped or shifted, verify that any associated state tied to the previously-selected item (expansion, scroll position, sub-cursors) is detected as stale and reset. Compare the selected item's identity (e.g., ID) before and after the update; if it changed, reset dependent state.
       source: copilot:PR#156
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: docstring-matches-keybindings
       category: ui
       pattern: Comments or docstrings that describe keyboard shortcuts or key bindings
@@ -370,6 +507,9 @@ rules:
         Verify that docstrings and comments describing key bindings match the actual key handling implementation. If a comment says a key does X, confirm the keypress handler actually does X — update the comment or the code so they agree.
       source: copilot:PR#156
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-matches-behavior
       category: style
       pattern: >-
@@ -378,6 +518,9 @@ rules:
         Verify that inline comments accurately describe what the code actually does — if only one branch of a described toggle is implemented here, the comment should reflect the actual behavior or reference where the other branch lives
       source: copilot:PR#156
       added: "2026-03-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: needs-human-circuit-breaker-prefix
       category: error-handling
       pattern: >-
@@ -386,6 +529,9 @@ rules:
         Verify that error message prefixes accurately identify the originating subsystem or failure mode. Do not reuse prefixes from unrelated code paths (e.g. using 'circuit breaker:' for a crucible child failure) as this conflates failure modes and misleads operators reading logs or state. This guidance supersedes any older advice to force 'circuit breaker:' prefixes on generic needs_human errors — dispatch now relies on NeedsHumanBeadIDSet(), not on specific LastError prefixes, so choose a prefix that accurately reflects the actual failure mode.
       source: copilot:PR#169
       added: "2026-03-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: handle-db-upsert-errors
       category: error-handling
       pattern: >-
@@ -394,6 +540,9 @@ rules:
         Verify that errors returned from state DB write operations (UpsertRetry, UpdateWorker, InsertEvent, etc.) are handled — at minimum logged with context (bead_id, anvil, operation). Discarding these errors can leave the system in an inconsistent state (e.g., a bead reset to open but not marked needs_human, causing infinite dispatch loops).
       source: copilot:PR#166
       added: "2026-03-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: preserve-existing-retry-state
       category: error-handling
       pattern: UpsertRetry called with a partially-populated RetryRecord struct
@@ -401,6 +550,9 @@ rules:
         Verify that UpsertRetry does not silently overwrite existing retry state (retry_count, next_retry, dispatch_failures, clarification_needed). Load the existing record first and only update the fields you intend to change, preserving counters and backoff state.
       source: copilot:PR#166
       added: "2026-03-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-dispatch-eligibility-filters
       category: testing
       pattern: >-
@@ -409,6 +561,9 @@ rules:
         When modifying query filters that determine dispatch eligibility (e.g. which beads are blocked, need human attention, or are circuit-broken), verify that a unit test exists asserting which rows are included and excluded by the new filter criteria — covering edge cases like different reason strings, flag combinations, and boundary values
       source: copilot:PR#169
       added: "2026-03-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: event-include-bead-anvil-context
       category: ui
       pattern: >-
@@ -417,6 +572,9 @@ rules:
         When logging to the Hearth event log via state.DB.LogEvent, always pass bead_id and anvil fields when that context is known. Because Hearth does not currently display the structured Anvil field, include the anvil name in the message text only when it materially helps operators correlate behavior across anvils. If bead_id is unknown or blank but you reference a PR or other external identifier, include the BeadID string in the message so the event remains traceable; daemon/lifecycle events with no associated bead do not need artificial bead/anvil context.
       source: copilot:PR#171
       added: "2026-03-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: auto-learn-skip-event-context
       category: error-handling
       pattern: >-
@@ -425,6 +583,9 @@ rules:
         Verify that skip/no-op events include all relevant identifiers (bead ID, anvil name) so they are traceable in dashboards and logs. When the skip is caused by upstream failures (e.g., all distillation calls errored), track the failure count and either include it in the skip message or emit a dedicated error event instead of silently skipping.
       source: copilot:PR#171
       added: "2026-03-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-exercises-described-scenario
       category: testing
       pattern: >-
@@ -433,6 +594,9 @@ rules:
         Verify that the test setup actually triggers the scenario described in the test name. If the code under test uses fixed/hardcoded values that ignore the test's input, either refactor the code to accept the relevant parameter or adjust the test to exercise the real code path.
       source: copilot:PR#175
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hot-reload-claim-accuracy
       category: other
       pattern: >-
@@ -441,6 +605,9 @@ rules:
         Verify the setting is actually tracked in the hot-reload allowlist (internal/hotreload/hotreload.go:applyChanges). If it is not in the allowlist, either add it there (plus any downstream scheduler/callback wiring) and update the Hot Reload docs, or remove the hot-reloadable claim from the changelog/docs/PR description.
       source: copilot:PR#178, copilot:PR#356
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: config-override-needs-test
       category: testing
       pattern: Adding a new configurable parameter or field that overrides default behavior
@@ -448,6 +615,9 @@ rules:
         Verify that unit tests exercise the new override by setting it to a boundary value (e.g., minimum) and confirming the overridden behavior takes effect
       source: copilot:PR#178
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-matches-implementation
       category: style
       pattern: >-
@@ -456,6 +626,9 @@ rules:
         Verify that doc comments accurately describe the exact conditions handled by the code. If the code uses <= 0 but the comment says 'when zero', update the comment to say 'when zero or negative' (or tighten the condition to match the comment).
       source: copilot:PR#178
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cross-repo-token-permissions
       category: security
       pattern: >-
@@ -464,6 +637,9 @@ rules:
         Verify that the workflow uses a dedicated secret (PAT or fine-grained token) with write access to the target repository. The default GITHUB_TOKEN is scoped to the current repo only and cannot push to external repos — using it for cross-repo publishing will silently fail or error.
       source: copilot:PR#186,PR#187
       added: "2026-03-11"
+      paths:
+        - '**/*.md'
+        - '**/*.yml'
     - id: homebrew-desc-length
       category: style
       pattern: Homebrew formula or goreleaser brew section with a `desc` or `description` field
@@ -471,6 +647,9 @@ rules:
         Verify the Homebrew description is a concise one-liner. Long descriptions trigger `brew audit` warnings and tap CI noise.
       source: copilot:PR#187
       added: "2026-03-11"
+      paths:
+        - '**/*.md'
+        - '**/*.yml'
     - id: docker-registry-auth
       category: security
       pattern: >-
@@ -479,6 +658,9 @@ rules:
         Verify that registry authentication is configured — either credentials (username/password or token) in the publishing tool config, or a prior docker login step in the CI workflow — so that image pushes do not fail at release time
       source: copilot:PR#191
       added: "2026-03-11"
+      paths:
+        - '**/*.md'
+        - '**/*.yml'
     - id: docker-ghcr-workflow-permissions
       category: other
       pattern: GoReleaser or workflow config that builds/pushes container images to GHCR
@@ -486,6 +668,9 @@ rules:
         Verify the GitHub Actions workflow grants `packages: write` permission to GITHUB_TOKEN for GHCR pushes. If the workflow builds and publishes multi-architecture images, also ensure it sets up QEMU and Docker buildx before the GoReleaser or docker build step. Missing permissions or required setup will typically surface as explicit 403 or build errors rather than a successful run with missing images.
       source: copilot:PR#191
       added: "2026-03-11"
+      paths:
+        - '**/*.md'
+        - '**/*.yml'
     - id: dockerfile-non-root-user
       category: security
       pattern: >-
@@ -494,6 +679,9 @@ rules:
         Prefer that production/runtime Dockerfiles run as a non-root user (typically via a USER directive). If the image intentionally runs as root, verify there is a documented justification and that an alternative hardening strategy is in place (for example, dropping privileges in the entrypoint or restricting capabilities/FS access).
       source: copilot:PR#191
       added: "2026-03-11"
+      paths:
+        - '**/*.md'
+        - '**/*.yml'
     - id: test-layout-must-match-render-logic
       category: testing
       pattern: Tests that assert which UI panel occupies a screen coordinate or region
@@ -501,6 +689,9 @@ rules:
         When testing UI hit-testing or coordinate-based panel lookups, verify that test assertions use the same height calculations and panel stacking order as the actual render functions — do not hardcode simplified region-to-panel mappings that diverge from how View() lays out subpanels (e.g. stacked Queue/Crucibles, ReadyToMerge/NeedsAttention splits)
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-layout-sync
       category: testing
       pattern: >-
@@ -509,6 +700,9 @@ rules:
         Verify that test layout calculations exactly mirror the production rendering logic (same height computations, same split ratios, same fixed-size regions) rather than reimplementing layout math that can drift out of sync with the real UI
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-should-match-condition
       category: style
       pattern: >-
@@ -517,6 +711,9 @@ rules:
         Verify that comments accurately describe the scope of the condition they annotate — if the code only handles specific cases (e.g., left/right click), the comment should not claim broader behavior (e.g., 'any button press')
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: mouse-wheel-action-gate
       category: ui
       pattern: >-
@@ -525,6 +722,9 @@ rules:
         Verify that WheelUp/WheelDown handlers check msg.Action == tea.MouseActionPress to prevent spurious scrolling from motion/release events when tea.WithMouseCellMotion() is active
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hit-test-covers-all-subpanels
       category: ui
       pattern: >-
@@ -533,6 +733,9 @@ rules:
         Verify that hit-testing logic distinguishes between all visually distinct sub-panels within a column — not just the primary one. If a column renders multiple panels (e.g., a list above and a usage/status panel below), the coordinate mapping must check the y-position against each sub-panel's boundary and return the correct panel identifier, otherwise mouse focus and scroll events will target the wrong panel.
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hearth-mouse-panel-hit-testing
       category: ui
       pattern: >-
@@ -541,6 +744,9 @@ rules:
         Verify that mouse hit-testing logic mirrors the actual rendering layout. When panels are conditionally stacked or split (e.g., Queue and Crucibles sharing a column), the click target regions must use the same height calculations as the render function, so each visible panel remains individually focusable via mouse.
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: layout-math-consistency
       category: ui
       pattern: >-
@@ -549,6 +755,9 @@ rules:
         Verify that mouse/input position mapping uses the exact same layout computation as the rendering code — factor shared geometry (header height, footer height, column splits, panel borders, minimums) into a single helper used by both the view/render path and the hit-testing/input-handling path, so they cannot diverge at different terminal sizes or when content wraps. Layout constants (heights, widths, offsets) must never be duplicated; a single constant or helper is the source of truth so that mouse regions, keyboard navigation, and rendered layout always agree.
       source: ['copilot:PR#192', 'copilot:PR#453']
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-comment-matches-implementation
       category: other
       pattern: >-
@@ -557,6 +766,9 @@ rules:
         Verify that the implementation actually matches what the doc comment claims — if a comment says a condition is special-cased, the code must contain that special-case logic, and vice versa
       source: copilot:PR#192
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-description-accuracy
       category: other
       pattern: >-
@@ -565,6 +777,9 @@ rules:
         Verify that the PR description accurately reflects the scope of changes — if code alters UI behavior, runtime logic, or user-facing output, the description must not claim 'no functional changes'
       source: copilot:PR#193
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: unique-event-fingerprint
       category: ui
       pattern: >-
@@ -573,6 +788,9 @@ rules:
         Verify that deduplication keys include a stable unique identifier (e.g., DB row ID) and all distinguishing fields (such as BeadID and full-precision timestamps), rather than relying on display-only formatted values that can collide across records
       source: copilot:PR#195
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: toast-stack-ordering
       category: ui
       pattern: Prepending items to a display list that is rendered in slice order
@@ -580,6 +798,9 @@ rules:
         Verify that the insertion order (prepend vs append) matches the intended visual order. If newest items should appear closest to a fixed UI edge (e.g., footer), ensure the storage order and render iteration produce that result — prepending newest while iterating in slice order places newest *furthest* from the end.
       source: copilot:PR#195
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: toast-fallback-ordering
       category: ui
       pattern: >-
@@ -588,6 +809,9 @@ rules:
         When constructing user-facing messages with multiple fallback values, verify that more descriptive/synthesized fallbacks are preferred over raw identifiers. A bare ID pre-filling the message variable can make later event-specific fallbacks unreachable.
       source: copilot:PR#195
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-description-matches-implementation
       category: other
       pattern: >-
@@ -596,6 +820,9 @@ rules:
         Verify that the actual implementation uses the library/API/mechanism described in the PR title, description, and changelog. If a different approach was used, ensure the PR metadata is updated to accurately reflect the real implementation.
       source: copilot:PR#195
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-duplicate-overlay-helpers
       category: ui
       pattern: >-
@@ -604,6 +831,9 @@ rules:
         Verify the new helper does not duplicate logic already present in an existing overlay function. If similar logic exists, extract a shared helper with configurable placement rather than maintaining parallel implementations that can drift.
       source: copilot:PR#195
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-name-matches-intent
       category: testing
       pattern: >-
@@ -612,6 +842,9 @@ rules:
         Verify that test function names and their doc comments accurately describe the behavior being tested, not internal implementation details or leftover naming from earlier drafts
       source: copilot:PR#195
       added: "2026-03-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: iota-label-array-sync
       category: ui
       pattern: Adding or reordering iota constants that have a corresponding label/string array
@@ -619,6 +852,9 @@ rules:
         Verify that all parallel arrays or switch cases indexed by iota constants are updated in sync — inserting a new iota value shifts all subsequent values, so every array, slice literal, or map keyed by those constants must add the new entry at the correct position
       source: copilot:PR#230
       added: "2026-03-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: alpine-user-management-compat
       category: other
       pattern: >-
@@ -627,6 +863,11 @@ rules:
         Verify that user creation and existence checks are portable across distros. Alpine (apk) lacks useradd by default — use `id -u <user>` for existence checks and fall back to `adduser` when `useradd` is unavailable, or declare the required package dependency for apk builds.
       source: copilot:PR#235
       added: "2026-03-13"
+      paths:
+        - '**/*.md'
+        - '**/*.service'
+        - '**/*.sh'
+        - '**/*.yml'
     - id: systemd-service-enable
       category: other
       pattern: Package post-install scripts that run systemctl daemon-reload for a service unit
@@ -634,6 +875,11 @@ rules:
         Verify that if documentation or changelog claims the service auto-starts after install, the post-install script actually calls systemctl enable (and optionally start) for the service. If the script only reloads the daemon, update either the script or the documentation so they match.
       source: copilot:PR#235
       added: "2026-03-13"
+      paths:
+        - '**/*.md'
+        - '**/*.service'
+        - '**/*.sh'
+        - '**/*.yml'
     - id: systemd-protecthome-breaks-homedir-access
       category: security
       pattern: >-
@@ -642,6 +888,11 @@ rules:
         Verify that systemd hardening directives (ProtectHome, ProtectSystem, etc.) do not prevent the service from accessing paths it needs at runtime — especially home directories containing repos or worktrees. If hardening is desired, prefer making it configurable via a drop-in override rather than baking in restrictive defaults.
       source: copilot:PR#235
       added: "2026-03-13"
+      paths:
+        - '**/*.md'
+        - '**/*.service'
+        - '**/*.sh'
+        - '**/*.yml'
     - id: service-config-path-mismatch
       category: other
       pattern: >-
@@ -650,6 +901,11 @@ rules:
         Verify that the service ExecStart command references the configuration path established by ConfigurationDirectory (e.g. --config /etc/<name>/config.yaml) or sets WorkingDirectory appropriately, so the process actually reads config from the expected location rather than falling back to CWD or home directory defaults
       source: copilot:PR#235
       added: "2026-03-13"
+      paths:
+        - '**/*.md'
+        - '**/*.service'
+        - '**/*.sh'
+        - '**/*.yml'
     - id: bool-config-null-semantics
       category: other
       pattern: >-
@@ -658,6 +914,8 @@ rules:
         Verify that config examples and documentation accurately reflect the actual semantics of boolean fields — if true behaves the same as unset/null (e.g., feature auto-detects rather than being forced on), use null or omit the field instead of true, and update comments to describe the real behavior
       source: copilot:PR#238
       added: "2026-03-14"
+      paths:
+        - '**/*.md'
     - id: doc-config-gating-accuracy
       category: other
       pattern: >-
@@ -666,6 +924,8 @@ rules:
         Verify that docs for config-based features accurately describe any prerequisite flags (e.g. `enabled: true`) that gate whether those config values are actually read and used by the implementation
       source: copilot:PR#238
       added: "2026-03-14"
+      paths:
+        - '**/*.md'
     - id: docs-webhook-schema-distinction
       category: other
       pattern: >-
@@ -674,6 +934,8 @@ rules:
         Verify that documentation clearly distinguishes between different payload schemas sent to different webhook targets, specifying which config path or flag produces which JSON schema so integrators know exactly what to expect
       source: copilot:PR#238
       added: "2026-03-14"
+      paths:
+        - '**/*.md'
     - id: grep-pipeline-under-strict-mode
       category: error-handling
       pattern: grep piped to awk/cut/sed in a script using set -e or set -euo pipefail
@@ -681,6 +943,9 @@ rules:
         Verify that grep failures (no match or regex errors) won't cause silent script exit. Prefer a single awk with exact field matching (e.g., $2 == value) that returns zero exit status on no match, and add an explicit error message when the expected value is empty.
       source: copilot:PR#242
       added: "2026-03-14"
+      paths:
+        - '**/*.md'
+        - '**/*.sh'
     - id: doc-comment-matches-param-usage
       category: style
       pattern: Function parameter used for more purposes than its doc comment describes
@@ -688,6 +953,9 @@ rules:
         Verify that doc comments for parameters accurately reflect all their usages — if a parameter drives behavior (e.g. sets a header value) in addition to logging, the comment must say so or the parameter should be renamed to reflect its full role
       source: copilot:PR#259
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: env-override-dedup
       category: other
       pattern: >-
@@ -696,6 +964,9 @@ rules:
         Verify that before appending new env key=value pairs, any existing entries with the same key are stripped from the slice to avoid duplicate keys with undefined precedence across platforms
       source: copilot:PR#257
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tui-filter-quit-fallthrough
       category: ui
       pattern: Text input or filter field intercepts all keypresses before global key handler
@@ -703,6 +974,9 @@ rules:
         Verify that quit keys (ctrl+c, q) are explicitly handled or allowed to fall through when a filter/input component is active, so the app remains consistently quittable
       source: copilot:PR#258
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ui-hint-matches-behavior
       category: ui
       pattern: >-
@@ -711,6 +985,9 @@ rules:
         Verify that every keyboard shortcut listed in hint/help text is actually implemented for all relevant states. If a hint says 'Esc clears', ensure Esc clears the filter in all states where a filter may be active, not just when the input is focused.
       source: copilot:PR#258
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: silent-db-error-in-loop
       category: error-handling
       pattern: DB/state query errors ignored inside a loop that proceeds to mutate state
@@ -718,6 +995,9 @@ rules:
         Verify that all errors from state DB queries (e.g., GetRetry, GetWorker) inside recovery/poll loops are handled explicitly — log a warning and continue rather than silently proceeding with stale or zero-value data that could incorrectly reset beads parked for human attention
       source: copilot:PR#271
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: docstring-matches-conditional-behavior
       category: style
       pattern: >-
@@ -726,6 +1006,9 @@ rules:
         Verify that the docstring accurately describes the actual conditional behavior, not an oversimplified summary — e.g., 'skips initial run but allows on later iterations' rather than 'skips entirely'
       source: copilot:PR#274
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-control-flow-paths
       category: testing
       pattern: >-
@@ -734,6 +1017,9 @@ rules:
         Verify a focused test case exists covering the skip path: confirm the skipped stage is not invoked on iteration 1, that phase/status transitions are correct, and that downstream logic (e.g., request_changes triggering a re-run of the skipped stage) still works on subsequent iterations
       source: copilot:PR#274
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: epic-branch-resolution-before-pipeline
       category: other
       pattern: >-
@@ -742,6 +1028,9 @@ rules:
         Verify that epic branches are resolved (as done in warden_rerun/approve_as_is) before constructing pipeline.Params.BaseBranch and bead.EpicBranch, so Crucible children create PRs against the epic branch rather than the provider default base
       source: copilot:PR#274
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pipeline-ctx-from-background
       category: concurrency
       pattern: >-
@@ -750,6 +1039,9 @@ rules:
         Verify that pipeline contexts (Temper, Warden, PR creation) are derived from context.Background() with a timeout, not from a shutdown-cancellable context, so in-flight work is not interrupted mid-flight during graceful shutdown
       source: copilot:PR#274
       added: "2026-03-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: distinct-event-types-for-expected-paths
       category: error-handling
       pattern: >-
@@ -758,6 +1050,9 @@ rules:
         Verify that error/failure event types are not used for conditions that are expected or benign. Expected outcomes (like a PR already existing) should use a distinct neutral event type (e.g., EventPRAlreadyExists) rather than a failure event, to avoid misleading dashboards, history views, and monitoring.
       source: copilot:PR#283
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-creation-failure-tracking
       category: error-handling
       pattern: >-
@@ -766,6 +1061,9 @@ rules:
         Verify that PR creation and other post-pipeline failures use a distinct failure recording path rather than dispatch-failure counters, to avoid incorrectly triggering retry exhaustion or auto-close behavior for VCS/provider issues unrelated to the bead's implementation
       source: copilot:PR#283
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: preserve-error-chain-on-sentinel
       category: error-handling
       pattern: >-
@@ -774,6 +1072,9 @@ rules:
         When returning a sentinel error in a branch that also has an underlying error, verify the original error is preserved in the chain using errors.Join or fmt.Errorf with %w, so that errors.Is(err, sentinel) continues to work and the root cause (exit status, exec error type) remains diagnosable
       source: copilot:PR#283
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: error-chain-preservation-and-precise-string-matching
       category: error-handling
       pattern: >-
@@ -782,6 +1083,9 @@ rules:
         Verify that original errors are preserved in the chain using fmt.Errorf with %w or errors.Join, and that status code string matching targets the specific formatted prefix (e.g., 'status 409') rather than a bare number that could appear anywhere in the message
       source: copilot:PR#283
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: health-check-auth-verify
       category: security
       pattern: >-
@@ -790,6 +1094,9 @@ rules:
         Verify that auth checks use a subcommand or API call that confirms a valid session/token exists, not just that the binary runs. Return `warn` or `error` when authentication cannot be confirmed, to avoid false-positive `ok` status.
       source: copilot:PR#286
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-check-silent-skip
       category: error-handling
       pattern: >-
@@ -798,6 +1105,9 @@ rules:
         Verify that early-exit paths (nil config, empty collections) return at least one diagnostic result (warn or info) explaining why checks were skipped, rather than returning nothing
       source: copilot:PR#286
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: exec-command-timeout
       category: error-handling
       pattern: >-
@@ -806,6 +1116,9 @@ rules:
         Verify that all external CLI invocations use exec.CommandContext with a short timeout so that a slow or hanging subprocess cannot block the caller indefinitely; return a warning or error on timeout rather than waiting forever
       source: ['copilot:PR#286', 'copilot:PR#362']
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doctor-message-provider-consistency
       category: style
       pattern: Doctor check output messages that reference a CLI tool or provider name
@@ -813,6 +1126,9 @@ rules:
         Verify that the doctor output message consistently names the actual provider or CLI being checked (e.g., reference 'OpenAI' when checking OPENAI_API_KEY, not an unrelated CLI like 'codex CLI') so users know exactly what to fix
       source: copilot:PR#286
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: injectable-exec-runner
       category: testing
       pattern: >-
@@ -821,6 +1137,9 @@ rules:
         Verify that exec/lookpath calls are behind an injectable interface or function parameter so unit tests can mock the runner deterministically, rather than skipping when the binary is absent from the test environment
       source: copilot:PR#286
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-comment-matches-behavior
       category: testing
       pattern: >-
@@ -829,6 +1148,9 @@ rules:
         Verify that test comments accurately describe what the code actually does — e.g., if the comment says 'skip if set' but the code forcibly clears the value with t.Setenv, update the comment to say 'force env var to be unset'. Also verify that test case comments accurately describe the actual expected values and behavior being asserted — misleading comments cause confusion about intended semantics.
       source: ['copilot:PR#286', 'copilot:PR#338', 'copilot:PR#638']
       added: "2026-03-16"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: deduplicate-error-chain-sentinel-rules
       category: other
       pattern: >-
@@ -837,6 +1159,8 @@ rules:
         Verify the new rule does not duplicate or significantly overlap an existing rule. If the scope overlaps, consolidate by broadening the existing rule or clearly differentiating the two. If the intent is only to update attribution (e.g., source PR), update the existing entry instead of adding a duplicate.
       source: ['copilot:PR#285', 'copilot:PR#322', 'copilot:PR#324', 'copilot:PR#326', 'copilot:PR#328', 'copilot:PR#329', 'copilot:PR#331', 'copilot:PR#332', 'copilot:PR#334', 'copilot:PR#337', 'copilot:PR#340', 'copilot:PR#344', 'copilot:PR#345']
       added: "2026-03-16"
+      paths:
+        - '**/*.yaml'
     - id: windows-exe-rename-lock
       category: error-handling
       pattern: >-
@@ -845,6 +1169,9 @@ rules:
         Verify that the code handles the Windows file-lock on a running .exe (e.g., by spawning a helper process to perform the swap after the parent exits). Also verify that the target/backup path is checked for existence before renaming, to avoid failure from a previous incomplete update.
       source: copilot:PR#293
       added: "2026-03-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: goroutine-outlives-process
       category: concurrency
       pattern: Goroutine spawned in a CLI command that exits shortly after
@@ -852,6 +1179,9 @@ rules:
         Verify that goroutines launched near program exit will actually complete before the process terminates. If the main function or command handler returns without waiting, the goroutine is silently killed. Prefer a synchronous call with a short timeout, a detached subprocess, or an explicit sync point (e.g. WaitGroup) before exit.
       source: copilot:PR#293
       added: "2026-03-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: octal-literal-style
       category: style
       pattern: >-
@@ -860,6 +1190,9 @@ rules:
         Verify all file permission literals use the 0o prefix (e.g. 0o755, 0o644) rather than the legacy bare-0 prefix, consistent with repo convention
       source: copilot:PR#293
       added: "2026-03-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: http-status-before-body-parse
       category: error-handling
       pattern: HTTP response body is read or parsed without first checking resp.StatusCode
@@ -867,6 +1200,9 @@ rules:
         Verify that every HTTP response checks the status code before reading/parsing the body. Non-2xx responses (404, 403, rate-limit HTML) must be detected early and returned as clear errors including the HTTP status, rather than falling through to confusing parse failures.
       source: copilot:PR#293
       added: "2026-03-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: wait-for-process-exit
       category: concurrency
       pattern: >-
@@ -875,6 +1211,9 @@ rules:
         Verify that code waiting for a process to stop uses an active polling loop (e.g., checking IsRunning() with backoff and timeout) rather than a fixed sleep, to avoid races where the process hasn't fully released resources
       source: copilot:PR#293
       added: "2026-03-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-duplicate-logging-in-helpers-and-callers
       category: style
       pattern: >-
@@ -883,6 +1222,9 @@ rules:
         When a helper returns a boolean decision, ensure only one site logs the outcome. Prefer returning (bool, reason) from the helper and letting the caller log once with full context (e.g., workerID), rather than having both the helper and caller emit overlapping log lines.
       source: copilot:PR#296
       added: "2026-03-19"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sanitize-llm-output-in-prompts
       category: security
       pattern: >-
@@ -891,6 +1233,9 @@ rules:
         Verify that any untrusted or LLM-originated text embedded into prompts is wrapped in fenced blocks (e.g., XML-style tags) with an explicit instruction to treat it as data only, and that prompt-breaking characters (e.g., triple backticks) are escaped or stripped before interpolation
       source: copilot:PR#306
       added: "2026-03-19"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-review-loop-behavior
       category: testing
       pattern: >-
@@ -899,6 +1244,9 @@ rules:
         Verify that new or modified Warden re-review behavior is covered by a unit test: assert that across multiple iterations the correct prior feedback string is passed (non-empty when focused re-review is active, empty when full re-review is enabled)
       source: copilot:PR#306
       added: "2026-03-19"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sanitized-id-consistent-use
       category: security
       pattern: >-
@@ -907,6 +1255,9 @@ rules:
         When untrusted input is sanitized into a safe variable, verify that ALL subsequent references use the sanitized version consistently — no code path should fall back to the raw value, particularly in fmt.Sprintf, template execution, or prompt construction
       source: copilot:PR#306
       added: "2026-03-19"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-new-config-keys
       category: other
       pattern: Adding new fields to AnvilConfig or top-level config structs
@@ -914,6 +1265,9 @@ rules:
         Verify that any new configuration keys are documented in docs/configuration.md with their type, default value, and description — not just referenced in design plans or code comments
       source: copilot:PR#316
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: yaml-field-alignment
       category: testing
       pattern: Test fixtures or YAML test data that define struct fields
@@ -921,6 +1275,9 @@ rules:
         Verify that field names in test YAML/JSON fixtures exactly match the struct tags in the corresponding Go type definitions, since YAML/JSON unmarshalling silently ignores unknown fields
       source: copilot:PR#316
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-flag-set-error-handling
       category: testing
       pattern: Calling cmd.Flags().Set(...) in tests without checking the returned error
@@ -928,6 +1285,9 @@ rules:
         Verify that the error returned by Flags().Set() is asserted (e.g., require.NoError) and that t.Cleanup is used to reset the flag value, preventing masked failures and leaked state across tests sharing global command instances
       source: copilot:PR#316
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cobra-silence-expected-errors
       category: error-handling
       pattern: >-
@@ -936,6 +1296,9 @@ rules:
         When a Cobra command prints its own failure summary before returning an error, set SilenceUsage: true on the command and either return a descriptive error (including relevant context like IDs or names) or use SilenceErrors to avoid Cobra double-printing a less-helpful generic message
       source: copilot:PR#316
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: unused-declarations
       category: style
       pattern: >-
@@ -944,6 +1307,9 @@ rules:
         Verify that all imports and local variables in Go files are actually used — Go treats unused imports and unused local variables as compilation errors, but package-level declarations and types may be intentionally unused and should not be auto-flagged by this rule
       source: copilot:PR#320
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-list-missing-limit
       category: other
       pattern: Calls to `bd list` or `bdExec` with `list` subcommand
@@ -951,6 +1317,9 @@ rules:
         Verify that `--limit 0` is passed to all `bd list` invocations that need the complete set of results, otherwise the default limit may silently truncate the list
       source: copilot:PR#320
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: capture-non-critical-errors
       category: error-handling
       pattern: >-
@@ -959,6 +1328,9 @@ rules:
         Verify that errors from supplementary/non-critical operations are captured (e.g., stored in a shared firstErr variable or accumulated as warnings) so the caller or UI can surface them, rather than being silently swallowed
       source: copilot:PR#320
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: propagate-enrichment-errors
       category: error-handling
       pattern: >-
@@ -967,6 +1339,9 @@ rules:
         Verify that errors from enrichment/decoration calls are either propagated to the caller or surfaced to the user so they know the result is incomplete
       source: copilot:PR#320
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: guard-periodic-fetch-overlap
       category: concurrency
       pattern: >-
@@ -975,6 +1350,9 @@ rules:
         Verify that periodic/timer-triggered async operations (e.g., polling external commands, fetching data) have an in-flight guard or cancellation mechanism to prevent overlapping executions from piling up goroutines or processes when the operation is slower than the tick interval
       source: copilot:PR#320
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-description-matches-contents
       category: other
       pattern: >-
@@ -983,6 +1361,10 @@ rules:
         Verify that every file, component, or artifact mentioned in the PR description is actually included in the changeset. If something listed is not shipped, either add it or update the description to match what is actually being delivered. In particular, if only a changelog fragment is present without the actual implementation, either add the missing code or update the PR description to reflect what is actually being shipped.
       source: ['copilot:PR#320', 'copilot:PR#383', 'copilot:PR#637', 'copilot:PR#648']
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.sh'
     - id: abort-path-cleanup
       category: ui
       pattern: Handling abort/cancel in Bubble Tea form or prompt updates
@@ -990,6 +1372,9 @@ rules:
         When a form or prompt is aborted, verify that: (1) the cmd returned from the sub-model's Update is propagated (not replaced with nil), and (2) any related selection state is cleared to avoid stale values on the next interaction
       source: copilot:PR#323
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: global-quit-key-overlay
       category: ui
       pattern: >-
@@ -998,6 +1383,9 @@ rules:
         Verify that ctrl+c is handled as a global quit key BEFORE any overlay/form-specific key handling, so users always have an escape hatch even when modals, sort selectors, or other overlays are active
       source: copilot:PR#323
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tui-row-height-calc
       category: ui
       pattern: >-
@@ -1006,6 +1394,9 @@ rules:
         Verify the subtracted constant matches the actual number of fixed-height elements (headers, footers, status bars, padding). Count each rendered line outside the dynamic content area and confirm the arithmetic leaves no unaccounted blank space or clipped rows. Prefer computing from actual rendered heights (e.g., lipgloss.Height) over magic numbers.
       source: copilot:PR#323
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: deterministic-sort-tiebreakers
       category: ui
       pattern: >-
@@ -1014,6 +1405,9 @@ rules:
         Verify that sort comparators include deterministic tie-breaker fields (e.g., secondary sort by timestamp, then by unique ID) so that equal-key items render in a stable, predictable order across refreshes
       source: copilot:PR#323
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: visual-width-not-rune-count
       category: ui
       pattern: >-
@@ -1022,6 +1416,9 @@ rules:
         Verify that terminal column width is calculated using visual-width-aware helpers (e.g. lipgloss.Width or runewidth) rather than rune count, since CJK characters and emoji occupy 2 columns and combining marks occupy 0
       source: copilot:PR#323
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: filtered-zero-results-messaging
       category: ui
       pattern: >-
@@ -1030,6 +1427,9 @@ rules:
         When displaying a zero-results message, verify whether active filters could be hiding results. If filters are enabled, the message must indicate that no results matched the current filters (e.g., by reporting excluded counts or naming the active filter) rather than implying none exist at all. This covers both 'no results found' and 'all up to date' phrasing.
       source: copilot:PR#327
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: filter-excludes-all-updates-test
       category: testing
       pattern: >-
@@ -1038,6 +1438,9 @@ rules:
         When filter options (e.g., NoMajor, NoMinor) can exclude all available updates, verify tests cover the edge case where every update is filtered out — ensuring summary output distinguishes between 'genuinely up to date' and 'updates exist but were excluded by filters'
       source: copilot:PR#327
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-time-constants
       category: style
       pattern: >-
@@ -1046,6 +1449,9 @@ rules:
         Verify that all time duration values use Go's time package constants (time.Second, time.Minute, time.Hour) instead of raw nanosecond literals or magic numbers, ensuring the intent is immediately clear to readers
       source: copilot:PR#327
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: distinguish-empty-from-error
       category: error-handling
       pattern: >-
@@ -1054,6 +1460,9 @@ rules:
         When evolving an existing API to expose three distinct outcomes ('no results found', 'not applicable/unsupported', and 'error occurred'), verify that the new tri-state contract is clearly documented, all direct and indirect callers are updated to handle each state explicitly, and tests cover the migration semantics (including backward-compatibility where required).
       source: copilot:PR#327,PR#329
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: silent-error-discard
       category: error-handling
       pattern: >-
@@ -1062,6 +1471,9 @@ rules:
         For top-level scan/check pipelines (CLI commands, orchestrators, or summary builders), verify that downstream errors are not only logged but also surfaced to callers (e.g., included in aggregated error collections or used to mark the command as failed). This rule is distinct from capture-non-critical-errors and propagate-enrichment-errors, which cover background/enrichment flows; use this rule only when logged errors would otherwise cause a high-level operation to appear fully successful.
       source: copilot:PR#327,PR#329
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: severity-sort-order-consistency
       category: style
       pattern: >-
@@ -1070,6 +1482,9 @@ rules:
         Verify that severity ordering is consistent with established conventions elsewhere in the codebase — if existing code sorts by highest severity first (major→minor→patch), new code handling the same data should preserve that order rather than reversing it
       source: copilot:PR#327
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-dead-struct-fields
       category: style
       pattern: >-
@@ -1078,6 +1493,9 @@ rules:
         Verify that every struct field is actually used. If a field duplicates a method parameter, either wire the field through (use it in methods instead of passing the param) or remove the field to avoid dead state.
       source: copilot:PR#327
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: kanban-card-height-consistency
       category: ui
       pattern: >-
@@ -1086,6 +1504,9 @@ rules:
         Verify that any constant used for item height in layout math (padding, scrolling, column alignment) matches the actual rendered height. Either enforce a fixed height in the render function (pad/truncate + explicit separator) or compute height dynamically from the rendered output (e.g., lipgloss.Height). Mixing a constant assumption with variable-height rendering causes misaligned columns and broken scrolling.
       source: copilot:PR#330
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-mutate-derived-fields
       category: ui
       pattern: >-
@@ -1094,6 +1515,9 @@ rules:
         Verify that derived/enriched fields (populated by background refresh or DB queries) are not manually overwritten in UI action handlers, as this causes temporary inconsistency until the next refresh cycle
       source: copilot:PR#330
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: state-sync-after-mutation
       category: ui
       pattern: >-
@@ -1102,6 +1526,9 @@ rules:
         After a successful mutation (move, update, delete), verify that the local view state (e.g. in-memory lists, cached entries, UI lanes) is updated or a refresh is triggered so all views reflect the change immediately, rather than waiting for the next periodic tick
       source: copilot:PR#330
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tri-state-return-distinction
       category: error-handling
       pattern: >-
@@ -1110,6 +1537,8 @@ rules:
         When designing or reviewing scan/search/collection API signatures, ensure the return type can explicitly represent all three outcomes — 'no results found', 'not applicable/unsupported', and 'an error occurred' — for example via a dedicated status enum, sentinel values, or clearly documented nil/empty/error semantics. Callers must be able to report accurate status rather than collapsing different empty/failure states into a single generic result. This rule addresses API design and return-type representation; see distinguish-empty-from-error for the related concern of migrating an existing API to a tri-state contract.
       source: copilot:PR#329
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: form-overlay-msg-routing
       category: ui
       pattern: >-
@@ -1118,6 +1547,9 @@ rules:
         Verify that when a form overlay is active, only key/mouse messages are routed to the form handler. Non-key messages (data updates, ticks, window resize) must still be handled by the main Update switch to prevent dropped messages, stuck loading states, or broken periodic loops.
       source: copilot:PR#335
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: silent-nil-on-unresolved-state
       category: error-handling
       pattern: >-
@@ -1126,6 +1558,9 @@ rules:
         Verify that every early-return path in action/command handlers propagates a meaningful error (e.g. ActionErrorMsg, error return) rather than silently returning nil, so failures are visible and diagnosable
       source: copilot:PR#335
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sort-map-keys-for-stable-ui
       category: ui
       pattern: >-
@@ -1134,6 +1569,9 @@ rules:
         Verify that slices derived from map iteration are sorted before use in UI elements, option lists, default selections, CLI output, or test assertions — Go map iteration order is randomized and produces nondeterministic ordering that causes unstable output and flaky tests.
       source: ['copilot:PR#335', 'copilot:PR#338']
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ansi-safe-toast-overlay
       category: ui
       pattern: >-
@@ -1142,6 +1580,9 @@ rules:
         Verify that overlay compositing is ANSI-aware and preserves underlying content/styling beyond the overlay bounds. Naive space-padding destroys lipgloss escape sequences and causes misalignment. Use an ANSI-aware overlay compositor (like placeOverlayAt) that splices the overlay into the background line while keeping surrounding styled content intact.
       source: copilot:PR#335
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-id-toast-feedback
       category: ui
       pattern: >-
@@ -1150,6 +1591,9 @@ rules:
         Verify that user-facing messages degrade gracefully when a dynamic value (e.g., ID, name) is empty — provide a meaningful fallback string instead of rendering blank text
       source: copilot:PR#335
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-visual-width-assertion
       category: testing
       pattern: >-
@@ -1158,6 +1602,9 @@ rules:
         When testing visual-width truncation, use the same width-measurement function the implementation uses (e.g. lipgloss.Width()) rather than byte length (len()). Byte length can differ from visual width for multi-byte characters, ANSI sequences, and wide glyphs, making the assertion too loose or incorrect.
       source: copilot:PR#335
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-backward-compat-unmarshalling
       category: testing
       pattern: >-
@@ -1166,6 +1613,9 @@ rules:
         Verify that unit tests exist covering the legacy/alternative input format, asserting that the parser correctly handles the old shape and produces the expected default values for any missing fields
       source: copilot:PR#336
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-description-matches-actual-changes
       category: other
       pattern: >-
@@ -1174,6 +1624,9 @@ rules:
         Verify that the count or list stated in the PR description or title matches the actual changes in the diff — e.g., if the PR says 'learned 4 rules' confirm exactly 4 new rules appear, or if it lists specific items confirm each is present; if they diverge, update the description or add the missing changes
       source: ['copilot:PR#332', 'copilot:PR#337', 'copilot:PR#557']
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.yaml'
     - id: preserve-rule-attribution-sources
       category: other
       pattern: >-
@@ -1182,6 +1635,8 @@ rules:
         When updating a rule's source field (a comma-separated list of PR attributions), verify that existing PR attributions are preserved and new PRs are appended rather than replacing prior entries
       source: copilot:PR#332
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: peer-dep-ecosystem-scope
       category: other
       pattern: >-
@@ -1190,6 +1645,9 @@ rules:
         Verify that peer-dependency or cross-package relationship lookups are scoped to the correct ecosystem. A shared set containing packages from all ecosystems can incorrectly union unrelated packages that happen to share a name across ecosystems (e.g., an npm peer-dep name matching a Go module). Use ecosystem-specific sets for adjacency and dependency accounting.
       source: copilot:PR#338
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: keybinding-scope-conflict
       category: ui
       pattern: >-
@@ -1198,6 +1656,9 @@ rules:
         Verify that new keybindings do not conflict with existing navigation in other views. Scope view-specific shortcuts behind a view-type check (e.g. only bind in list view, not kanban) so that standard navigation (vim-style hjkl, arrow keys) remains functional in all modes.
       source: copilot:PR#342
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-form-overwrites-existing-data
       category: ui
       pattern: >-
@@ -1206,6 +1667,9 @@ rules:
         Verify that submitting an empty, blank, or unchanged form field does not silently overwrite existing data — either treat empty/blank input as a no-op, validate and block submission, or prefill the form with the current value so the user edits rather than replaces blindly. Form action handlers should guard against empty/blank input before issuing update commands to prevent unintentional clearing of existing values.
       source: copilot:PR#342
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: dedup-priority-mapping
       category: style
       pattern: >-
@@ -1214,6 +1678,9 @@ rules:
         Verify that priority string-to-int conversion is not duplicated across code paths. It should be factored into a shared helper function (or use strconv.Atoi with bounds checking) so all callers stay consistent.
       source: copilot:PR#342
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: deduplicate-warden-rules
       category: other
       pattern: >-
@@ -1222,6 +1689,8 @@ rules:
         Before inserting a new rule or checklist entry, scan existing rules for semantic overlap. If a match exists, consolidate by appending the new source (e.g. PR number) to the existing rule's source list and merging any unique wording into the existing rule's pattern/check instead of creating a separate entry.
       source: ['copilot:PR#349', 'copilot:PR#359', 'copilot:PR#360', 'copilot:PR#361', 'copilot:PR#364', 'copilot:PR#365', 'copilot:PR#348', 'copilot:PR#353', 'copilot:PR#424', 'copilot:PR#425', 'copilot:PR#430', 'copilot:PR#493', 'copilot:PR#518', 'copilot:PR#529']
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: sourcelist-yaml-flow-sequence
       category: style
       pattern: >-
@@ -1230,6 +1699,8 @@ rules:
         Verify that multi-value source fields remain as YAML flow sequences (e.g. `source: [copilot:PR#285, copilot:PR#322]`) rather than being collapsed into a single scalar string. The SourceList type treats scalar values as a single-element list, which breaks structured multi-source attribution.
       source: ['copilot:PR#349', 'copilot:PR#359']
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: pr-metadata-matches-diff
       category: other
       pattern: >-
@@ -1238,6 +1709,8 @@ rules:
         Verify that the stated count in PR metadata (title, description, commit message) actually matches the diff — e.g. if it says 'learn 1 new rule' confirm exactly 1 new rule entry was added, not just an edit to an existing one
       source: ['copilot:PR#349', 'copilot:PR#353']
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: new-crud-needs-tests
       category: testing
       pattern: >-
@@ -1246,6 +1719,9 @@ rules:
         Verify that new DB CRUD functions have focused tests in the matching _test.go file covering insert, query (grouping, ordering, date parsing), and delete (ensuring only targeted rows are removed)
       source: copilot:PR#354
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: zero-value-yaml-marshal
       category: other
       pattern: >-
@@ -1254,6 +1730,9 @@ rules:
         Verify that intentional zero values (e.g., 0 duration to disable a feature) are still serialized correctly. If a zero value has semantic meaning (like disabling a scheduled task), the marshal method must emit it rather than omitting it, otherwise round-tripping through save/load will silently replace it with the default. This applies equally to omitempty struct tags — if a zero value is semantically significant, either remove the omitempty tag or use a custom marshal method that always emits the field.
       source: copilot:PR#356, copilot:PR#413
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-invalid-duration-parsing
       category: testing
       pattern: Adding a new duration config field with error handling for invalid values
@@ -1261,6 +1740,9 @@ rules:
         Verify that a unit test exists covering the invalid duration parsing failure mode, consistent with existing invalid duration tests (e.g., invalid poll_interval, bellows_interval). The test should write a config with an invalid duration string and assert the returned error mentions the specific field name.
       source: copilot:PR#356
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nil-func-param-validation
       category: error-handling
       pattern: >-
@@ -1269,6 +1751,9 @@ rules:
         Verify that function parameters are checked for nil before invocation, returning a clear error instead of allowing a nil-dereference panic
       source: copilot:PR#358
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: wire-config-to-all-callers
       category: other
       pattern: >-
@@ -1277,6 +1762,9 @@ rules:
         When adding an optional config parameter to a function, verify that ALL call sites are updated to pass the config where the new behavior should apply — otherwise the new code path is dead code that contradicts the stated intent
       source: copilot:PR#358
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-branches
       category: testing
       pattern: >-
@@ -1285,6 +1773,9 @@ rules:
         When a function gains a new code path (e.g., a feature-flag branch or mode switch), verify that unit tests cover the new branch — assert the expected side-effects occur and the old path's side-effects do not
       source: copilot:PR#358
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: log-event-missing-bead-id
       category: error-handling
       pattern: LogEvent calls in error paths where a bead ID variable is in scope
@@ -1292,6 +1783,9 @@ rules:
         Verify that LogEvent calls pass the available bead ID rather than an empty string, so failures can be correlated back to the originating bead in state.db
       source: copilot:PR#358
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: zero-interval-ticker-panic
       category: error-handling
       pattern: >-
@@ -1300,6 +1794,9 @@ rules:
         Verify that time.NewTicker is never called with a zero or negative duration. If an interval of 0 means 'disabled', add a guard before ticker creation to skip scheduling (e.g. block on ctx.Done() or return early) instead of panicking at runtime.
       source: copilot:PR#362
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: emit-event-on-empty-flush
       category: error-handling
       pattern: >-
@@ -1308,6 +1805,9 @@ rules:
         Verify that completion or summary events are emitted even when the effective result count is zero (e.g., all duplicates, all filtered). Silent early returns on zero-result paths make successful queue draining invisible in the event log and break observability contracts.
       source: copilot:PR#362
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-sleep-in-tests
       category: testing
       pattern: time.Sleep used in tests to wait for goroutine or background loop side effects
@@ -1315,6 +1815,9 @@ rules:
         Tests must not use fixed time.Sleep delays for synchronization with background goroutines. Use deterministic synchronization instead: require.Eventually polling, test-only hooks, or channels to signal that the expected state change was processed.
       source: copilot:PR#366
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: disable-background-worker-fully
       category: concurrency
       pattern: >-
@@ -1323,6 +1826,9 @@ rules:
         When a feature-flag or config toggle disables a background worker, verify that the ticker/loop is also paused or stopped — not just the worker's data cleared. Otherwise the goroutine continues waking up on its schedule, performing no-op work, and potentially logging spurious errors for stale state.
       source: copilot:PR#366
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hot-reload-change-detection-gate
       category: other
       pattern: >-
@@ -1331,6 +1837,9 @@ rules:
         Verify that settings updates requiring hot-reload are not placed inside functions that short-circuit when an unrelated subset of config is unchanged. Each independently-configurable feature should either have its own change-detection gate or be placed on a reload path that always executes.
       source: copilot:PR#366
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hot-reload-aware-worker-init
       category: concurrency
       pattern: >-
@@ -1339,6 +1848,9 @@ rules:
         Verify that conditionally-started workers are created when enabled regardless of scheduling parameters, so hot-reload can later start/stop them when config values change at runtime
       source: copilot:PR#366
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hot-reload-ticker-zero-interval
       category: concurrency
       pattern: >-
@@ -1347,6 +1859,9 @@ rules:
         Verify that setting the interval to zero or a negative value actually pauses/stops the ticker rather than being silently ignored, and that the ticker can be re-enabled when a positive value is later provided
       source: copilot:PR#366
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: non-blocking-channel-send
       category: concurrency
       pattern: >-
@@ -1355,6 +1870,9 @@ rules:
         Verify that channel send operations cannot block under concurrent callers. If a function is intended to be non-blocking and called from multiple goroutines, ensure all channel sends use non-blocking select patterns or are serialized with a mutex to prevent goroutine blocking when the channel buffer is full.
       source: copilot:PR#366
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-generic-rule-category
       category: style
       pattern: Warden rule definitions in warden-rules.yaml
@@ -1362,6 +1880,8 @@ rules:
         Verify that a specific, descriptive category is assigned when an appropriate one exists (for example, `style`, `testing`, or `concurrency`). The generic `category: other` should only be used when no more precise category applies, to keep triage, search, and reporting meaningful.
       source: ['copilot:PR#348', 'copilot:PR#353', 'copilot:PR#424', 'copilot:PR#529']
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: warden-source-field-wording
       category: style
       pattern: >-
@@ -1370,6 +1890,8 @@ rules:
         Verify that warden rule text refers to the 'source field' or to PR attributions in the source field, rather than calling it a 'source list' or implying list semantics. The source field is modeled as a SourceList and may appear as either a single YAML scalar or a YAML sequence; commas in scalar values are just part of the string and are not treated as separators.
       source: ['copilot:PR#337', 'copilot:PR#353']
       added: "2026-03-20"
+      paths:
+        - '**/*.yaml'
     - id: unreachable-early-return
       category: other
       pattern: >-
@@ -1378,6 +1900,9 @@ rules:
         Verify that early-return guards on function results are actually reachable — if the called function guarantees a non-empty result (e.g., by adding a fallback/default entry), the guard is dead code. Either remove it or adjust it to detect the fallback value if a true 'no-op' mode is intended.
       source: copilot:PR#346
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: resolve-go-race-detection-config
       category: testing
       pattern: >-
@@ -1386,6 +1911,9 @@ rules:
         Verify that GoRaceDetection is resolved using the full precedence chain (.forge/temper.yaml > per-anvil config > global config) rather than reading from a single config level. Use the shared resolution helper (e.g., config.ResolveGoRaceDetection or Daemon.resolveGoRaceDetection) to ensure consistent behavior with the main Temper pipeline.
       source: copilot:PR#346
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: git-checkout-vs-reset-hard
       category: error-handling
       pattern: Code using `git checkout -- .` to discard uncommitted changes
@@ -1393,6 +1921,9 @@ rules:
         Verify that rollback/discard operations reset both the index and working tree. `git checkout -- .` only restores from the index and leaves staged changes intact. Prefer `git reset --hard` (or `git reset --hard` followed by `git clean -fd` if untracked files matter) to ensure the repo is fully clean.
       source: copilot:PR#346
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: git-clean-ignored-artifacts
       category: other
       pattern: git clean commands used to undo install or build side-effects
@@ -1400,6 +1931,9 @@ rules:
         Verify git clean uses -fdx or -fdX to also remove ignored files/directories (e.g., node_modules/, bin/, obj/) when the intent is to fully undo install side-effects. Plain -fd leaves ignored artifacts behind.
       source: copilot:PR#346
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-matches-implementation
       category: style
       pattern: >-
@@ -1408,6 +1942,9 @@ rules:
         Verify that doc comments accurately describe the actual implementation behavior — especially around error returns, fallback paths, edge cases, and reuse/lookup semantics. If the code silently falls back instead of returning an error, the comment must not claim an error is returned, and vice versa. After changing function semantics, update the doc comment to reflect the new behavior.
       source: ['copilot:PR#346', 'copilot:PR#490', 'copilot:PR#647']
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-helper-filesystem-errors
       category: testing
       pattern: >-
@@ -1416,6 +1953,9 @@ rules:
         Verify that all filesystem operations in test helpers (os.WriteFile, os.MkdirAll, os.Create, etc.) have their errors checked, typically with require.NoError(t, err), so that fixture setup failures are caught immediately rather than causing misleading test failures downstream
       source: copilot:PR#346
       added: "2026-03-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: yaml-sequence-not-scalar
       category: style
       pattern: YAML field that holds multiple values written as a comma-separated scalar string
@@ -1423,6 +1963,8 @@ rules:
         Verify that multi-value YAML fields use a proper sequence (list entries with -) rather than a comma-separated scalar, which will be treated as a single string and not split automatically
       source: copilot:PR#353
       added: "2026-03-21"
+      paths:
+        - '**/*.yaml'
     - id: rule-category-self-consistency
       category: style
       pattern: A rule or guideline that itself violates the convention it enforces
@@ -1430,6 +1972,8 @@ rules:
         Verify that the rule's own metadata (e.g., category, naming, format) follows the same conventions the rule prescribes — for example, a rule that prohibits the generic `category: other` should not itself use that category; use the most specific applicable category instead.
       source: copilot:PR#353
       added: "2026-03-21"
+      paths:
+        - '**/*.yaml'
     - id: test-name-matches-assertion
       category: testing
       pattern: Test function or description string that references UI state/view names
@@ -1437,6 +1981,9 @@ rules:
         Verify test names and description strings accurately reflect the current behavior being asserted — if a tab or navigation action now leads to a different view, rename the test to match the new destination so failures remain self-explanatory
       source: copilot:PR#369
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: expandable-state-sync
       category: ui
       pattern: >-
@@ -1445,6 +1992,9 @@ rules:
         Verify that expandable/collapsible state is derived from the same criteria used when rendering children, not from raw source data that may include unresolved or filtered-out entries
       source: copilot:PR#369
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: dynamic-terminal-width-truncation
       category: ui
       pattern: >-
@@ -1453,6 +2003,9 @@ rules:
         Verify that all text truncation and padding in TUI components uses the dynamic viewport width (e.g., `m.width`) rather than hardcoded constants, so content stays within the terminal bounds at any window size
       source: copilot:PR#369
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-fragment-collision-safe
       category: error-handling
       pattern: Changelog fragment filenames keyed only by date (e.g., deps-batch-YYYY-MM-DD)
@@ -1460,6 +2013,9 @@ rules:
         Verify fragment filenames are collision-safe when the function may run multiple times per day on the same branch — include a time component, nonce, or increment a suffix when the target file already exists. Also ensure 'nothing to commit' from git is treated as a no-op rather than an error.
       source: copilot:PR#370
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: git-pathspec-relative-paths
       category: other
       pattern: >-
@@ -1468,6 +2024,9 @@ rules:
         Verify that paths passed to `git add` are repo-relative (e.g. `changelog.d/<file>`) rather than absolute filesystem paths; absolute paths with drive letters or backslashes are brittle as git pathspecs, especially on Windows
       source: copilot:PR#370
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: consistent-test-assertions
       category: testing
       pattern: Test files using raw t.Errorf/t.Fatal/t.Error instead of testify assert/require
@@ -1475,6 +2034,9 @@ rules:
         Verify test assertions use testify/assert and testify/require consistently with the rest of the package tests, rather than raw t.Errorf or t.Fatal calls
       source: copilot:PR#370
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: non-bead-pr-removal-determinism
       category: other
       pattern: >-
@@ -1483,6 +2045,9 @@ rules:
         When beadID is empty and multiple items can share the same empty value, verify that removal uses a more specific identifier (e.g., PRID) to ensure deterministic removal rather than matching the first item with the empty ID
       source: copilot:PR#371
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sanitize-before-tui-render
       category: security
       pattern: >-
@@ -1491,6 +2056,9 @@ rules:
         Verify that sanitizeTitle (or equivalent ANSI/control-character stripping) is applied to all raw strings before they are rendered into TUI components, including fallback/default label paths — not just the primary rendering path
       source: copilot:PR#371
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tui-title-sanitization
       category: ui
       pattern: >-
@@ -1499,6 +2067,9 @@ rules:
         Verify that all bead titles rendered into TUI strings (labels, status messages, etc.) pass through sanitizeTitle() (and truncation if needed) to prevent ANSI escape codes, control characters, or newlines from corrupting the terminal UI
       source: copilot:PR#371
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-key-binding-accuracy
       category: style
       pattern: Code comments describing keyboard shortcuts or key bindings in UI/TUI code
@@ -1506,6 +2077,9 @@ rules:
         Verify that comments describing key bindings match the actual key bindings used in the code and UI footers (e.g., comment says 'D key' but binding uses lowercase 'd')
       source: copilot:PR#372
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: form-helper-test-coverage
       category: testing
       pattern: >-
@@ -1514,6 +2088,9 @@ rules:
         Verify that new candidate filtering, exclusion logic, and option construction in form helpers are covered by unit tests (e.g., excludes self/existing items, includes all expected options, validates default selections)
       source: copilot:PR#372
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: dep-candidates-filter-by-anvil
       category: other
       pattern: >-
@@ -1522,6 +2099,9 @@ rules:
         Verify that dependency candidate lists are filtered to the same anvil as the target bead, preventing invalid cross-anvil selections when the underlying command runs in a specific anvil's working directory
       source: copilot:PR#372
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cross-anvil-dep-scope
       category: other
       pattern: >-
@@ -1530,6 +2110,9 @@ rules:
         Verify that dependency removal operations resolve the correct anvil for each bead involved — especially when removing bidirectional relationships (e.g., blocks/blocked-by), ensure the operation executes in the anvil that owns each respective bead, not always the current anvil.
       source: copilot:PR#372
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: gh-cli-output-parsing
       category: other
       pattern: Parsing stdout of `gh pr create` with string trimming to extract the PR URL
@@ -1537,6 +2120,9 @@ rules:
         Verify that `gh pr create` output is parsed robustly — either use `--json url -q .url` for stable machine-readable output, or extract the URL with a regex/helper rather than assuming the entire stdout is the URL, since `gh` may emit warnings or other text alongside it.
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: deterministic-test-helpers
       category: testing
       pattern: >-
@@ -1545,6 +2131,9 @@ rules:
         Verify that time-dependent or non-deterministic values in tests are injected via a helper (e.g., branchName(date time.Time)) so tests exercise actual production logic deterministically rather than validating locally-constructed strings
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: filter-options-consistent-application
       category: other
       pattern: >-
@@ -1553,6 +2142,9 @@ rules:
         Verify that filter options (e.g. --patch-only, --no-major) are applied consistently across ALL code paths that consume the filtered data, including PR body generation, changelog fragments, and grouping functions — not just the display/summary path
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-creation-requires-actual-changes
       category: other
       pattern: Code that creates a PR or changelog fragment after a scan/update command
@@ -1560,6 +2152,9 @@ rules:
         Verify that the PR being created contains the actual changes the command is supposed to make (e.g., updated manifests, lockfiles, applied patches), not just a changelog fragment. PR creation should be gated behind confirmation that the substantive changes have been committed.
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: fallback-error-masking
       category: error-handling
       pattern: >-
@@ -1568,6 +2163,9 @@ rules:
         Verify that fallback paths only trigger on the specific expected error condition (e.g., 'already exists'), not on any error. Use a pre-check (e.g., rev-parse --verify) or inspect the error message/exit code to distinguish expected vs unexpected failures, and return the original error for unexpected cases to avoid masking real failures.
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: git-checkout-remote-fallback
       category: error-handling
       pattern: git checkout <branch> used as fallback when branch creation fails
@@ -1575,6 +2173,9 @@ rules:
         When falling back to checkout an existing branch, verify that the code handles the case where the branch exists only on the remote by fetching origin/<branch> first and using 'git checkout -B <branch> origin/<branch>' to track it, rather than assuming the branch exists locally
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: gh-pr-already-exists-url-extraction
       category: error-handling
       pattern: >-
@@ -1583,6 +2184,9 @@ rules:
         Verify that the existing PR URL is extracted from both stdout and stderr, and that if no URL is found, the code returns an error or falls back to a follow-up command (e.g., `gh pr view --json url`) rather than silently returning an empty string as success
       source: copilot:PR#373
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: capture-stderr-external-commands
       category: error-handling
       pattern: >-
@@ -1591,6 +2195,14 @@ rules:
         Verify that cmd.Stderr is buffered (via cmd.CombinedOutput() or by explicitly setting cmd.Stderr to a buffer) and its contents are included in the returned error message and any audit logs along with relevant context (e.g., path, arguments) to make failures diagnosable, instead of surfacing only `exit status N` from *exec.ExitError
       source: copilot:PR#375, copilot:PR#615
       added: "2026-03-21"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: american-english-spelling
       category: style
       pattern: >-
@@ -1599,6 +2211,9 @@ rules:
         Verify all comments and user-facing strings use American English spelling for consistency with the rest of the codebase
       source: copilot:PR#375
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: select-all-respects-view-visibility
       category: ui
       pattern: Functions that select or operate on 'all visible' items in a multi-view UI
@@ -1606,6 +2221,9 @@ rules:
         Verify that 'select all visible' operations use the currently rendered dataset for the active view (e.g., flat hierarchy list, filtered results) rather than the full backing collection, so hidden or collapsed items are not included.
       source: copilot:PR#374
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bulk-mode-header-alignment
       category: ui
       pattern: >-
@@ -1614,6 +2232,9 @@ rules:
         Verify that column headers receive the same prefix or equivalent left padding as data rows so that header columns remain visually aligned with their corresponding data columns
       source: copilot:PR#374
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bulk-select-visual-consistency
       category: ui
       pattern: >-
@@ -1622,6 +2243,9 @@ rules:
         Verify that every item type that can be bulk-selected also renders a visual selection indicator (checkbox, highlight, etc.), and conversely that items without a visual indicator cannot be bulk-selected
       source: copilot:PR#374
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: copilot-no-p-flag
       category: other
       pattern: >-
@@ -1630,6 +2254,9 @@ rules:
         Verify that Copilot provider invocations do not use `-p -` or any `-p` flag — Copilot reads the prompt from stdin when `-p` is omitted, and may not support `-p -`. Use the shared provider arg builder or align with internal/provider/provider.go to pass prompts via stdin only.
       source: copilot:PR#377
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: provider-switch-exhaustive
       category: other
       pattern: >-
@@ -1638,6 +2265,9 @@ rules:
         Verify all supported providers (Claude, Gemini, Copilot, OpenAI, etc.) have explicit branches with correct flags/args; a catch-all default should not silently apply one provider's CLI flags to another
       source: copilot:PR#377
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: provider-env-override
       category: other
       pattern: Code that spawns a provider/AI subprocess outside of smith.go
@@ -1645,6 +2275,9 @@ rules:
         Verify that per-provider environment overrides (Provider.Env) are applied and CLAUDECODE env vars are stripped, matching the env filtering logic in internal/smith/smith.go
       source: copilot:PR#377
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-duplicate-error-prefix
       category: error-handling
       pattern: >-
@@ -1653,6 +2286,9 @@ rules:
         Verify that error messages are not double-prefixed. Either let the error carry the full context and display it as-is, or have the error carry only the underlying detail and let the UI/caller add the user-facing prefix — never both.
       source: copilot:PR#377
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: async-result-stale-check
       category: concurrency
       pattern: >-
@@ -1661,6 +2297,9 @@ rules:
         Verify that async/in-flight result handlers check whether the operation is still relevant before applying state changes — e.g., compare a run ID, check a cancel func, or confirm the target object still matches — to prevent stale completions from corrupting UI state
       source: copilot:PR#377
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-full-slice-rebuild-for-length
       category: performance
       pattern: >-
@@ -1669,6 +2308,9 @@ rules:
         Verify that hot paths (key-press handlers, scroll, render loops) do not rebuild slices solely to clamp or bound-check an index; prefer a cached count, a separate count function, or a pre-computed length field instead.
       source: copilot:PR#378
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: help-text-keybinding-completeness
       category: ui
       pattern: Footer/status bar help text listing keyboard shortcuts in a TUI view
@@ -1676,6 +2318,9 @@ rules:
         Verify that all active keybindings handled in Model.Update (or equivalent input handler) are reflected in the on-screen help text, including globally-available bindings like AI improve (i), so the displayed hints match actual behavior
       source: copilot:PR#378
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ui-keybinding-hint-completeness
       category: ui
       pattern: Footer or help text listing keyboard shortcuts in a TUI view
@@ -1683,6 +2328,9 @@ rules:
         Verify all keybindings handled in Model.Update are reflected in the displayed help/footer text, with no omissions or stale entries. Additionally verify that keyboard shortcut scope (global vs panel-scoped) is consistent between the input handler and the help/footer display: if a shortcut works globally, it should be advertised globally; if it is panel-scoped, the handler should be gated on the correct panel focus state.
       source: ['copilot:PR#378', 'copilot:PR#488']
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: help-keybinding-view-accuracy
       category: ui
       pattern: >-
@@ -1691,6 +2339,9 @@ rules:
         Verify every key shown in the help text is actually handled in the current view/mode; remove or conditionally render entries for keys that only work in other views
       source: copilot:PR#379
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: help-overlay-close-keys-consistency
       category: ui
       pattern: >-
@@ -1699,6 +2350,9 @@ rules:
         Verify that keys advertised in the help keymap behave consistently: if 'q' is shown as quit in the help overlay, it should quit (not just close the overlay); if the overlay uses different close keys (esc/?), remove 'q' from the overlay's close handling and document only the actual close keys
       source: copilot:PR#379
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: clamp-overlay-dimensions
       category: ui
       pattern: >-
@@ -1707,6 +2361,9 @@ rules:
         Verify overlay dimensions are clamped to available terminal size with both a minimum floor and a maximum ceiling (min(calculated, available)), so overlays never exceed terminal bounds on small terminals
       source: copilot:PR#379
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: clamp-ui-dimensions
       category: ui
       pattern: >-
@@ -1715,6 +2372,9 @@ rules:
         Verify that computed dimensions (width, height) are clamped to a minimum of 1 before being assigned to UI components, to prevent zero or negative values that can cause rendering issues or panics on narrow windows
       source: copilot:PR#379
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ui-keybinding-test-coverage
       category: testing
       pattern: New keybinding or overlay behavior added to a Bubbletea Model.Update handler
@@ -1722,6 +2382,9 @@ rules:
         Verify a test exists that sends the triggering key message to Model.Update and asserts the expected state change (e.g., overlay toggled, key consumed)
       source: copilot:PR#379
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: layout-width-slack-consistency
       category: ui
       pattern: >-
@@ -1730,6 +2393,9 @@ rules:
         Verify that all display modes (narrow, full, etc.) use a consistent slack/gutter calculation so that the sum of rendered widths (including borders, padding, and active-element decorations) never exceeds the terminal width and causes wrapping or horizontal scroll.
       source: copilot:PR#381
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: viewport-height-overflow
       category: ui
       pattern: >-
@@ -1738,6 +2404,9 @@ rules:
         Verify that any hint or extra line rendered outside the viewport is accounted for in the available row budget (e.g. reduce rowsHeight by 1 when the hint is visible) so the total output never exceeds m.height and causes terminal scrolling or glitching.
       source: copilot:PR#381
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-placement-accuracy
       category: style
       pattern: >-
@@ -1746,6 +2415,9 @@ rules:
         Verify that each doc comment directly precedes the function it describes, especially after refactoring or reordering functions
       source: copilot:PR#381
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-key-formatting
       category: style
       pattern: Changelog entries that mention keyboard keys or key presses
@@ -1753,6 +2425,8 @@ rules:
         Keyboard keys (e.g., d, Esc, q, Enter) should use inline code formatting (backticks) rather than single quotes or plain text so they render correctly in release notes
       source: copilot:PR#383
       added: "2026-03-21"
+      paths:
+        - '**/*.md'
     - id: refresh-guard-completeness
       category: concurrency
       pattern: >-
@@ -1761,6 +2435,9 @@ rules:
         Verify the guard is cleared in ALL terminal message handlers (including error messages) for every command in the batch, or use a counted completion / dedicated 'all-done' message so the guard accurately covers the full async cycle and cannot get stuck or allow overlapping cycles
       source: copilot:PR#384
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tui-cursor-capture-before-refresh
       category: ui
       pattern: >-
@@ -1769,6 +2446,9 @@ rules:
         Verify that the focused item ID is captured immediately before triggering a refresh (e.g., in the tick/refresh handler), not relied upon from a field that may be empty or stale if the user has not scrolled since startup
       source: copilot:PR#384
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cursor-state-restoration
       category: ui
       pattern: Functions that capture or restore focused/selected item IDs for UI refresh
@@ -1776,6 +2456,9 @@ rules:
         Verify that the focused ID is explicitly cleared when the cursor is on a non-item element (header, separator, out-of-bounds) so that refresh does not restore a stale selection and override the user's current cursor position
       source: copilot:PR#384
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: api-contract-partial-return
       category: error-handling
       pattern: >-
@@ -1784,6 +2467,9 @@ rules:
         Verify that when a loop is interrupted early (e.g., context cancellation, deadline exceeded), the documented contract of returning one result per input is still honoured — either by appending an error-carrying result for each remaining item, or by updating the doc comment to explicitly describe partial-return behaviour
       source: copilot:PR#386
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: surfaced-rollback-errors
       category: error-handling
       pattern: Rollback errors discarded with `_ = Rollback...` or similar blank assignment
@@ -1791,6 +2477,9 @@ rules:
         Verify that rollback failures are surfaced to callers (e.g., combined into Result.Err or a dedicated field) so consumers can detect and handle incomplete cleanup rather than silently leaving state dirty
       source: copilot:PR#386
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: error-include-diagnostics
       category: error-handling
       pattern: >-
@@ -1799,6 +2488,9 @@ rules:
         Verify the error message includes actionable diagnostic details (e.g. failed step name, summary) rather than a generic message, so callers can surface meaningful feedback without additional context
       source: copilot:PR#386
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: api-contract-matches-spec
       category: other
       pattern: >-
@@ -1807,6 +2499,9 @@ rules:
         Verify that exported function signatures exactly match the API contract specified in the PR description or task. If parameters were added or removed, either update the spec/task description or adjust the implementation to match the expected call sites.
       source: copilot:PR#386
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-result-vs-error-state
       category: error-handling
       pattern: >-
@@ -1815,6 +2510,9 @@ rules:
         When a result struct contains both a data collection and an Errors field, verify that empty data is not displayed as 'nothing found' without first checking if errors occurred — a failed operation producing zero results should show an error state, not a success/empty state
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: overlay-state-machine-tests
       category: testing
       pattern: >-
@@ -1823,6 +2521,9 @@ rules:
         Verify that tests cover key state machine transitions, including cancellation paths (Esc), late/async message arrivals, and the full happy-path flow through each state
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: late-async-result-stale-ui
       category: concurrency
       pattern: >-
@@ -1831,6 +2532,9 @@ rules:
         Verify that async scan/fetch results are ignored when the UI state that requested them is no longer active. Use a generation counter, request ID, or cancelable context so late-arriving messages from closed overlays are discarded rather than mutating hidden state.
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: overlay-consume-all-input
       category: ui
       pattern: >-
@@ -1839,6 +2543,9 @@ rules:
         Verify that ALL input event types (including tea.MouseMsg) are consumed or suppressed while the overlay is active, consistent with how other overlays in the codebase handle input isolation
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ui-message-matches-docs
       category: ui
       pattern: Toast notifications, status messages, or user-facing output text
@@ -1846,6 +2553,9 @@ rules:
         Verify that the wording and metrics in toast/status messages match what is described in the PR description and changelog (e.g. if docs promise 'packages + skipped groups' reporting, the toast must show both counts)
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: global-keybinding-help-consistency
       category: ui
       pattern: >-
@@ -1854,6 +2564,9 @@ rules:
         Verify that any global keybinding is reflected in all relevant panel keymaps (or marked as global in help), so on-screen help matches actual behavior regardless of which panel is focused
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cancel-copy-matches-behavior
       category: ui
       pattern: >-
@@ -1862,6 +2575,9 @@ rules:
         Verify the displayed action label matches actual behavior: if the copy says 'cancel', a context cancel must be wired up and propagated to the background operation; if no cancellation is implemented, the copy should say 'close' or 'dismiss' instead
       source: copilot:PR#387
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: async-msg-guard-overlay-state
       category: ui
       pattern: >-
@@ -1870,6 +2586,9 @@ rules:
         Verify that any handler processing an async completion message (e.g. a background operation result) guards against the overlay having been dismissed — check the relevant visibility flag before creating new form state, and handle the dismissed case by resetting/closing state and showing a summary toast instead
       source: copilot:PR#388
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: per-item-timeout-in-loops
       category: error-handling
       pattern: >-
@@ -1878,6 +2597,9 @@ rules:
         Verify that the timeout is either applied per-iteration inside the loop or scaled proportionally to the number of items, so that a large collection cannot exhaust the deadline mid-loop and cause avoidable failures
       source: copilot:PR#388
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-exercises-real-code-path
       category: testing
       pattern: >-
@@ -1886,6 +2608,9 @@ rules:
         Verify that tests exercise the real code path (e.g., set required state flags and provide minimal valid inputs) rather than reimplementing the logic inline, so regressions in the actual implementation are caught
       source: copilot:PR#388
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pass-real-config-not-zero-value
       category: other
       pattern: >-
@@ -1894,6 +2619,9 @@ rules:
         Verify that per-anvil or per-component config structs are populated from the real loaded configuration (e.g., forge.yaml anvil settings) rather than zero-value defaults, so behavior like GoRaceDetection, GolangciLint, or other settings are respected at runtime
       source: copilot:PR#388
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: batch-close-scope-validation
       category: other
       pattern: >-
@@ -1902,6 +2630,9 @@ rules:
         Verify that only records matching the actually-applied items are closed/updated, not all open records of that type. The completion message or result should carry the specific identifiers of what was applied so downstream close logic can filter to matching items rather than closing everything.
       source: copilot:PR#388
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-precondition-validation
       category: testing
       pattern: >-
@@ -1910,6 +2641,9 @@ rules:
         Verify the test setup accurately reproduces the failure mode: assert the problematic precondition exists before applying the fix, not after. For git worktree tests, confirm remote-tracking refs are absent before the operation under test (e.g., via `git show-ref` failing), and arrange state in the order that mirrors the real failure scenario.
       source: copilot:PR#389
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-remote-tracking-ref-absence
       category: testing
       pattern: >-
@@ -1918,6 +2652,9 @@ rules:
         Assert the absence of the actual remote-tracking ref (refs/remotes/origin/<branch>) using `git show-ref --verify --quiet`, not just the absence of upstream config. The lease check depends on the remote-tracking ref, not the branch config.
       source: copilot:PR#389
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: selective-error-suppression
       category: error-handling
       pattern: >-
@@ -1926,6 +2663,9 @@ rules:
         Verify that error suppression is scoped to the specific expected error (e.g. 'couldn't find remote ref' for first-push scenarios) and all other errors are returned to fail fast with clear diagnostics
       source: copilot:PR#389
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-duplicate-collection-sort
       category: style
       pattern: >-
@@ -1934,6 +2674,9 @@ rules:
         Verify there is a single source of truth for collection ordering — reuse the existing sorted slice instead of rebuilding and re-sorting a parallel list that could diverge
       source: copilot:PR#390
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: limit-without-sort-order
       category: other
       pattern: Using --limit on a list/query command combined with time-based filtering in code
@@ -1941,6 +2684,9 @@ rules:
         Verify that the data source guarantees ordering (e.g. by date desc) before applying --limit, otherwise the limit may exclude records that would pass the time filter. Either add an explicit sort flag or document the behavior as best-effort.
       source: copilot:PR#391
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: per-context-timeouts
       category: performance
       pattern: >-
@@ -1949,6 +2695,9 @@ rules:
         Verify that timeouts are scoped per operation or per resource rather than shared across all fetches; slow or unreachable targets should not stall unrelated results, and different operation types (e.g., open vs closed queries) should be able to use different timeout durations
       source: copilot:PR#391
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-exec-args-for-behavior-changes
       category: testing
       pattern: >-
@@ -1957,6 +2706,9 @@ rules:
         Verify there is a unit test that inspects the exact args passed to the exec function to assert the new flag/argument is present, so future refactors cannot silently revert the behavior.
       source: copilot:PR#391
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ui-requirement-location-match
       category: ui
       pattern: Feature adds a label or indicator to a UI element (header, footer, status bar)
@@ -1964,6 +2716,9 @@ rules:
         Verify the label/indicator is placed in the exact UI element specified by the requirement (e.g. status bar vs header), and that the PR description clarifies the placement if it differs from the spec
       source: copilot:PR#392
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: new-keybinding-test-coverage
       category: testing
       pattern: >-
@@ -1972,6 +2727,9 @@ rules:
         Verify that each newly added key alias has its own test case exercising the handler directly (e.g., sending keyMsg('v') in the relevant view state) in addition to any existing tests for the original key
       source: copilot:PR#392
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: overlay-respects-panel-width
       category: ui
       pattern: >-
@@ -1980,6 +2738,9 @@ rules:
         Verify that overlay components (e.g. event panels, modals) are constrained to their designated column range (e.g. mainPanelWidth()) so they do not overwrite adjacent panels outside their bounds
       source: copilot:PR#395
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ansi-truncate-before-style
       category: ui
       pattern: >-
@@ -1988,6 +2749,9 @@ rules:
         Truncate the raw string before applying ANSI/lipgloss styles, not after; truncating already-styled strings can cut escape sequences mid-sequence and corrupt terminal output
       source: copilot:PR#395
       added: "2026-03-21"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-accuracy-bounds
       category: style
       pattern: >-
@@ -1996,6 +2760,9 @@ rules:
         Verify that comments describing bounds use precise language: use 'at most', 'up to', or 'maximum' when the operation enforces an upper bound, not 'exactly' unless the result is guaranteed to equal that value
       source: copilot:PR#397
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: remove-dead-code-after-refactor
       category: style
       pattern: >-
@@ -2004,6 +2771,9 @@ rules:
         Verify that any function or field retained solely for tests (with no runtime callers) is actually still needed; if the production code no longer uses it, remove the dead code and update or delete the associated tests
       source: copilot:PR#398
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-state-distinguish-filter-vs-none
       category: ui
       pattern: Empty state messages in list/hierarchy views with active filters
@@ -2011,6 +2781,9 @@ rules:
         Verify empty state distinguishes between 'no items exist' and 'items exist but are filtered out' — only show filter-related message when the unfiltered collection has items (e.g., len(m.beads) > 0)
       source: copilot:PR#398
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: keybinding-help-text-accuracy
       category: ui
       pattern: >-
@@ -2019,6 +2792,9 @@ rules:
         Verify that each keybinding's help text accurately describes its action in the current context, and that all active bindings for an action (e.g., both Enter and Space) are represented — don't reuse bindings with generic or mismatched descriptions across different views
       source: copilot:PR#398
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: reset-loading-on-view-switch
       category: ui
       pattern: >-
@@ -2027,6 +2803,9 @@ rules:
         Verify that all loading/fetching flags (m.loading, m.fetching) and transient UI state (m.beads, etc.) are reset when switching views, so a mid-flight fetch cannot leave a loading screen stuck on the wrong view
       source: copilot:PR#398
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: synthetic-worker-pid-sentinel
       category: ui
       pattern: Synthetic or virtual workers constructed in the TUI/UI layer with a PID field
@@ -2034,6 +2813,9 @@ rules:
         Verify synthetic workers (not managed by the daemon) set PID to 0 or a sentinel value, not os.Getpid() or any real process ID, to prevent kill actions from accidentally signaling the wrong process
       source: copilot:PR#400
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: per-group-vs-cumulative-counters
       category: other
       pattern: >-
@@ -2042,6 +2824,9 @@ rules:
         Verify that per-iteration log messages use a local/per-iteration counter, not the running cumulative total; or that the message clearly states it is the overall total so far
       source: copilot:PR#400
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: background-phase-semantics
       category: style
       pattern: >-
@@ -2050,6 +2835,9 @@ rules:
         Verify that grouping constants accurately reflect the semantics of all included phases — if a phase is user-initiated, foreground, or excluded from capacity/stale detection for different reasons than the others, the comment, name, or grouping should be updated or split to reflect that distinction
       source: copilot:PR#400
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-visual-truncation-assertions
       category: testing
       pattern: >-
@@ -2058,6 +2846,9 @@ rules:
         When testing visual truncation or wrapping behavior in rendered terminal/TUI output, do not rely solely on NotContains(output, fullString/longString) — lipgloss or other renderers may wrap long text across lines, so the full string can still be present split across lines while NotContains appears to pass. Instead, assert that the rendered output contains truncation indicators (e.g. an ellipsis "…") when the text exceeds the available width, verify that no rendered line exceeds the expected width, and/or assert the exact number of rendered lines to distinguish intentional truncation from simple wrapping.
       source: copilot:PR#402
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-duplicated-branch-logic
       category: style
       pattern: >-
@@ -2066,6 +2857,9 @@ rules:
         Verify that shared computations (e.g. prefix, widths, truncation) are factored out before the branch point, so only the truly differing logic lives inside each branch — preventing inconsistent future edits
       source: copilot:PR#402
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: panel-width-calculation
       category: ui
       pattern: Width calculations for list items or content rendering in multi-panel layouts
@@ -2073,6 +2867,9 @@ rules:
         Verify that item width calculations account for all visible panels (e.g., detail/side panels) by using the actual available panel width rather than the full window width, to prevent content wrapping or truncation when secondary panels are displayed
       source: copilot:PR#402
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: flush-buffered-text-before-plain-line
       category: ui
       pattern: >-
@@ -2081,6 +2878,9 @@ rules:
         Verify that any buffered streaming text is flushed before appending a plain-text entry, so output preserves chronological ordering
       source: copilot:PR#404
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: wrap-exec-errors-with-context
       category: error-handling
       pattern: >-
@@ -2089,6 +2889,9 @@ rules:
         When capturing errors from exec calls or multi-step operations, verify the error is wrapped with enough context (e.g., operation name, resource identifier, status) so the caller can diagnose which step failed without ambiguity
       source: copilot:PR#406
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sequential-timeout-accumulation
       category: performance
       pattern: Multiple sequential operations each with their own timeout/context deadline
@@ -2096,6 +2899,9 @@ rules:
         For fixed or otherwise bounded multi-step sequences with an intended overall deadline, verify that sequential timeout-bearing calls are coordinated via an overall parent context/deadline (and, if needed, per-step timeouts derived from it) or are run concurrently, so worst-case latency cannot exceed the intended overall bound; do not apply this pattern to open-ended/variable-length loops where per-item timeout guidance (e.g., per-item-timeout-in-loops) should remain the primary rule
       source: copilot:PR#406
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: npm-group-sourcedir-partition
       category: other
       pattern: >-
@@ -2104,6 +2910,9 @@ rules:
         Verify that dependency groups are partitioned by SourceDir (or equivalent package root) before merging, so that grouped updates never mix dependencies from different manifest directories. Each group's SourceDir must be consistent across all members — do not blindly take SourceDir from members[0] without validating all members share the same value.
       source: copilot:PR#409
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hermetic-test-no-real-externals
       category: testing
       pattern: >-
@@ -2112,6 +2921,9 @@ rules:
         Verify tests do not depend on real external commands or network access. Stub or mock command execution to make tests hermetic, and assert on the actual behavior (e.g. working directory, arguments passed) rather than side effects that could pass vacuously.
       source: copilot:PR#409
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tui-git-quiet-mode
       category: ui
       pattern: >-
@@ -2120,6 +2932,9 @@ rules:
         Verify that git commands executed from within a TUI use a quiet/redirectable output mode (stdout/stderr to io.Discard or a logger) so that git progress and status output does not corrupt the alt-screen UI or pollute the Live Activity log
       source: copilot:PR#410
       added: "2026-03-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: normalize-default-before-insert
       category: error-handling
       pattern: >-
@@ -2128,6 +2943,9 @@ rules:
         Verify that empty/zero-value fields are normalized to the column's default value (or rejected with an error) before executing the INSERT, so the table's default constraint is not bypassed by storing an empty string
       source: copilot:PR#413
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: update-rows-affected
       category: error-handling
       pattern: SQL UPDATE or DELETE that returns nil without checking RowsAffected
@@ -2135,6 +2953,9 @@ rules:
         Verify that UPDATE/DELETE operations check sql.Result.RowsAffected() and return a clear error when 0 rows were affected, to avoid silently succeeding when the target row doesn't exist
       source: copilot:PR#413
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: struct-tags-match-comments
       category: style
       pattern: >-
@@ -2143,6 +2964,9 @@ rules:
         Verify that the struct actually has the yaml and mapstructure tags matching the referenced struct. If the comment says tags enable automatic config population, the tags must be present and their keys must match the YAML keys (e.g. wicket_enabled, not Enabled). Either add correct tags or remove the misleading comment and use explicit mapping.
       source: copilot:PR#413
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: gh-cli-body-via-stdin
       category: security
       pattern: >-
@@ -2151,6 +2975,9 @@ rules:
         Verify that large or sensitive text passed to gh CLI uses --body-file - with stdin piping instead of --body argv flag, to avoid OS command-line length limits (especially on Windows) and to prevent exposing content in the process argument list
       source: copilot:PR#416
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: slice-reference-capture
       category: testing
       pattern: >-
@@ -2159,6 +2986,9 @@ rules:
         Verify that recorded arguments are defensively copied (e.g. slices.Clone) before storing, so that later mutations by the caller do not silently corrupt the test's assertions
       source: copilot:PR#416
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: mock-record-all-args
       category: testing
       pattern: Mock/stub structs that record method calls but drop one or more arguments
@@ -2166,6 +2996,9 @@ rules:
         Verify that mock call recorders capture ALL method arguments (not just some), so tests can assert the full context of each call. Use a struct to record multiple parameters rather than storing only one field.
       source: copilot:PR#416
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: check-test-parse-errors
       category: testing
       pattern: >-
@@ -2174,6 +3007,9 @@ rules:
         Verify that parse errors in test setup are checked and cause an immediate test failure (t.Fatalf) rather than being silently ignored, which would let the test proceed with a zero value and produce misleading results
       source: copilot:PR#416
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: conditional-close-on-partial-failure
       category: error-handling
       pattern: >-
@@ -2182,6 +3018,9 @@ rules:
         Verify that a parent/gate is not closed unconditionally when downstream side-effect operations (e.g. dependency transfers, notifications) can partially fail. Track success of all critical operations and only close the parent when all succeed; otherwise leave it open or roll back so dependent items remain correctly gated.
       source: copilot:PR#417
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: derive-timeout-from-parent-ctx
       category: concurrency
       pattern: context.WithTimeout(context.Background()
@@ -2189,6 +3028,9 @@ rules:
         When adding a timeout to a request- or operation-scoped task, derive it from the caller's context (e.g. context.WithTimeout(ctx, ...)) rather than context.Background(), so the work participates in caller cancellation/shutdown semantics. This guidance does NOT apply to contexts that are intentionally detached from the caller, such as cleanup defers that must run even after shutdown (see cleanup-defer-canceled-ctx) or pipeline/background contexts that are meant to outlive the initiating request (see pipeline-ctx-from-background).
       source: copilot:PR#417
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: assert-close-reason-contains-context
       category: testing
       pattern: >-
@@ -2197,6 +3039,9 @@ rules:
         When testing a command that closes/completes a resource with a reason or message, assert not just that the command was called, but also that the reason/message includes all relevant contextual details (e.g. related entity IDs, counts) so future changes don't silently regress operator-visible messages
       source: copilot:PR#417
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-create-bead-fields
       category: error-handling
       pattern: >-
@@ -2205,6 +3050,9 @@ rules:
         Verify that required downstream fields (e.g. bead_title, bead_description) are non-empty before accepting the decision as valid. Treat creation actions with missing required fields as parse failures so the caller can retry or fall back, rather than propagating incomplete data to downstream creators.
       source: copilot:PR#419
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: per-run-temp-dirs
       category: concurrency
       pattern: >-
@@ -2213,6 +3061,9 @@ rules:
         Verify that each run creates its own isolated temporary directory via os.MkdirTemp instead of using the shared os.TempDir(), to prevent log collisions and cross-run interference when multiple runs execute concurrently. Ensure cleanup (e.g., defer os.RemoveAll) is in place.
       source: copilot:PR#419
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: check-subprocess-exit-code
       category: error-handling
       pattern: >-
@@ -2221,6 +3072,9 @@ rules:
         When wrapping a subprocess call, verify that the exit code and stderr are checked before treating stdout as valid output. Non-zero exit codes or stderr content should propagate as errors rather than being silently passed to callers, which can cause misclassification of failures and unnecessary retries.
       source: copilot:PR#419
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: retry-scope-match-contract
       category: error-handling
       pattern: >-
@@ -2229,6 +3083,9 @@ rules:
         Verify that retry logic only retries the specific error conditions documented in the contract. Generic retries that also cover provider/runner errors can double costs or repeat side effects when the upstream is down. The set of retried errors must match what the spec/tests/docs promise.
       source: copilot:PR#419
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-decision-action-before-use
       category: error-handling
       pattern: >-
@@ -2237,6 +3094,9 @@ rules:
         When a function accepts a union-like struct (e.g. a decision with multiple possible actions), verify it validates the action/type field matches the expected variant and that required fields for that variant are non-empty before proceeding — fail fast on misuse rather than silently producing invalid results
       source: copilot:PR#420
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-bounded-int-params
       category: error-handling
       pattern: >-
@@ -2245,6 +3105,9 @@ rules:
         Verify that integer parameters with documented valid ranges (e.g. priority 0-4) are validated or clamped at the function boundary, returning a clear error for out-of-range values rather than forwarding them to downstream tools
       source: copilot:PR#420
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: api-signature-matches-spec
       category: other
       pattern: >-
@@ -2253,6 +3116,9 @@ rules:
         Verify that function signatures match their specification in PR descriptions, design docs, and task text. If extra parameters are added beyond the spec, either update all documentation and call sites to match, or derive the value internally to keep the API consistent with the agreed design.
       source: copilot:PR#420
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-db-persistence
       category: testing
       pattern: >-
@@ -2261,6 +3127,9 @@ rules:
         Verify that tests for persistent features assert against the actual database layer (e.g., state.DB.GetWicketIssue) rather than only in-memory structures, ensuring the test would fail if persistence is broken
       source: copilot:PR#420
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-persistent-state-db
       category: other
       pattern: >-
@@ -2269,6 +3138,9 @@ rules:
         Verify that state which must survive process restarts and be visible to other components is persisted via state.DB (SQLite) rather than kept only in package-level in-memory maps. Check whether a matching table/CRUD helper already exists in internal/state/db.go before introducing new in-memory storage.
       source: copilot:PR#420
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: distinct-event-types
       category: error-handling
       pattern: >-
@@ -2277,6 +3149,9 @@ rules:
         Verify that each logically distinct event (startup, progress, completion, failure) uses its own dedicated event type so consumers can unambiguously distinguish them in timelines and queries
       source: copilot:PR#421
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: trigger-label-fetch-gap
       category: other
       pattern: >-
@@ -2285,6 +3160,9 @@ rules:
         Verify that all configured label types are included in fetch queries — either by unioning results from both label sets with de-duplication, or by fetching broadly and filtering in code. Items matching only the trigger/override label must not be silently excluded. When multiple label configs exist, ensure the fetch covers the union of all relevant labels so items matching any configured label are not silently dropped.
       source: copilot:PR#421
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: config-hot-reload-ticker
       category: concurrency
       pattern: >-
@@ -2293,6 +3171,9 @@ rules:
         Verify that runtime config changes (especially intervals/durations) actually take effect in running loops. If a ticker is created once from an initial config value, updating the config later won't change the polling cadence. The goroutine must either watch for config changes and reset the ticker, or the documentation must state a restart is required.
       source: copilot:PR#421,copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: distinguish-db-error-types
       category: error-handling
       pattern: >-
@@ -2301,6 +3182,9 @@ rules:
         Verify that database insert errors are not broadly interpreted as a single expected condition (e.g., unique-constraint violation). Detect the specific error type (constraint violation, duplicate key) and handle unexpected failures (DB unavailable, timeout, schema error) separately with appropriate logging and error propagation.
       source: copilot:PR#421
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: failed-side-effect-blocks-retry
       category: error-handling
       pattern: >-
@@ -2309,6 +3193,9 @@ rules:
         Verify that if the tracked operation fails after the record is created, the record is either deleted or moved to a retriable state so that skip/dedup logic does not permanently block future retry attempts
       source: copilot:PR#421
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: report-effective-defaults
       category: ui
       pattern: >-
@@ -2317,6 +3204,9 @@ rules:
         Verify that status reports and UI displays show the effective value (after defaults are applied) rather than the raw config value, so users are not misled by zero/empty values that will be replaced at runtime
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ipc-handler-error-propagation
       category: error-handling
       pattern: >-
@@ -2325,6 +3215,9 @@ rules:
         Verify that IPC and status endpoint handlers propagate errors back to the caller as error responses rather than silently swallowing them and returning empty/zero-value results. This includes process kill operations — handlers should map kill/signal failures to error responses so CLI/TUI consumers can surface real outcomes instead of reporting unconditional success.
       source: ['copilot:PR#422', 'copilot:PR#497']
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: status-display-completeness
       category: ui
       pattern: IPC status/info command that returns system state to the user
@@ -2332,6 +3225,9 @@ rules:
         Verify that all fields mentioned in the PR description or design doc are actually included in the IPC response payload AND rendered in both text and JSON output formats. Cross-reference the command's stated purpose against its actual output fields.
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: wicket-repo-resolution-accuracy
       category: ui
       pattern: >-
@@ -2340,6 +3236,9 @@ rules:
         Verify that status output accurately reflects the full resolved state (e.g., per-source breakdown of configured vs derived values) rather than printing a misleading fallback when the collection is partially populated from mixed sources
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ipc-payload-completeness
       category: ui
       pattern: Adding IPC status/payload structs or updating daemon status responses
@@ -2347,6 +3246,9 @@ rules:
         Verify that all fields mentioned in the PR description or design doc are included in the IPC payload struct — if a feature is called out (e.g. 'show last poll time'), the corresponding data field must exist in the response type so the CLI can display it
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: shared-field-sync
       category: concurrency
       pattern: >-
@@ -2355,6 +3257,9 @@ rules:
         Verify that all struct fields accessed from multiple goroutines are protected by a mutex, use atomic.Pointer, or follow an existing synchronization pattern (e.g., the notifier/dispatcher atomic patterns in the daemon)
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: status-reflect-derived-config
       category: other
       pattern: >-
@@ -2363,6 +3268,9 @@ rules:
         When building status responses or diagnostic output, verify that derived/fallback values are included alongside explicitly configured ones, so the output accurately reflects actual runtime behavior rather than just what was explicitly configured
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: prefer-count-over-list-len
       category: performance
       pattern: >-
@@ -2371,6 +3279,9 @@ rules:
         Use a DB-side COUNT(*) query or dedicated Count helper instead of loading full rows and measuring slice length. Loading entire objects (especially those with large text fields like bodies/descriptions) just to count them wastes memory and degrades performance as data grows.
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: display-matches-runtime-behavior
       category: ui
       pattern: >-
@@ -2379,6 +3290,9 @@ rules:
         Verify that status output reflects the actual runtime behavior, not just configured values. If the system derives or infers additional items at runtime (e.g., from git remotes, environment, defaults), the display should either use the same derivation logic or clearly label the output as showing only explicitly configured items.
       source: copilot:PR#422
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: config-default-semantic-mismatch
       category: other
       pattern: >-
@@ -2387,6 +3301,9 @@ rules:
         When a config field controls opt-in/opt-out behavior, verify that the default value's semantics match the documented behavior. If a default value like 'forge-triage' exists but code treats the field as a required filter, unlabeled items will be silently skipped — confirm the default, docs, and gating logic all agree on whether the field is required or merely advisory
       source: copilot:PR#423
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: spam-heuristic-false-positives
       category: security
       pattern: >-
@@ -2395,6 +3312,9 @@ rules:
         Verify that spam heuristics use explicit allowlists or known-placeholder matching rather than broad length thresholds, so legitimate short inputs (e.g. 'Help', 'Bug', 'Docs') are not silently discarded
       source: copilot:PR#423
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: unused-type-field-drift
       category: style
       pattern: >-
@@ -2403,6 +3323,9 @@ rules:
         Verify that the type being modified is actually wired into the system. If a parallel or canonical representation exists elsewhere (e.g. a config struct in another package), updating an unused copy causes drift and misleads future readers. Either wire the unused type into consumers or update the canonical type instead.
       source: copilot:PR#423
       added: "2026-03-23"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: action-to-state-mapping
       category: other
       pattern: Storing an action/decision enum value directly as a state field
@@ -2410,6 +3333,9 @@ rules:
         Verify that action/decision values are mapped to their corresponding lifecycle state constants before persistence, rather than storing raw action strings that may differ from the state values other code queries against
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: gh-api-pagination
       category: performance
       pattern: GitHub API list calls using --per-page without --paginate
@@ -2417,6 +3343,9 @@ rules:
         Verify that all GitHub API list/search calls include --paginate (or manual page iteration) so results beyond the first page are not silently dropped
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: close-reason-propagation
       category: other
       pattern: >-
@@ -2425,6 +3354,9 @@ rules:
         Verify that close/completion functions propagate the appropriate reason or status (e.g. 'completed', 'not planned') to the underlying API, and that the interface signature supports the reason parameter — don't silently drop context documented in the design
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: notify-all-pr-paths
       category: other
       pattern: Multiple code paths that create PRs or call ingotRecordPR/emit PR-created events
@@ -2432,6 +3364,9 @@ rules:
         Verify that notification callbacks (e.g. notifyWicketPRCreated) are invoked in every code path that successfully creates a PR, not just the primary finalizePipeline path. Check alternate flows like warden re-run and approve-as-is for missing notification calls.
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stale-issue-reply-retriage
       category: other
       pattern: >-
@@ -2440,6 +3375,9 @@ rules:
         Verify that reply/re-triage handlers scan ALL relevant states (e.g. both ask_clarify AND stale), not just one. If a stale issue can receive an author reply that should reactivate it, the handler must include that state in its scan or provide a separate transition path back into the active workflow.
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stale-detection-timestamp-accuracy
       category: other
       pattern: >-
@@ -2448,6 +3386,9 @@ rules:
         Verify that staleness/inactivity detection is based on a dedicated timestamp tracking the specific actor's last meaningful activity (e.g., last author reply), not a generic updated_at field that gets bumped by unrelated operations like automated updates, bot activity, or other users' actions
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: struct-insert-field-sync
       category: other
       pattern: A struct has fields added or a DB schema is migrated with new columns
@@ -2455,6 +3396,9 @@ rules:
         Verify that all insert/update functions are updated to include the new fields, so values are not silently dropped or left to defaults when callers provide them
       source: copilot:PR#426
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: capture-time-now-once
       category: concurrency
       pattern: Multiple time.Now() calls used to derive related values
@@ -2462,6 +3406,9 @@ rules:
         Verify that time.Now() is captured once into a local variable when multiple time-derived values (formatted strings, IDs, filenames) need to be consistent — repeated calls can diverge at second or midnight boundaries, causing mismatched identifiers or race-like bugs. This applies in tests too: capture a single `now := time.Now()` and derive all time-dependent values from it to prevent flaky failures around date boundaries.
       source: ['copilot:PR#427', 'copilot:PR#455']
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: log-deferred-cleanup-errors
       category: error-handling
       pattern: >-
@@ -2470,6 +3417,9 @@ rules:
         Verify that errors from deferred cleanup operations (worktree removal, file cleanup, resource release) are logged rather than silently discarded. Silent failures can leave behind stale resources that break subsequent runs.
       source: copilot:PR#427
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stable-worktree-id-for-retries
       category: error-handling
       pattern: >-
@@ -2478,6 +3428,9 @@ rules:
         Verify that worktree and branch IDs are stable across crash/retry runs (e.g., derived from date or deterministic input) so that ResetBranch can clean up previous attempts. Random or unique-per-run IDs cause 'branch already exists' failures when a leftover branch exists but its worktree directory does not.
       source: copilot:PR#427
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: worktree-branch-preexist
       category: error-handling
       pattern: >-
@@ -2486,6 +3439,9 @@ rules:
         Verify that the code handles the case where the target branch already exists locally (e.g., from a previous interrupted run). The worktree creation will fail if the branch exists. Either delete the pre-existing branch first, or use a creation mode that can reuse/reset an existing branch.
       source: copilot:PR#427
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: worktree-absolute-path-reroot
       category: other
       pattern: >-
@@ -2494,6 +3450,9 @@ rules:
         Verify that absolute paths captured during a scan/analysis phase are re-rooted (converted to repo-relative paths, then joined with the apply worktree path) before being used in a different worktree context. Otherwise operations like npm install or git commit may target the wrong directory.
       source: copilot:PR#428
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: worktree-scan-semantics
       category: other
       pattern: >-
@@ -2502,6 +3461,9 @@ rules:
         Verify that scan/read-only worktrees base from the current local HEAD (no fetch, no remote branch checkout) to preserve 'scan the working tree as-is' semantics. Using the default CreateWithOptions behavior fetches origin and checks out the remote default branch, which changes scan semantics and creates inconsistency with fallback paths that scan the local checkout. Use options like ResetBranch: false or a detached worktree from HEAD when only filesystem isolation (e.g. node_modules) is needed.
       source: copilot:PR#428
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: feature-wiring-matches-description
       category: other
       pattern: >-
@@ -2510,6 +3472,9 @@ rules:
         Verify that newly introduced functions are wired into all intended call sites (not just tests or secondary flows). If a PR description claims a feature applies broadly (e.g., to all new issues), confirm the primary code path actually invokes the new logic, not just a secondary or re-triage path.
       source: copilot:PR#429
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: preserve-existing-fields-on-partial-update
       category: other
       pattern: >-
@@ -2518,6 +3483,10 @@ rules:
         When updating a database row, verify that partially-populated structs do not overwrite existing columns with zero values and that fields not being intentionally changed are preserved. Either load the existing row first and merge changes onto it (read-modify-write), or use narrower, column-specific update methods that only touch the intended fields — otherwise unrelated fields get silently zeroed out.
       source: ['copilot:PR#429', 'copilot:PR#430']
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.yaml'
     - id: bd-call-timeout
       category: concurrency
       pattern: >-
@@ -2526,6 +3495,9 @@ rules:
         Verify that all bd/beads CLI invocations are wrapped in a context.WithTimeout so that Dolt connectivity issues cannot block indefinitely — especially in long-lived daemon contexts that have no inherent deadline
       source: copilot:PR#429
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: markdown-blockquote-multiline
       category: ui
       pattern: >-
@@ -2534,6 +3506,9 @@ rules:
         Verify that multi-line content inside a `> ` blockquote prefix has each line prefixed with `>`, or is normalized to a single line, so the rendered output doesn't break after the first line
       source: copilot:PR#429
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: triage-action-field-validation
       category: error-handling
       pattern: >-
@@ -2542,6 +3517,9 @@ rules:
         Verify that action-specific required fields are validated after parsing (e.g., duplicate requires duplicate_id, already_fixed requires reference_pr, out_of_scope requires a non-empty reason). Missing required fields should be treated as a parse failure so retry/fallback logic applies, rather than allowing empty or ambiguous values to persist.
       source: copilot:PR#429
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-cmd-dir-scope
       category: other
       pattern: exec.Command(Context) calling `bd` or other beads CLI commands
@@ -2549,6 +3527,9 @@ rules:
         Verify that cmd.Dir is set to the anvil path so the command uses the correct .beads/ config. Without this, the command may query the wrong beads DB or fail depending on the daemon's working directory.
       source: copilot:PR#429
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: prompt-size-cap
       category: performance
       pattern: >-
@@ -2557,6 +3538,9 @@ rules:
         Verify that any collection injected into an LLM prompt is capped to a reasonable maximum count or token budget to avoid blowing context limits, excessive cost, and fallback failures
       source: copilot:PR#429
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: rate-limit-error-incomplete-fields
       category: error-handling
       pattern: >-
@@ -2565,6 +3549,9 @@ rules:
         Verify that all rate-limit error fields (Remaining, ResetAt, RetryAfter) are populated with real values parsed from response headers, stderr, or a rate_limit API endpoint—not left as zero/sentinel values—and that every code path making external API calls (not just the primary helper) shares the same rate-limit detection and propagation logic
       source: copilot:PR#431
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: rate-limit-propagation
       category: error-handling
       pattern: >-
@@ -2573,6 +3560,9 @@ rules:
         When a rate limit or backoff signal is detected in a sub-operation, verify that the signal propagates to the caller so it can short-circuit remaining work in the same cycle instead of continuing to hammer the API
       source: copilot:PR#431
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: rate-limit-remaining-reset-on-success
       category: error-handling
       pattern: >-
@@ -2581,6 +3571,9 @@ rules:
         Verify that recording a successful request preserves the last-known remaining quota and reset time instead of clearing them. If remaining is only populated on error responses, ensure a periodic refresh (e.g., dedicated rate-limit API call) keeps the value current so quota-aware throttling logic can actually activate.
       source: copilot:PR#431
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: exponential-backoff-overflow
       category: performance
       pattern: >-
@@ -2589,6 +3582,9 @@ rules:
         Verify that the exponent or resulting value is clamped to the maximum backoff BEFORE float-to-int conversion, not after. Large exponents can overflow float64→int64, producing negative or garbled durations. Prefer integer doubling with early clamping or cap the retry counter once max backoff is reached.
       source: copilot:PR#431
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-helper-stub-documentation
       category: testing
       pattern: >-
@@ -2597,6 +3593,9 @@ rules:
         Verify that test helper comments accurately describe which dependencies are stubbed vs left to the caller. If the helper does not install safe default stubs for external process execution, the comment must explicitly state that callers are responsible for stubbing them to prevent accidental real process spawning.
       source: copilot:PR#432
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: zero-timeout-semantics
       category: error-handling
       pattern: Setting a timeout value that could be zero or negative without explicit handling
@@ -2604,6 +3603,9 @@ rules:
         Verify that zero/negative timeout values have well-defined semantics (e.g., fall back to a sensible default) rather than silently changing behavior to mean 'no time budget' or 'instant expiry'
       source: copilot:PR#433
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: zero-timeout-guard
       category: error-handling
       pattern: >-
@@ -2612,6 +3614,9 @@ rules:
         Verify that timeout values are guarded or normalized before being passed to .Timeout() calls, since a zero value may be treated as 'use default' in some contexts but as 'immediate/no wait' in others, causing unexpectedly instant operations
       source: copilot:PR#433
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-comments-match-implementation
       category: testing
       pattern: >-
@@ -2620,6 +3625,9 @@ rules:
         Verify that test comments and assertions accurately reflect the current implementation behavior, especially after adding fast-path returns or changing control flow. Stale comments that describe old failure modes mislead future readers.
       source: copilot:PR#433
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-context-timeout-headless
       category: testing
       pattern: >-
@@ -2628,6 +3636,9 @@ rules:
         Verify the overall test context timeout is generous enough (≥60s) to absorb slow subprocess startup on loaded CI, even when per-element/executor timeouts are kept short to fail fast on real errors
       source: copilot:PR#433
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: map-stale-entry-cleanup
       category: concurrency
       pattern: >-
@@ -2636,6 +3647,9 @@ rules:
         Verify that maps rebuilt each cycle are fully cleared or replaced (clear + repopulate, or build-new-and-swap) so stale entries from removed config are not retained, and that duplicate/conflicting ownership across sources is detected and logged rather than silently overwritten
       source: copilot:PR#434
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cache-comment-matches-impl
       category: other
       pattern: >-
@@ -2644,6 +3658,9 @@ rules:
         Verify the comment accurately describes the actual implementation: if the comment says the cache is rebuilt periodically, confirm it is actually cleared and repopulated; if it claims downstream code uses the cache to skip expensive operations (e.g. git calls), confirm those code paths actually read from the cache instead of re-resolving independently
       source: copilot:PR#434
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nondeterministic-map-iteration
       category: concurrency
       pattern: >-
@@ -2652,6 +3669,9 @@ rules:
         Verify that code iterating over maps does not depend on iteration order. If order matters (e.g., first-match semantics, deterministic output, stable duplicate detection), sort the keys or collect values into a slice with a defined ordering before processing.
       source: copilot:PR#436
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: accurate-dynamic-messages
       category: error-handling
       pattern: >-
@@ -2660,6 +3680,9 @@ rules:
         Verify that user-facing or persisted messages accurately reflect all possible code paths. If a function can return matches from multiple contexts, either narrow the search scope to match the message or make the message dynamic/agnostic based on the actual result.
       source: copilot:PR#436
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cap-bd-list-scans
       category: performance
       pattern: >-
@@ -2668,6 +3691,9 @@ rules:
         Verify that bd list / bead summary scans are capped with a reasonable limit and not unbounded, especially when called per-anvil in a loop. Unbounded scans become slow as databases grow and timeout failures may silently degrade to expensive fallbacks.
       source: copilot:PR#436
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sqlite-error-type-check
       category: error-handling
       pattern: >-
@@ -2676,6 +3702,9 @@ rules:
         Verify that database/driver errors are identified using typed error unwrapping (errors.As/errors.Is) and specific error codes rather than substring matching on error message text, which is brittle across driver versions and error wrapping
       source: copilot:PR#437
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: assert-expected-log-messages
       category: testing
       pattern: >-
@@ -2684,6 +3713,9 @@ rules:
         Verify that the test captures log output and asserts the expected log message is emitted, so regressions that silently change or remove the log line are caught
       source: copilot:PR#437
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: multi-source-fair-aggregation
       category: other
       pattern: >-
@@ -2692,6 +3724,9 @@ rules:
         Verify that when results from multiple sources are combined and capped, each source gets fair representation (e.g., per-source quota or round-robin merge) so that a single prolific source cannot starve all others from the final result
       source: copilot:PR#438
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bound-aggregate-fetch-time
       category: performance
       pattern: >-
@@ -2700,6 +3735,9 @@ rules:
         Verify that aggregate I/O is bounded: use a shared context deadline or total timeout around the loop, cap the number of items queried, and/or fan out with a concurrency limit — so a single slow call or a large collection cannot stall the caller for minutes
       source: copilot:PR#438
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-name-matches-fixture
       category: testing
       pattern: >-
@@ -2708,6 +3746,9 @@ rules:
         Verify that the test name accurately describes the behavior being tested, and that the test fixtures match the scenario implied by the name. If the name says 'shared repo across anvils', the fixture must have multiple anvils referencing the same repo; if the fixture tests 'multi-repo lookup', rename the test accordingly.
       source: copilot:PR#438
       added: "2026-03-24"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: lipgloss-margin-height-calc
       category: ui
       pattern: >-
@@ -2716,6 +3757,9 @@ rules:
         Verify that inner height calculations account for all rendered lines including margin lines from lipgloss styles (e.g. MarginBottom(1) adds an extra line that must be included in height math to avoid clipping content)
       source: copilot:PR#444
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: lipgloss-frame-vs-padding
       category: ui
       pattern: >-
@@ -2724,6 +3768,9 @@ rules:
         When computing available inner width for panel content, verify whether the width variable already excludes borders. If it does, subtract only padding (GetHorizontalPadding) not the full frame size (GetHorizontalFrameSize), which includes borders and would double-subtract, truncating content earlier than necessary.
       source: copilot:PR#444
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: type-name-matches-semantics
       category: style
       pattern: >-
@@ -2732,6 +3779,9 @@ rules:
         Verify that type/struct names accurately reflect their contents and how they are used — e.g., if a summary is grouped by repo, name it RepoSummary not AnvilSummary
       source: copilot:PR#444
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: gate-disabled-feature-fetches
       category: performance
       pattern: >-
@@ -2740,6 +3790,9 @@ rules:
         Verify that expensive or periodic data fetches (e.g. DB queries, API calls) are gated on the corresponding feature-enabled flag so they are skipped when the feature is disabled and the results would never be displayed or consumed
       source: copilot:PR#444
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-op-form-toast
       category: ui
       pattern: >-
@@ -2748,6 +3801,9 @@ rules:
         Verify that pending/success toasts and status indicators are only shown when the action command is non-nil. No-op form submissions (e.g. cancellation options, empty inputs) should not display misleading progress or confirmation messages.
       source: copilot:PR#451
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: toast-action-test-coverage
       category: testing
       pattern: >-
@@ -2756,6 +3812,9 @@ rules:
         Verify that new toast/notification behavior has unit tests covering both the positive case (toast enqueued when action returns a non-nil result) and the negative case (no toast for intentional no-op actions)
       source: copilot:PR#451
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: trim-cmd-output-in-errors
       category: error-handling
       pattern: >-
@@ -2764,6 +3823,9 @@ rules:
         Verify that stdout and stderr strings are trimmed with strings.TrimSpace() before checking emptiness and before including in error messages, so trailing newlines don't cause misleading or noisy error output
       source: copilot:PR#452
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-close-json-flag-consistency
       category: error-handling
       pattern: >-
@@ -2772,6 +3834,9 @@ rules:
         Verify that ALL call sites passing `bd close` include the `--json` flag consistently. When fixing an interactive-prompt or parsing bug by adding a flag to one call site, grep for every other invocation of the same command and ensure none are missed. Also verify that changelog/PR descriptions accurately reflect which call sites were actually changed.
       source: copilot:PR#452
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: calendar-day-vs-duration-dedup
       category: other
       pattern: >-
@@ -2780,6 +3845,9 @@ rules:
         Verify whether skip/dedup logic should use a rolling time window (e.g., 24h since last run) or calendar-day boundaries — ensure the implementation matches the documented intent, and that edge cases near midnight are acceptable
       source: copilot:PR#455
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: per-item-event-skips-cycle
       category: error-handling
       pattern: >-
@@ -2788,6 +3856,9 @@ rules:
         Verify that skip/deduplication logic uses a cycle-level completion event rather than a per-item event, so a partially completed run does not cause the entire next cycle to be skipped
       source: copilot:PR#455
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-component-accuracy
       category: style
       pattern: Changelog entries in changelog.d/ that reference a component or subsystem name
@@ -2795,6 +3866,9 @@ rules:
         Verify the component name in the changelog bullet matches the actual package/directory where the code change occurred. Cross-reference the changed files' package paths (e.g. internal/vulncheck) with the label used in the changelog entry to avoid attributing changes to the wrong subsystem.
       source: copilot:PR#455
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: consistent-event-types-for-error-paths
       category: error-handling
       pattern: >-
@@ -2803,6 +3877,9 @@ rules:
         When a failure can occur in both a normal path and a recovery/fallback path, verify that both paths log the same event type (e.g. EventPRCreationFailed) so that downstream consumers (dashboards, alerts, analytics) surface the failure consistently regardless of which code path produced it
       source: copilot:PR#457
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nil-check-after-create
       category: error-handling
       pattern: >-
@@ -2811,6 +3888,9 @@ rules:
         After calling a function that returns a struct pointer and error, verify the pointer is non-nil and its critical fields are populated before dereferencing — even when err is nil. Providers may return (nil, nil) or partially-populated structs. Treat unexpected nil/empty results as an error path (log + escalate).
       source: copilot:PR#457
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: clear-retry-on-success
       category: error-handling
       pattern: >-
@@ -2819,6 +3899,9 @@ rules:
         When a retried operation finally succeeds or the result already exists (e.g. ErrPRAlreadyExists), verify that retry state is explicitly cleared (e.g. ClearRetry) so the item does not remain stuck in a needs_human or needs_attention state
       source: copilot:PR#457
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: context-timeout-propagation
       category: concurrency
       pattern: >-
@@ -2827,6 +3910,9 @@ rules:
         Verify that operations with potentially long durations (API calls, PR creation, CI interactions) use a dedicated context with an appropriate timeout rather than inheriting a short-lived parent context that could cause the operation to fail and reintroduce the problem it was meant to fix
       source: copilot:PR#457
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ahead-check-must-use-actual-base
       category: other
       pattern: >-
@@ -2835,6 +3921,9 @@ rules:
         Verify that ahead-of-base detection uses the actual target base branch (e.g. bead.EpicBranch for crucible children) rather than hardcoding origin/main. Comparing against the wrong base can misclassify branches as ahead when they are fully merged into their real base, causing spurious PR creation and needs_human escalation.
       source: copilot:PR#457
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-preexisting-state-cleanup
       category: testing
       pattern: Tests for recovery/retry logic that creates or modifies retry/state records
@@ -2842,6 +3931,9 @@ rules:
         Verify tests include a scenario where pre-existing state (e.g. a retries row with needs_human=1 from a prior failure) is properly cleaned up after successful recovery, not just that new happy/sad paths work from a clean slate
       source: copilot:PR#457
       added: "2026-03-25"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: zip-entry-type-check
       category: security
       pattern: >-
@@ -2850,6 +3942,9 @@ rules:
         When extracting from a zip archive, verify that the matched zip.File entry is a regular file (not a directory or symlink) before copying its contents — otherwise you may silently install an empty or malicious file
       source: copilot:PR#461
       added: "2026-03-26"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tar-entry-type-check
       category: security
       pattern: Extracting files from tar archives by matching on file name or path
@@ -2857,6 +3952,9 @@ rules:
         Verify that the code checks the entry type flag (e.g., tar.TypeReg) and rejects directories, symlinks, and other non-regular file types before extracting — otherwise a malicious archive could write empty files or create symlinks to arbitrary paths
       source: copilot:PR#461
       added: "2026-03-26"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-assert-meaningful-values
       category: testing
       pattern: >-
@@ -2865,6 +3963,9 @@ rules:
         Verify that tests assert meaningful content of generated values, not just that they are non-empty. For platform/environment-dependent outputs, assert that relevant runtime values (e.g., GOOS, GOARCH) appear in the result so the test would catch regressions where those fields are omitted.
       source: copilot:PR#461
       added: "2026-03-26"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: exec-error-type-narrowing
       category: error-handling
       pattern: >-
@@ -2873,6 +3974,9 @@ rules:
         Verify the error override is narrowed to the specific expected failure mode (e.g. *exec.ExitError with a particular ExitCode) and that context errors (ctx.Err()) are not masked. A blanket 'if err != nil but output looks okay' can hide unrelated failures such as binary-not-found, permission denied, or context cancellation.
       source: copilot:PR#463
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: new-exec-paths-need-tests
       category: testing
       pattern: >-
@@ -2881,6 +3985,9 @@ rules:
         Verify that new execution paths with conditional success/failure logic have unit test coverage for both the success case and the error/failure case, especially when reinterpreting non-zero exit codes as success
       source: copilot:PR#463
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hide-window-subprocess
       category: ui
       pattern: >-
@@ -2889,6 +3996,9 @@ rules:
         Verify that all exec.Command/exec.CommandContext calls for git, gh, bd, and other subprocesses use executil.HideWindow (or equivalent) to prevent flashing a console window on Windows, and include a context/timeout where feasible
       source: ['copilot:PR#464', 'copilot:PR#521', 'copilot:PR#525']
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-external-ref-url-construction
       category: security
       pattern: >-
@@ -2897,6 +4007,9 @@ rules:
         Verify that any external string used to construct a URL is validated (e.g. digits-only for issue numbers, reasonable length) and/or URL-escaped before interpolation, to prevent malformed URLs or injection into terminal escape sequences (OSC 8)
       source: copilot:PR#464
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: terminal-escape-injection
       category: security
       pattern: String interpolation into terminal escape sequences (OSC 8, CSI, etc.)
@@ -2904,6 +4017,9 @@ rules:
         Verify that any user-controlled or external strings embedded in terminal escape sequences are sanitized to reject ASCII control characters (0x00–0x1F, 0x7F). Fall back to plain text when inputs contain unsafe characters to prevent terminal escape injection.
       source: copilot:PR#464
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ipc-response-error-check
       category: error-handling
       pattern: >-
@@ -2912,6 +4028,9 @@ rules:
         Verify that after an IPC Send call, the code checks both the returned error AND the response type (e.g. resp.Type == "error"). A nil error only means the message was delivered, not that the command succeeded. Extract and surface any error message from resp.Payload so the user sees accurate feedback.
       source: copilot:PR#467
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ipc-socket-exists-stale
       category: error-handling
       pattern: Code that calls ipc.SocketExists() to determine daemon availability
@@ -2919,6 +4038,9 @@ rules:
         Verify that daemon availability is determined by actually attempting a connection (ipc.NewClient()) rather than just checking if the socket file exists, since stale socket files can persist after crashes and give false positives
       source: copilot:PR#467
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: surface-scan-errors-on-no-results
       category: error-handling
       pattern: >-
@@ -2927,6 +4049,9 @@ rules:
         When aggregating results from multiple operations, verify that the 'no results' path distinguishes between 'nothing found' and 'all operations failed'. Track whether at least one operation succeeded; if none did and errors occurred, propagate the error instead of silently returning a zero value.
       source: copilot:PR#467
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: creation-error-propagation
       category: error-handling
       pattern: >-
@@ -2935,6 +4060,9 @@ rules:
         Verify that creation/mutation functions propagate errors (returning (result, error) or at minimum a success flag) rather than relying on a follow-up query to detect failure — otherwise error messages will be misleading when creation silently fails
       source: copilot:PR#467
       added: "2026-03-27"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: phase-list-backward-compat
       category: backward-compatibility
       pattern: Removing entries from phase/status constant lists or filter sets
@@ -2942,6 +4070,9 @@ rules:
         Verify that removing a phase or status value from a filter list won't break backward compatibility for users upgrading from older versions that may have persisted records with that value. Consider keeping deprecated values in exclusion lists or adding a DB migration to clean up lingering records.
       source: copilot:PR#466
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: remove-stale-references-after-flow-deletion
       category: backward-compatibility
       pattern: >-
@@ -2950,6 +4081,9 @@ rules:
         When removing a flow or feature, verify that all reference lists (e.g. phase arrays, enums, constants, doc comments) are updated to either remove the deleted item or clearly mark it as legacy with an explanation of why it is retained (e.g. backward compatibility with existing DB rows)
       source: copilot:PR#466
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-configured-dispatch-label
       category: style
       pattern: >-
@@ -2958,6 +4092,9 @@ rules:
         Verify that references to the auto-dispatch label use the configured value (auto_dispatch_tag) rather than hardcoding a specific label name, since each anvil can configure its own dispatch label and dispatch checks are case-insensitive
       source: copilot:PR#471
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-hardcoded-config-refs
       category: style
       pattern: >-
@@ -2966,6 +4103,9 @@ rules:
         Verify that comments, docs, changelog entries, and user-facing messages refer to configurable values generically (e.g. "the anvil's configured auto-dispatch label") rather than hardcoding a specific default name that may not match the user's configuration. If mentioning a default, clearly label it as an example only (e.g. 'for example, the default label "forgeReady"') and still describe behavior in terms of the configured value.
       source: copilot:PR#471
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: dispatch-mode-awareness
       category: style
       pattern: >-
@@ -2974,6 +4114,9 @@ rules:
         Verify that descriptions of dispatch/tagging behavior account for all configured auto_dispatch modes (e.g. 'tagged' vs 'all'), not just one mode. Wording should not imply a label gate when auto_dispatch:all would bypass it.
       source: copilot:PR#471
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: url-shortening-scope
       category: security
       pattern: >-
@@ -2982,6 +4125,9 @@ rules:
         Verify that URL shortening/rewriting logic is scoped to known supported hosts (e.g. github.com) by parsing with net/url and inspecting host + path segments, rather than applying broad pattern matching to arbitrary URLs. Non-matching URLs should be returned verbatim.
       source: copilot:PR#472
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: shared-display-formatting
       category: ui
       pattern: >-
@@ -2990,6 +4136,9 @@ rules:
         Verify that display formatting functions are shared/reused across all views that render the same data (e.g., list view and detail view), rather than duplicated or reimplemented independently, to prevent divergence
       source: copilot:PR#472
       added: "2026-03-28"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bubbletea-blocking-in-update
       category: ui
       pattern: >-
@@ -2998,6 +4147,10 @@ rules:
         Verify that no blocking operations (clipboard.WriteAll, exec.Command, HTTP calls, file I/O) run synchronously in Update. They should be wrapped in a tea.Cmd function that returns a tea.Msg, so the event loop stays responsive and the UI does not freeze.
       source: copilot:PR#475
       added: "2026-03-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
     - id: ipc-command-test-coverage
       category: testing
       pattern: A new IPC command type is added to the daemon's handleIPC function
@@ -3005,6 +4158,9 @@ rules:
         Verify that the appropriate internal/daemon/*_test.go file(s) or the package's existing IPC test suite include tests for the new IPC command, covering both the error/unavailable path and the success/ok path to maintain consistent test coverage across the IPC surface
       source: copilot:PR#488
       added: "2026-03-31"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: deterministic-query-result-selection
       category: other
       pattern: >-
@@ -3013,6 +4169,9 @@ rules:
         When selecting a single record from a query that could return multiple matches, verify the selection is deterministic. If ordering is not guaranteed by the query, sort by a stable key (e.g., updated_at, created_at, or ID) and explicitly handle the multiple-match case with logging. Returning an arbitrary match can cause silent data inconsistencies.
       source: copilot:PR#490
       added: "2026-03-31"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: tracked-goroutine-consistency
       category: concurrency
       pattern: >-
@@ -3021,6 +4180,9 @@ rules:
         When a goroutine is tracked via WaitGroup for shutdown/test synchronization, verify that ALL call sites launching that same goroutine are tracked consistently, otherwise WaitGroup.Wait behavior will differ depending on which code path triggered the goroutine
       source: copilot:PR#490
       added: "2026-03-31"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stale-cached-fields
       category: other
       pattern: >-
@@ -3029,6 +4191,9 @@ rules:
         Verify that cached or backfilled fields are updated whenever the upstream value changes, not only when the local value is empty. A write-once guard can cause stale data if the source value is later renamed, corrected, or updated.
       source: copilot:PR#491
       added: "2026-03-31"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: timestamp-string-comparison
       category: other
       pattern: >-
@@ -3037,6 +4202,9 @@ rules:
         Verify that timestamp comparisons parse strings into time.Time (or equivalent) before comparing, rather than relying on raw string ordering which breaks with varying formats or timezones
       source: copilot:PR#491
       added: "2026-03-31"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: unbounded-event-scan
       category: performance
       pattern: >-
@@ -3045,6 +4213,9 @@ rules:
         Verify that queries needing the latest (or aggregated) row per group use window functions (ROW_NUMBER() OVER PARTITION BY) or GROUP BY with MAX/MIN in SQL rather than fetching all rows and filtering in application code, especially for tables that grow unboundedly or are queried on a recurring timer
       source: copilot:PR#492
       added: "2026-03-31"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-env-isolation
       category: testing
       pattern: >-
@@ -3053,6 +4224,9 @@ rules:
         Verify the test is deterministic by redirecting environment-dependent paths (HOME, USERPROFILE, XDG_CONFIG_HOME, APPDATA) to a temp directory or by injecting/mocking the dependency, so results don't vary based on the machine's real filesystem state
       source: copilot:PR#494
       added: "2026-04-04"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: consistent-struct-field-propagation
       category: style
       pattern: >-
@@ -3061,6 +4235,9 @@ rules:
         When a struct field is added or changed in one construction site, verify that all other construction sites for the same struct type also include the field so behavior is consistent across all code paths
       source: copilot:PR#496
       added: "2026-04-05"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-worker-pid-from-state
       category: security
       pattern: >-
@@ -3069,6 +4246,9 @@ rules:
         Verify that process IDs are looked up from trusted internal state (e.g. state.db worker rows) rather than accepted directly from client input. Client-supplied PIDs must be validated against the recorded PID for the corresponding worker, and the request must be rejected if the worker is not found or the PID mismatches, to prevent signaling arbitrary processes.
       source: copilot:PR#497
       added: "2026-04-07"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: process-group-signal-safety
       category: security
       pattern: Sending signals to negated PID (-pid) to target a process group
@@ -3076,6 +4256,9 @@ rules:
         Verify that the process group ID matches the PID before signaling -pid. Call syscall.Getpgid(pid) to confirm pgid==pid, and fall back to signaling the single PID when the PGID cannot be determined or does not match, to avoid killing unrelated processes after PID reuse.
       source: copilot:PR#497
       added: "2026-04-07"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: verify-process-exit-after-kill
       category: concurrency
       pattern: >-
@@ -3084,6 +4267,9 @@ rules:
         After escalating to a forceful kill signal, verify the process has actually exited (e.g., poll kill(pid,0) or waitpid for a short window) before updating persistent state to reflect termination. Log or return an error if the process remains alive to avoid zombie processes with stale DB status.
       source: copilot:PR#497
       added: "2026-04-07"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: windows-process-group-kill
       category: other
       pattern: >-
@@ -3092,6 +4278,9 @@ rules:
         Verify that process/process-group termination logic works correctly on Windows (no SIGINT, no Unix process groups). Either implement Windows-specific termination (job objects, GenerateConsoleCtrlEvent) or clearly document and handle the platform gap — do not imply cross-platform process-tree kill support that only works on Unix.
       source: copilot:PR#497
       added: "2026-04-07"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sysprocattr-merge
       category: other
       pattern: >-
@@ -3100,6 +4289,9 @@ rules:
         Verify that helpers which modify SysProcAttr merge into any existing SysProcAttr rather than overwriting it, so that flags set by earlier callers (e.g. CreationFlags, HideWindow, CREATE_NEW_PROCESS_GROUP) are preserved
       source: copilot:PR#497
       added: "2026-04-07"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-accuracy-config-semantics
       category: documentation
       pattern: >-
@@ -3108,6 +4300,8 @@ rules:
         Verify that documentation accurately reflects the actual implementation semantics — e.g. whether a config field is shared across components or scoped to one, and what its fallback behavior is. Cross-reference with the source code or canonical docs (like docs/providers.md) rather than assuming.
       source: copilot:PR#500
       added: "2026-04-09"
+      paths:
+        - '**/*.md'
     - id: follow-up-tracking
       category: documentation
       pattern: >-
@@ -3116,6 +4310,8 @@ rules:
         Verify that listed follow-up items have corresponding bead IDs from `bd create`, or if beads were not created, that the document includes the exact `bd create` commands to run
       source: copilot:PR#500
       added: "2026-04-09"
+      paths:
+        - '**/*.md'
     - id: trim-whitespace-inputs
       category: error-handling
       pattern: >-
@@ -3124,6 +4320,9 @@ rules:
         Verify that string inputs destined for command execution are trimmed with strings.TrimSpace (or equivalent) and that whitespace-only values are treated as empty/unset, not passed through as valid commands
       source: copilot:PR#501
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: temper-yaml-scope-accuracy
       category: documentation
       pattern: >-
@@ -3132,6 +4331,9 @@ rules:
         Verify that references to .forge/temper.yaml accurately reflect its supported features (currently only go_race_detection). Do not suggest it as a solution for custom commands, shell features, or environment variables. Instead, recommend wrapper scripts or explicit shell invocation (e.g., sh -c '...').
       source: copilot:PR#501
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: docstring-matches-behavior
       category: documentation
       pattern: >-
@@ -3140,6 +4342,9 @@ rules:
         Verify that docstrings accurately describe the actual implementation behavior — e.g., if setting any field disables all defaults, don't say each field independently replaces its corresponding step. Also verify that any referenced files or escape hatches actually exist and support the described usage.
       source: copilot:PR#501
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: safety-check-errors-must-fail
       category: error-handling
       pattern: >-
@@ -3148,6 +4353,9 @@ rules:
         When a safety-critical validation step returns an error, verify the pipeline treats it as a hard failure (retry or abort) rather than logging and proceeding, which would silently bypass the safety guarantee
       source: copilot:PR#502
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: reset-must-include-remote
       category: error-handling
       pattern: >-
@@ -3156,6 +4364,9 @@ rules:
         Verify that when a local branch is reset to undo unwanted commits, the corresponding remote branch is also rewound or deleted. Otherwise the remote retains the violating commits, causing non-fast-forward errors on subsequent pushes and potentially leaking denied changes.
       source: copilot:PR#502
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-path-not-filepath-for-git-paths
       category: security
       pattern: >-
@@ -3164,6 +4375,9 @@ rules:
         Git always produces forward-slash paths. Using filepath.Match/filepath.Base will silently fail on Windows because filepath uses OS-native separators. Use path.Match/path.Base (package "path") or manual slash splitting for git-originated paths to ensure consistent cross-platform behavior.
       source: copilot:PR#502
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: filepath-match-non-path-strings
       category: security
       pattern: >-
@@ -3172,6 +4386,9 @@ rules:
         Verify that filepath.Match is only used for actual file paths. For non-path strings (e.g. command lines), use a matcher that does not special-case '/' as a separator, since '*' in filepath.Match won't match across '/' on Unix, leading to surprising behavior with patterns like 'rm -rf /*'
       source: copilot:PR#502
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: post-execution-safety-docs
       category: security
       pattern: >-
@@ -3180,6 +4397,9 @@ rules:
         Verify that documentation and naming do not imply pre-execution prevention when the mechanism actually detects violations after the fact. Terms like 'prevent' or 'block' should be replaced with 'detect and reject' or similar language that accurately describes post-execution enforcement.
       source: copilot:PR#502
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: explicit-config-gating
       category: other
       pattern: >-
@@ -3188,6 +4408,9 @@ rules:
         Verify that optional override fields (e.g. stage-specific provider chains) are only populated when the corresponding configuration key is explicitly set by the user; do not fill them with resolved defaults/fallbacks, as this silently disables legacy fallback paths that check for empty values
       source: copilot:PR#503
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-provider-slice-guard
       category: error-handling
       pattern: >-
@@ -3196,6 +4419,9 @@ rules:
         After filtering a provider chain (especially Copilot quota filtering), verify the resulting slice is non-empty before indexing into it. If it can be empty, add a fallback to provider.Defaults() or treat it as a dispatch failure with a clear log/event rather than risking a panic on an empty slice index.
       source: copilot:PR#503
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stage-specific-variable-naming
       category: style
       pattern: >-
@@ -3204,6 +4430,9 @@ rules:
         Verify that variable names accurately reflect the pipeline stage they belong to — e.g. provider chains resolved for the schematic stage should not be named with a smith prefix, and vice versa
       source: copilot:PR#503
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hotreload-per-anvil-field-comparison
       category: other
       pattern: Adding a new per-anvil configuration field
@@ -3211,6 +4440,9 @@ rules:
         Verify that the hot-reload per-anvil comparison loop includes the new field so that changes to it trigger a config reload
       source: copilot:PR#503
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stage-config-round-trip-tests
       category: testing
       pattern: Adding new fields to config structs that use custom MarshalYAML/UnmarshalYAML
@@ -3218,6 +4450,9 @@ rules:
         Verify that Save→Load round-trip tests cover the new fields, especially when the struct has custom YAML marshaling that could silently drop or mangle new fields
       source: copilot:PR#503
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hook-env-on-skip-path
       category: error-handling
       pattern: A lifecycle hook is executed after a stage that can be conditionally skipped
@@ -3225,6 +4460,9 @@ rules:
         Verify that hook environment variables (stage name, iteration, etc.) are explicitly populated even when the associated stage is skipped, so hooks always receive correct metadata
       source: copilot:PR#504
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-secrets-in-logs
       category: security
       pattern: Logging command strings, raw subprocess output, or environment variables
@@ -3232,6 +4470,9 @@ rules:
         Verify that log output does not include full command strings (which may contain embedded secrets like tokens or webhook URLs) or unsanitized subprocess stdout/stderr. Log only identifiers (e.g. hook name, exit status) and gate verbose output behind a debug flag.
       source: copilot:PR#504
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cross-platform-shell-tests
       category: testing
       pattern: >-
@@ -3240,6 +4481,9 @@ rules:
         Verify that tests using shell command strings are cross-platform: if shellArgs() or similar uses cmd /c on Windows, POSIX syntax ($VAR, >, >>) won't work. Either make command strings conditional on runtime.GOOS (e.g. %VAR% for cmd) or skip shell-dependent assertions on Windows.
       source: copilot:PR#504
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: go-import-sort-order
       category: style
       pattern: Go import blocks where standard library packages are not in gofmt-sorted order
@@ -3247,6 +4491,9 @@ rules:
         Verify that all Go import blocks are sorted according to gofmt conventions (alphabetical within each group)
       source: copilot:PR#504
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: iteration-env-var-accuracy
       category: other
       pattern: >-
@@ -3255,6 +4502,9 @@ rules:
         Verify that FORGE_ITERATION reflects the actual iteration context: stages outside the Smith-Warden loop (e.g., schematic) should either use a sentinel value (0) or the docs should clearly state what value they receive
       source: copilot:PR#504
       added: "2026-04-09"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: terminology-consistency
       category: style
       pattern: >-
@@ -3263,6 +4513,9 @@ rules:
         Verify that all references to renamed packages use the new names consistently throughout docs and comments (e.g. use 'quench/burnish' not 'cifix/reviewfix' when referring to worker names)
       source: copilot:PR#505
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: narrow-error-tolerance
       category: error-handling
       pattern: >-
@@ -3271,6 +4524,9 @@ rules:
         Verify that error tolerance is narrowed to specific exit-status errors (e.g., *exec.ExitError) and not broadly ignoring all errors, which could mask timeouts, context cancellations, or other execution failures. Check that context errors (ctx.Err()) are not suppressed.
       source: copilot:PR#507
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nil-error-wrap
       category: error-handling
       pattern: Using fmt.Errorf with %w to wrap an error variable that may be nil
@@ -3278,6 +4534,9 @@ rules:
         Verify that when using %w in fmt.Errorf, the wrapped error is guaranteed to be non-nil. Wrapping a nil error with %w returns nil, silently discarding the intended error message and any side effects. If the error may be nil, either guard with a nil check, use a concrete error value, or use a non-wrapping format verb.
       source: copilot:PR#509
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: decode-json-preserve-underlying-error
       category: error-handling
       pattern: >-
@@ -3286,6 +4545,9 @@ rules:
         When a JSON decoding utility fails, verify it returns or wraps the underlying decode error from the best attempt rather than a generic message. Only use a generic 'no valid JSON found' error when the input truly contains no plausible JSON start.
       source: copilot:PR#509
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-matches-code
       category: style
       pattern: >-
@@ -3294,6 +4556,9 @@ rules:
         Verify that comments accurately reflect the actual values or constants used in the code. When a constant, timeout, or numeric value is changed, ensure all nearby comments referencing the old value are updated to match. This applies to all numeric literals — timeouts, limits, thresholds, iteration counts, and similar quantities.
       source: copilot:PR#511
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: consistent-timeout-coverage
       category: concurrency
       pattern: >-
@@ -3302,6 +4567,9 @@ rules:
         When introducing a standardized timeout (or any uniform policy) for external subprocess invocations, verify that ALL call sites are updated—not just the ones touched by the current change. Audit the codebase for remaining callers that still use a raw context or ad-hoc timeout, and either migrate them or explicitly document why they are excluded.
       source: copilot:PR#511
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-dummy-import-suppressor
       category: style
       pattern: >-
@@ -3310,6 +4578,9 @@ rules:
         Verify that every import is actually used in meaningful code. If an import is only kept alive by a dummy reference (e.g. `var _ = time.Second`), remove both the unused import and the suppressor variable.
       source: copilot:PR#514
       added: "2026-04-10"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: hook-env-anvil-path
       category: other
       pattern: HookEnv struct literal or hook invocation where AnvilPath may be unset
@@ -3317,6 +4588,9 @@ rules:
         Verify that HookEnv always populates AnvilPath so FORGE_ANVIL_PATH is available to hook scripts. When adding new call sites that construct HookEnv (especially in batched or alternative code paths like BatchFix), ensure AnvilPath is threaded through from the caller and set consistently with the primary pipeline path.
       source: copilot:PR#515
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-hook-integration-in-fix-functions
       category: testing
       pattern: >-
@@ -3325,6 +4599,9 @@ rules:
         When adding hook callbacks around core operations, verify that tests actually invoke the outer function (e.g. Fix/Run) end-to-end—not just stub the hook and assert its fields. Tests should confirm: (1) the before_* hook runs before the operation and aborts on error, (2) the after_* hook error is non-fatal, and (3) ordering is correct across all invocations of the wrapped operation within the function. Consider introducing a package-level function variable (e.g. temperRunFn) to make the inner operation stubbable for unit tests.
       source: copilot:PR#515
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: guard-flag-without-feature
       category: error-handling
       pattern: >-
@@ -3333,6 +4610,9 @@ rules:
         When a boolean flag enables/requires a feature, verify the config validates that the corresponding feature is actually configured — otherwise the flag is silently ignored, masking misconfiguration
       source: copilot:PR#516
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: temper-config-doc-accuracy
       category: documentation
       pattern: >-
@@ -3341,6 +4621,9 @@ rules:
         Verify that documentation about temper configuration accurately reflects implementation behavior. Specifically, ensure docs clarify that only temper.build, temper.test, and temper.lint commands trigger replacement of auto-detected steps — modifier-only fields like lint_required do not replace auto-detection by themselves and only affect their corresponding command when it is explicitly configured.
       source: copilot:PR#516
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: trim-whitespace-validation
       category: error-handling
       pattern: Validation that checks for empty strings on user-provided configuration values
@@ -3348,6 +4631,9 @@ rules:
         Verify that string validation uses strings.TrimSpace before checking emptiness, so whitespace-only values are rejected. Also use the trimmed value for any uniqueness/duplicate checks.
       source: copilot:PR#517
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: reject-negative-timeout
       category: error-handling
       pattern: Parsing or accepting duration/timeout values from configuration
@@ -3355,6 +4641,9 @@ rules:
         Verify that negative durations are rejected during config validation. Negative durations parse successfully but cause context.WithTimeout to fire immediately, which is surprising at runtime. Zero should be allowed as a sentinel for 'use default'.
       source: copilot:PR#517
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: trim-config-strings
       category: error-handling
       pattern: >-
@@ -3363,6 +4652,9 @@ rules:
         Verify that string fields parsed from configuration (names, commands, paths, directories) are trimmed with strings.TrimSpace before use, to prevent confusing runtime failures from leading/trailing whitespace
       source: copilot:PR#517
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-name-matches-behavior
       category: testing
       pattern: >-
@@ -3371,6 +4663,9 @@ rules:
         Verify that test names accurately describe what the test asserts. If a test is named after a behavioral scenario (e.g. 'StopsOnRequiredFailure'), it should exercise that behavior end-to-end, not just check a precondition. Either rename the test to match what it actually checks or extend it to verify the claimed behavior.
       source: copilot:PR#517
       added: "2026-04-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: stale-changed-files-across-iterations
       category: concurrency
       pattern: >-
@@ -3379,6 +4674,11 @@ rules:
         Verify that any derived/computed data used inside a retry or iteration loop is recomputed each iteration rather than cached from the first pass. In particular, when a pipeline re-runs Smith and then Temper, the changed-file list must be refreshed so that step-skip decisions reflect all commits, not just the initial diff.
       source: copilot:PR#519
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+        - '**/*.sum'
     - id: base-branch-fallback-consistency
       category: error-handling
       pattern: >-
@@ -3387,6 +4687,11 @@ rules:
         Verify that the base branch resolution logic matches how the worktree or VCS layer detects the default branch (e.g. checking origin/main then origin/master), rather than hardcoding a fallback that may silently fail on repos with a different default branch
       source: copilot:PR#519
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+        - '**/*.sum'
     - id: handle-glob-match-errors
       category: error-handling
       pattern: >-
@@ -3395,6 +4700,11 @@ rules:
         Verify that pattern matching errors are not silently ignored. Invalid patterns should either be validated upfront and surfaced as configuration errors, or the error should be logged and the match treated as true (fail-open) so that the guarded action still runs rather than being silently skipped.
       source: copilot:PR#519
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+        - '**/*.sum'
     - id: git-commands-need-context-and-error-propagation
       category: error-handling
       pattern: >-
@@ -3403,6 +4713,11 @@ rules:
         Verify that git subprocess calls accept a context.Context (or enforce a bounded timeout) and propagate errors to the caller instead of swallowing them, so pipelines cannot hang and callers can distinguish 'no results' from 'command failed'
       source: copilot:PR#519
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+        - '**/*.sum'
     - id: cli-doc-required-flags
       category: documentation
       pattern: CLI quick-reference or usage documentation that shows command syntax
@@ -3410,6 +4725,8 @@ rules:
         Verify that all required flags (especially --anvil) are included in documented command examples so that copy-paste usage works without runtime errors
       source: copilot:PR#520
       added: "2026-04-13"
+      paths:
+        - '**/*.md'
     - id: doc-provider-fallback-accuracy
       category: documentation
       pattern: >-
@@ -3418,6 +4735,8 @@ rules:
         Verify that documented provider fallback chains match the actual resolution order in ProvidersForStageWithAnvil: smith/warden/schematic fall back through anvil stage_providers → global stage_providers → smith_providers → providers, while cifix/reviewfix skip smith_providers and fall back through anvil stage_providers → global stage_providers → providers
       source: copilot:PR#520
       added: "2026-04-13"
+      paths:
+        - '**/*.md'
     - id: deny-patterns-flow-position
       category: documentation
       pattern: >-
@@ -3426,6 +4745,8 @@ rules:
         Verify that deny_patterns validation is shown AFTER the Smith stage (post-Smith output/diff) and BEFORE Temper, not before Smith. The actual implementation in internal/pipeline/pipeline.go runs deny-pattern checks as Step 2.5 between Smith and Temper.
       source: copilot:PR#520
       added: "2026-04-13"
+      paths:
+        - '**/*.md'
     - id: lstat-non-existence-check
       category: error-handling
       pattern: >-
@@ -3434,6 +4755,9 @@ rules:
         When checking if a path exists with os.Lstat/os.Stat, verify that errors other than IsNotExist are handled explicitly and returned early, rather than falling through to creation logic that would produce misleading errors or inconsistent state
       source: ['copilot:PR#521', 'copilot:PR#540']
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-accuracy
       category: style
       pattern: Code comments describing fallback behavior or error handling of other components
@@ -3441,6 +4765,9 @@ rules:
         Verify that comments accurately describe the actual behavior of the referenced component. Do not claim a specific fallback exists (e.g., 'temper will fall back to npm ci') unless the referenced code actually implements that fallback. Use neutral language like 'steps may fail/skip' when the outcome depends on external state.
       source: copilot:PR#521
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: external-ref-format-assumption
       category: style
       pattern: >-
@@ -3449,6 +4776,9 @@ rules:
         Verify that code handling external references (like issue tracker IDs) accounts for multiple formats (shorthand like gh-42, full URLs, non-GitHub references like jira-123) rather than assuming a single format. Prompt guidance should only use GitHub-specific closing keywords when the reference is confirmed to be a GitHub issue.
       source: copilot:PR#522
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-prompt-fields
       category: testing
       pattern: >-
@@ -3457,6 +4787,9 @@ rules:
         Verify that new prompt fields have corresponding tests asserting the output appears when the field is set and is omitted when empty or unset
       source: copilot:PR#522
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: accurate-field-comments
       category: style
       pattern: >-
@@ -3465,6 +4798,9 @@ rules:
         Verify that comments describing field formats accurately reflect all possible values passed through from the upstream source, not just one common case. Avoid narrowing the description to a single format (e.g. 'GitHub issue URL') when the field can carry multiple formats (e.g. shorthand like 'gh-42', full URLs, or non-GitHub references).
       source: copilot:PR#522
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-avoid-format-assumptions
       category: style
       pattern: >-
@@ -3473,6 +4809,9 @@ rules:
         Verify that descriptions of field values do not over-specify or assume a particular format. Use generic terms (e.g. 'external reference') instead of format-specific ones (e.g. 'GitHub issue URL') unless the format is guaranteed by the schema.
       source: copilot:PR#522
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-specific-rule-categories
       category: style
       pattern: "Adding or modifying warden rules with category: other"
@@ -3480,6 +4819,8 @@ rules:
         Verify that the rule category is as specific as possible rather than defaulting to 'other'. Documentation-focused rules should use 'documentation', concurrency rules should use 'concurrency', etc. Generic categories reduce the value of triage and search filtering.
       source: ['copilot:PR#518', 'copilot:PR#529']
       added: "2026-04-13"
+      paths:
+        - '**/*.yaml'
     - id: github-issue-url-host-validation
       category: security
       pattern: Extracting issue numbers from URLs using regex without validating the hostname
@@ -3487,6 +4828,9 @@ rules:
         When parsing an external_ref or URL to extract a GitHub issue number, verify the hostname belongs to github.com before using the number. A bare regex like `/issues/(\d+)` matches any host (GitLab, example.com, etc.) and could inject incorrect 'Closes #N' directives that close the wrong issue.
       source: copilot:PR#523
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-decodejson-for-bd-output
       category: error-handling
       pattern: >-
@@ -3495,6 +4839,9 @@ rules:
         Verify that executil.DecodeJSON is used instead of json.Unmarshal when parsing bd subprocess output, as bd may emit leading/trailing diagnostic noise that raw json.Unmarshal cannot tolerate. Also ensure both array and object JSON forms are handled.
       source: copilot:PR#523
       added: "2026-04-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: single-source-of-truth-for-ids
       category: style
       pattern: >-
@@ -3503,6 +4850,9 @@ rules:
         Verify that identifiers and metadata are not duplicated across nesting levels. Keep canonical fields at one level only (prefer the outer/top-level struct) to avoid divergence between two sources of truth.
       source: copilot:PR#524
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-correlation-ids
       category: error-handling
       pattern: >-
@@ -3511,6 +4861,9 @@ rules:
         Verify that request/correlation ID parameters are validated as non-empty before use, especially when the struct field is tagged with omitempty which would silently drop the field from serialized output and break request-response correlation
       source: copilot:PR#524
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-channel-receive-timeout
       category: testing
       pattern: >-
@@ -3519,6 +4872,9 @@ rules:
         Verify that channel receives in tests use a select with time.After (or context deadline) so a regression causes a bounded, debuggable failure instead of hanging until the global test timeout
       source: copilot:PR#524
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: error-msg-matches-command
       category: error-handling
       pattern: Error messages that reference CLI commands or flags
@@ -3526,6 +4882,9 @@ rules:
         Verify that error messages exactly match the actual CLI command and flags being invoked, so that troubleshooting output is accurate and consistent with the code
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-anvil-path-before-use
       category: error-handling
       pattern: >-
@@ -3534,6 +4893,9 @@ rules:
         Verify that the anvil's Path field is validated as non-empty before use. If other similar handlers return an error for a missing path, this one must too, to avoid running commands in an unexpected working directory.
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: nil-field-panic-on-struct-literal
       category: error-handling
       pattern: >-
@@ -3542,6 +4904,9 @@ rules:
         Verify that new required fields are either defensively nil-checked before use, lazily initialized on first access, or stored by value so that direct struct-literal construction does not panic
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: log-failed-async-completion
       category: error-handling
       pattern: Calling RequestTracker.Complete or similar boolean-returning completion methods
@@ -3549,6 +4914,9 @@ rules:
         Verify that the boolean result of async completion calls is checked and that a warning is logged when it returns false, so silent drops of unknown/duplicate request IDs are surfaced for debugging
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: async-event-include-response-payload
       category: ui
       pattern: Broadcasting async completion events after background IPC operations finish
@@ -3556,6 +4924,9 @@ rules:
         Verify that async completion events include the full response payload (or at least a user-facing message and error context), not just the request_id and type. Clients like Hearth need actionable details to display success/error outcomes to the user.
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: assert-correlation-fields
       category: testing
       pattern: >-
@@ -3564,6 +4935,9 @@ rules:
         When testing async or queued responses, verify that correlation fields (e.g. RequestID) are non-empty, not just the response type. A queued response without a usable request ID is a regression that type-only assertions won't catch.
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: async-queued-response-request-id
       category: testing
       pattern: "Test assertions on IPC responses that return type \"queued\""
@@ -3571,6 +4945,9 @@ rules:
         Verify that tests for queued IPC responses assert RequestID is non-empty, ensuring clients can correlate the eventual async completion
       source: copilot:PR#525
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ctx-cancel-blocked-read
       category: concurrency
       pattern: >-
@@ -3579,6 +4956,9 @@ rules:
         Verify that context cancellation can actually unblock a pending read. If the read has no deadline (or a very long one), a cancelled context will not be observed until the next successful read, leaking the goroutine/connection. Ensure a mechanism exists to unblock the read on ctx.Done() — e.g., a helper goroutine that closes the connection or sets an immediate read deadline when the context is cancelled.
       source: copilot:PR#526
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: centralize-quit-cleanup
       category: concurrency
       pattern: Multiple code paths return tea.Quit or terminate the application
@@ -3586,6 +4966,9 @@ rules:
         Verify that all quit/exit paths perform the same cleanup (closing subscriptions, IPC connections, goroutines) rather than only the main quit handler. Centralize shutdown logic so early-return quit paths do not skip resource cleanup.
       source: copilot:PR#526
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-duplicate-git-pointer-parsing
       category: style
       pattern: >-
@@ -3594,6 +4977,9 @@ rules:
         Extract a shared helper for parsing and validating .git file gitdir pointers instead of duplicating the read-parse-resolve-stat logic in multiple functions
       source: copilot:PR#527
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: retry-directory-removal
       category: error-handling
       pattern: os.RemoveAll used to delete worktree or temporary directories
@@ -3601,6 +4987,9 @@ rules:
         Verify that directory removal uses retry-with-backoff rather than a single os.RemoveAll call, especially on Windows where file locking can cause transient deletion failures. If cleanup fails after retries, the operation should fail rather than proceeding with a stale directory.
       source: copilot:PR#527
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: factor-shared-test-setup
       category: testing
       pattern: >-
@@ -3609,6 +4998,9 @@ rules:
         Verify that repeated test setup logic is extracted into a shared test helper function (with t.Helper()) rather than duplicated inline across test cases, to reduce duplication and make future test additions less error-prone
       source: copilot:PR#527
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: smith-spawn-assumes-worktree
       category: error-handling
       pattern: >-
@@ -3617,6 +5009,9 @@ rules:
         Verify that new guards on Smith spawn paths account for all callers, including non-repo contexts (schematic temp dirs, triage temp dirs) where no .git worktree linkage exists. Guards should distinguish 'inside a repo but wrong directory' from 'intentionally not a repo'.
       source: copilot:PR#527
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: context-aware-backoff-sleep
       category: concurrency
       pattern: >-
@@ -3625,6 +5020,9 @@ rules:
         Verify that retry/backoff loops honor context cancellation by using a timer with select on ctx.Done() instead of bare time.Sleep, so the operation can abort promptly when the caller's context is cancelled (e.g. during shutdown)
       source: copilot:PR#527
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cleanup-retry-consistency
       category: error-handling
       pattern: >-
@@ -3633,6 +5031,9 @@ rules:
         Verify that cleanup paths reuse existing retry/backoff removal logic instead of single-shot os.RemoveAll, especially on Windows where file locking can cause transient deletion failures
       source: copilot:PR#527
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: windows-junction-detection
       category: other
       pattern: Code that checks for symlinks using os.ModeSymlink on file mode bits
@@ -3640,6 +5041,9 @@ rules:
         Verify that Windows junctions (reparse points) are also detected, not just os.ModeSymlink. On Windows, junctions created with mklink /J do not set ModeSymlink. Use FILE_ATTRIBUTE_REPARSE_POINT via golang.org/x/sys/windows or equivalent platform-specific detection.
       source: copilot:PR#528
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: windows-junction-not-symlink
       category: testing
       pattern: >-
@@ -3648,6 +5052,9 @@ rules:
         On Windows, os.Symlink for directories requires elevated privileges or Developer Mode. Use junctions (mklink /J) instead to match production behavior. Either create a junction on Windows or skip the test with a clear message explaining why.
       source: copilot:PR#528
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-platform-fidelity
       category: testing
       pattern: >-
@@ -3656,6 +5063,9 @@ rules:
         Verify that tests for platform-specific behavior use the actual platform primitive (e.g., junctions on Windows via mklink /J) rather than a cross-platform approximation (e.g., os.Symlink), or clearly document that the test only covers the approximation
       source: copilot:PR#528
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-platform-helpers-for-dir-links
       category: testing
       pattern: >-
@@ -3664,6 +5074,9 @@ rules:
         Verify that tests use platform-appropriate helpers (e.g. createDirLink) instead of os.Symlink directly, so that on Windows the test exercises junction/reparse-point behavior rather than being skipped due to missing symlink privileges
       source: copilot:PR#530
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: swallowed-errors-misleading-handling
       category: error-handling
       pattern: >-
@@ -3672,6 +5085,9 @@ rules:
         Verify that if a caller checks or logs a function's returned error, the function can actually return a meaningful error. Either simplify the call site to ignore the return value, or fix the callee to propagate errors so the handling is actionable.
       source: copilot:PR#530
       added: "2026-04-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-rule-category-consistency
       category: style
       pattern: >-
@@ -3680,6 +5096,8 @@ rules:
         Verify that new warden rules use a category consistent with existing rules that cover the same concern area. Comment-correctness and code-comment alignment rules should use the 'style' category.
       source: copilot:PR#529
       added: "2026-04-15"
+      paths:
+        - '**/*.yaml'
     - id: behavior-flag-needs-test
       category: testing
       pattern: >-
@@ -3688,6 +5106,9 @@ rules:
         Verify that a focused regression test exists asserting the altered behavior when the flag is enabled, covering both the primary path and any reuse/cleanup paths
       source: copilot:PR#531
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: label-update-early-return
       category: other
       pattern: >-
@@ -3696,6 +5117,9 @@ rules:
         Verify that early-return optimizations for unchanged content do not skip applying metadata (labels, tags, status flags) that may not yet be present on the existing record
       source: copilot:PR#531
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: comment-association
       category: style
       pattern: >-
@@ -3704,6 +5128,9 @@ rules:
         Verify that multi-line comments and doc comments are placed directly above the symbol they describe, with no unrelated declarations between the comment and its target
       source: copilot:PR#531
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-duplicate-warn-logging
       category: error-handling
       pattern: >-
@@ -3712,6 +5139,9 @@ rules:
         Verify that internal helper functions do not log warnings/errors themselves when callers already log the returned error. Prefer returning structured detail (exit status, stderr, stdout) so the caller can log once with full context, avoiding duplicate log entries that create operational noise.
       source: copilot:PR#532
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: log-underlying-error
       category: error-handling
       pattern: >-
@@ -3720,6 +5150,9 @@ rules:
         When logging command or operation failures, verify that the underlying Go error is included as a structured field (e.g., slog.String("error", err.Error())) alongside any captured stderr/stdout/exit status, so diagnostics are complete even when the streams are empty
       source: copilot:PR#532
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: preserve-combined-output-in-errors
       category: error-handling
       pattern: >-
@@ -3728,6 +5161,9 @@ rules:
         When changing command execution from CombinedOutput to separate stdout/stderr capture, verify that error messages returned to callers still include both stdout and stderr content, not just stderr, so diagnostics are not lost
       source: copilot:PR#532
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-comment-column-sync
       category: style
       pattern: >-
@@ -3736,6 +5172,9 @@ rules:
         Verify that the doc comment accurately reflects the current SELECT column list and Scan order — update it whenever columns are added, removed, or reordered
       source: copilot:PR#533
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: accurate-event-types
       category: error-handling
       pattern: >-
@@ -3744,6 +5183,9 @@ rules:
         Verify that the event type passed to LogEvent accurately describes what actually happened. If the code path represents a failure or escalation (e.g. flagging as needs-human), do not reuse a success-oriented event type (e.g. EventBeadRecovered). Use an appropriate error/failure event type or introduce a dedicated one.
       source: copilot:PR#533
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: assert-test-errors
       category: testing
       pattern: >-
@@ -3752,6 +5194,9 @@ rules:
         Every error returned by a function under test must be asserted with require.NoError or similar; do not silently ignore returned errors as this masks failures and can cause nil-pointer dereferences.
       source: copilot:PR#533
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: recovery-reset-partial-failure-test
       category: testing
       pattern: >-
@@ -3760,6 +5205,9 @@ rules:
         When adding a failure counter with a reset path, verify there is a test for resetting after partial failures (not just after the circuit fully trips). Ensure the reset is not a no-op when the counter is nonzero but below the threshold.
       source: copilot:PR#533
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: recovery-failure-reset-scope
       category: error-handling
       pattern: >-
@@ -3768,6 +5216,9 @@ rules:
         When clearing failure counters on success, ensure ALL accumulated failure state (counts, timestamps) is unconditionally reset, while only conditionally clearing flags (like needs_human or last_error) that may have been set by unrelated code paths. Avoid coupling the reset of counters to a WHERE clause that matches a specific error message, as intermediate failures may store a different error string.
       source: copilot:PR#533
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: circuit-breaker-trip-reason
       category: error-handling
       pattern: Code that records or logs a circuit-breaker trip with a generic failure message
@@ -3775,6 +5226,9 @@ rules:
         Verify that the error message distinguishes the trip reason (e.g., consecutive-failure count vs time-window expiry) and includes relevant context such as the failure count or elapsed time since the first failure
       source: copilot:PR#533
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-redundant-pr-title-suffix
       category: ui
       pattern: >-
@@ -3783,6 +5237,9 @@ rules:
         When rendering list items that combine multiple fields into a label, verify that derived or auto-populated fields like Title do not duplicate information already shown (e.g. a PR number). Either suppress the suffix when the title is redundant, or populate Title with genuinely new information.
       source: copilot:PR#534
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-new-rendering-behavior
       category: testing
       pattern: >-
@@ -3791,6 +5248,9 @@ rules:
         When adding or changing rendering logic (e.g. label formatting, display text composition), verify that existing tests cover the new behavior and edge cases like duplicated or malformed output
       source: copilot:PR#534
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: mock-exec-distinct-responses
       category: testing
       pattern: >-
@@ -3799,6 +5259,9 @@ rules:
         Verify that when a function under test makes multiple calls to the same dependency (e.g., multiple SQL queries), the mock/stub returns distinct responses per call and the test asserts the expected result count, so duplicate or conflated results cannot mask regressions
       source: copilot:PR#535
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: notify-event-type-has-handler
       category: other
       pattern: A new EventType constant is added to the notify package
@@ -3806,6 +5269,9 @@ rules:
         Verify that every new EventType has either a corresponding notifier method that calls ShouldNotify and emits a notification (e.g. a Teams Adaptive Card), or is explicitly documented as intended for generic webhooks only
       source: copilot:PR#536
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: notification-event-consistency
       category: other
       pattern: >-
@@ -3814,6 +5280,9 @@ rules:
         Verify that every new event type has dedicated handling in all notification targets so that event filtering and payload semantics are consistent across channels. Reusing an existing notifier method (e.g. BeadFailed for a new orphan_recovery_failed event) can cause the event to be silently dropped if the target filters by event type.
       source: copilot:PR#536
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: func-comment-matches-impl
       category: style
       pattern: >-
@@ -3822,6 +5291,9 @@ rules:
         Verify that the function/method comment accurately reflects the actual implementation, including any flags, parameters, or configurable values. Update comments when the underlying invocation changes.
       source: copilot:PR#537
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: docs-setting-correct-section
       category: documentation
       pattern: >-
@@ -3830,6 +5302,9 @@ rules:
         Verify that each documented configuration setting is placed in the section/table corresponding to its functional area, not grouped with unrelated features just because it was added nearby
       source: copilot:PR#537
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: node-modules-junction-skip-consistency
       category: other
       pattern: >-
@@ -3838,6 +5313,9 @@ rules:
         Verify that node_modules junction/symlink creation respects the SkipNodeModulesJunction flag consistently across all code paths, including retry and deny-pattern reset paths, not just the initial worktree creation. If a bead opts out of junctions (e.g., deps-update beads), no subsequent path should silently re-create them.
       source: copilot:PR#539
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: skip-node-modules-junction-conditional
       category: error-handling
       pattern: >-
@@ -3846,6 +5324,9 @@ rules:
         Verify that node_modules junction/symlink operations are conditional on SkipNodeModulesJunction being false, so that depcheck/deps-update beads do not reintroduce junctions that corrupt the main checkout's dependencies
       source: copilot:PR#539
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: log-readdir-errors
       category: error-handling
       pattern: >-
@@ -3854,6 +5335,9 @@ rules:
         Verify that the error is included in any associated log message (e.g. as an "error" or "read_error" field) so that the resulting default/sentinel state is actionable for debugging
       source: copilot:PR#540
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: empty-path-guard
       category: error-handling
       pattern: >-
@@ -3862,6 +5346,9 @@ rules:
         Verify that empty or zero-value path parameters are handled explicitly (early return or clear log message) rather than silently falling through to operate on the current working directory
       source: copilot:PR#540
       added: "2026-04-15"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: use-daemon-ctx-for-bd-subprocesses
       category: concurrency
       pattern: >-
@@ -3870,6 +5357,9 @@ rules:
         Verify bd subprocess calls derive their context from the daemon-scoped context (e.g. d.runCtx) so they cancel promptly on shutdown instead of hanging for the full timeout
       source: copilot:PR#542
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-coverage-for-bd-state-changes
       category: testing
       pattern: >-
@@ -3878,6 +5368,9 @@ rules:
         Verify there is a focused test that exercises the new bd invocation path, asserts the exact bd arguments passed, and covers the safety conditions that should prevent the bd call (e.g., claim-race failures, error paths where state must not be mutated). Reuse existing fake-bd-on-PATH test harnesses in daemon tests.
       source: copilot:PR#542
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: scoped-bead-claim-release
       category: concurrency
       pattern: >-
@@ -3886,6 +5379,9 @@ rules:
         Verify the bd claim is only released from call sites where Forge is known to own the claim. Pre-claim failures, claim races, or already-claimed-by-another errors must not trigger release, since that can reopen/unassign a bead legitimately held by another Forge instance or a human. Prefer an explicit release-safe flag or a separate variant of the helper over an unconditional release.
       source: copilot:PR#542
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: errgroup-error-handling
       category: concurrency
       pattern: Code uses errgroup.Group for concurrent goroutines
@@ -3893,6 +5389,11 @@ rules:
         Verify goroutines actually return meaningful errors and that errgroup.Wait()'s returned error is checked and handled. If goroutines always return nil and Wait()'s error is ignored, switch to sync.WaitGroup + semaphore instead, since errgroup is only providing concurrency limiting and risks silently dropping future errors.
       source: copilot:PR#544
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+        - '**/*.sum'
     - id: go-mod-tidy-direct-deps
       category: other
       pattern: >-
@@ -3901,6 +5402,11 @@ rules:
         Verify `go mod tidy` has been run and committed so directly-imported modules are promoted to direct requirements in go.mod/go.sum, preventing CI tidy-check failures
       source: copilot:PR#544
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+        - '**/*.sum'
     - id: poll-mode-gating-config
       category: other
       pattern: >-
@@ -3909,6 +5415,9 @@ rules:
         Verify the flag is combined with the relevant config setting inside the function (e.g. force full/unfiltered when the feature interval is <=0) so callers passing the flag unconditionally cannot break legacy mode
       source: copilot:PR#545
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: prune-stale-snapshots-on-config-reload
       category: concurrency
       pattern: >-
@@ -3917,6 +5426,9 @@ rules:
         Verify the merged view is driven by the currently configured names (e.g., from cfg.Load()) rather than the snapshot map's keys, and/or that snapshot entries for removed anvils are pruned on config reload, so stale entries for deregistered anvils don't leak into Queue/IPC output indefinitely
       source: copilot:PR#546
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: reuse-sorted-merged-slice
       category: performance
       pattern: >-
@@ -3925,6 +5437,9 @@ rules:
         Verify the already-sorted merged slice is reused and filtered to the needed subset instead of performing a second merge/sort and re-acquiring locks, when the sort key is independent of the subset
       source: copilot:PR#546
       added: "2026-04-17"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: gitenv-fail-closed-absolute-paths
       category: error-handling
       pattern: >-
@@ -3933,6 +5448,9 @@ rules:
         Verify the function fails closed (returns nil/error) when it cannot produce a guaranteed-absolute path: filepath.Abs failures must not fall back to a possibly-relative input, and resolved gitdir paths must be checked with os.Stat AND verified via IsDir() (not just existence) before being used. Any non-absolute or non-directory result should abort rather than silently weaken the confinement guarantee.
       source: copilot:PR#560
       added: "2026-04-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: filter-git-env-vars-in-tests
       category: testing
       pattern: >-
@@ -3941,6 +5459,9 @@ rules:
         Verify os.Environ() is filtered to remove any existing GIT_DIR/GIT_WORK_TREE/GIT_CEILING_DIRECTORIES entries before appending the test's env, so duplicate entries don't make git's behavior platform-dependent and the test flaky
       source: copilot:PR#560
       added: "2026-04-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: deterministic-case-insensitive-map-lookup
       category: concurrency
       pattern: >-
@@ -3949,6 +5470,9 @@ rules:
         Verify the loop detects multiple case-insensitive matches and returns a deterministic result (e.g. error/not-found) instead of relying on randomized map iteration order
       source: copilot:PR#561
       added: "2026-04-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-fixtures-use-production-types
       category: testing
       pattern: >-
@@ -3957,6 +5481,9 @@ rules:
         Verify test fixtures use the same concrete types as production code (e.g. construct a minimal real struct with the relevant field set) so tests exercise the actual type contract and don't mask regressions when code depends on the full type's fields
       source: copilot:PR#561
       added: "2026-04-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-uses-production-types
       category: testing
       pattern: >-
@@ -3965,6 +5492,9 @@ rules:
         Verify tests use the same typed values as production code (e.g., crucible.Status constants instead of bare strings) so behavior matches and future type-aware operations like iteration or type assertions don't break
       source: copilot:PR#561
       added: "2026-04-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-use-real-types-not-strings
       category: testing
       pattern: >-
@@ -3973,6 +5503,9 @@ rules:
         Verify tests use the actual typed constants (e.g. crucible.Status) rather than raw string literals, so tests reflect real runtime values and catch type/assertion drift
       source: copilot:PR#561
       added: "2026-04-30"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: ipc-version-compat-nil-field
       category: error-handling
       pattern: >-
@@ -3981,6 +5514,9 @@ rules:
         Verify that missing optional fields (nil pointer / zero value after unmarshal) are distinguished from present-but-empty values — e.g., use a pointer field and treat nil as 'absent' to fall back to an alternate data source, so newer clients remain compatible with older servers that don't populate the field
       source: copilot:PR#589
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: prune-stale-map-entries-on-config-reload
       category: other
       pattern: >-
@@ -3989,6 +5525,9 @@ rules:
         Verify entries for removed or renamed keys are pruned against the current configured set during reload or snapshot construction so reported state reflects only active entities
       source: copilot:PR#589
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-invocations-need-anvil-dir-and-runner
       category: error-handling
       pattern: >-
@@ -3997,6 +5536,9 @@ rules:
         Verify every `bd` invocation runs from an anvil directory by setting `cmd.Dir` to a configured anvil path (or routing through an injected runner like `s.bdRunner`/`forgechat.DefaultBdRunner`) and uses the standard stderr-capture/`executil.HideWindow` wrapper, so `bd` can locate the Dolt DB and failures surface instead of silently returning empty results.
       source: copilot:PR#590
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bd-show-json-parse
       category: error-handling
       pattern: Parsing output of `bd show --json` directly with json.Unmarshal
@@ -4004,6 +5546,9 @@ rules:
         Verify bd show --json output is decoded using executil.DecodeJSON / unwrapJSONArray (or equivalent) so both array `[{...}]` and bare object `{...}` forms are accepted and trailing diagnostics are tolerated.
       source: copilot:PR#590
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: bead-id-anvil-disambiguation
       category: other
       pattern: >-
@@ -4012,6 +5557,9 @@ rules:
         Verify the lookup accounts for the same bead ID existing in multiple anvils: either key by (bead_id, anvil), accept a caller-provided anvil hint, or return an empty/ambiguous result when multiple anvils match — never silently pick the first mapping, which is non-deterministic and can attach the wrong anvil.
       source: copilot:PR#590
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-global-mutation-in-parallel-test-stubs
       category: testing
       pattern: >-
@@ -4020,6 +5568,9 @@ rules:
         Verify the stub is safe for parallel use: either no test in the package uses t.Parallel(), or the global swap is protected by a package-level mutex held across the test's lifetime, or the dependency is injected (constructor/struct field/context) instead of mutating a global.
       source: copilot:PR#590
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: clear-stale-state-on-prop-change
       category: ui
       pattern: >-
@@ -4028,6 +5579,10 @@ rules:
         Verify that when the identifying prop changes (e.g. switching to a new entity), stale state like data/error/loading is cleared synchronously during render or in the same setter call, so the component never paints new metadata against old data
       source: copilot:PR#591
       added: "2026-05-11"
+      paths:
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: handle-401-logout-in-api-calls
       category: error-handling
       pattern: >-
@@ -4036,6 +5591,10 @@ rules:
         Verify the component handles ApiError status 401 by calling logout() from the auth context to redirect to /login, consistent with useApiPoll and WorkerLogModal, instead of just surfacing an 'unauthorized' error
       source: copilot:PR#591
       added: "2026-05-11"
+      paths:
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: pr-description-matches-scope
       category: testing
       pattern: >-
@@ -4044,6 +5603,10 @@ rules:
         Verify that every deliverable mentioned in the PR description is included in the diff; if not, either add the missing items (including any required test harness) or update the PR description to reflect the actual scope
       source: copilot:PR#591
       added: "2026-05-11"
+      paths:
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: memoize-object-props-with-reset-effects
       category: performance
       pattern: >-
@@ -4052,6 +5615,9 @@ rules:
         Verify the prop is memoized (e.g. useMemo keyed by stable identity fields) or that the child's effect compares stable identity fields instead of object reference, so periodic parent re-renders don't clobber child state or trigger redundant refetches
       source: copilot:PR#592
       added: "2026-05-11"
+      paths:
+        - '**/*.md'
+        - '**/*.tsx'
     - id: preserve-graph-tree-structure
       category: ui
       pattern: >-
@@ -4060,6 +5626,9 @@ rules:
         Verify the renderer does not globally deduplicate nodes by ID. Global dedupe can place a node at the wrong hop/level, draw edges between non-adjacent levels, and hide expand affordances for occurrences at the depth limit. Render the API tree as-is, or track per-occurrence placement while still preventing recursive expansion, so hop labels and expandability remain accurate.
       source: copilot:PR#592
       added: "2026-05-11"
+      paths:
+        - '**/*.md'
+        - '**/*.tsx'
     - id: verification-commands-match-repo
       category: other
       pattern: >-
@@ -4068,6 +5637,10 @@ rules:
         Verify the listed commands actually exist in this repo — check package.json scripts, Makefile targets, and conventional Go commands (e.g. `go test ./...`, `npm run build` in `internal/web/frontend`). Either update the description to match real commands or add the missing scripts/targets.
       source: ['copilot:PR#592', 'copilot:PR#593']
       added: "2026-05-11"
+      paths:
+        - '**/*.json'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: empty-state-vs-loading
       category: ui
       pattern: >-
@@ -4076,6 +5649,10 @@ rules:
         Verify the filtered-empty message is gated on an active filter (e.g. filter.trim().length > 0) and/or !loading, so it doesn't show misleadingly during initial load or when no filter is applied
       source: copilot:PR#593
       added: "2026-05-11"
+      paths:
+        - '**/*.json'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: scroll-anchoring-comment-accuracy
       category: ui
       pattern: >-
@@ -4084,6 +5661,10 @@ rules:
         Verify the comment accurately describes the mechanism — browsers use scroll anchoring to preserve visual viewport position, not scrollTop preservation. Reword to mention scroll position/viewport or scroll anchoring explicitly rather than scrollTop.
       source: copilot:PR#593
       added: "2026-05-11"
+      paths:
+        - '**/*.json'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: include-reviewing-status-in-active-filters
       category: ui
       pattern: >-
@@ -4092,6 +5673,11 @@ rules:
         Verify the status filter includes 'reviewing' (Warden stage) alongside pending/running/monitoring, so Warden-stage beads are counted and visible in both UI filters and active Smith slot counts; apply consistently across all related contexts (e.g., pipeline bar, beadRows, and active-slot capacity)
       source: copilot:PR#594
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: dedupe-counts-by-entity
       category: ui
       pattern: >-
@@ -4100,6 +5686,11 @@ rules:
         Verify counts are de-duplicated by the logical entity key (e.g. (anvil, bead_id)) rather than counting raw list entries, so that a single bead contributing multiple workers to the same bucket is not counted multiple times
       source: copilot:PR#594
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: predicate-matches-comment-intent
       category: ui
       pattern: >-
@@ -4108,6 +5699,11 @@ rules:
         Verify the predicate's implementation actually identifies the specific entity described in its name/comment. If the distinguishing characteristic is a composite (id prefix, missing field, synthetic marker), the check must include those discriminators — otherwise legitimate items sharing only the broad attribute will be incorrectly filtered. Either tighten the predicate to match the documented intent or update the name/comment to reflect the broader behavior.
       source: copilot:PR#594
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: validate-path-after-wait
       category: security
       pattern: >-
@@ -4116,6 +5712,11 @@ rules:
         Verify the path is re-validated (Lstat + EvalSymlinks + allowlist check + regular-file check) immediately before opening, so a symlink materializing later cannot bypass the allowlist guarantee
       source: copilot:PR#595
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: doc-comment-matches-return-contract
       category: style
       pattern: >-
@@ -4124,6 +5725,11 @@ rules:
         Verify the doc comment accurately describes what the function actually returns in each documented case, especially for sentinel/zero values vs. populated values
       source: copilot:PR#595
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: ts-optional-fn-narrowing
       category: error-handling
       pattern: >-
@@ -4132,6 +5738,11 @@ rules:
         Ensure the optional function is narrowed before invocation — use an explicit `if (fn && ...)` guard or optional-chaining call `fn?.(...)` to avoid TS 'possibly undefined' errors under strict mode
       source: copilot:PR#595
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: safe-dom-id-from-user-input
       category: ui
       pattern: >-
@@ -4140,6 +5751,14 @@ rules:
         Verify the value is slugified/encoded into a safe, deterministic token (no whitespace or illegal chars) and is unique across elements, rather than interpolated raw
       source: copilot:PR#596
       added: "2026-05-11"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.json'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: ts-config-typecheck-coverage
       category: testing
       pattern: >-
@@ -4148,6 +5767,14 @@ rules:
         Verify the new config file is included in a tsconfig (e.g. tsconfig.node.json) so it is covered by tsc/lint typechecking, rather than only being checked at runtime
       source: copilot:PR#596
       added: "2026-05-11"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.json'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: test-files-typecheck-coverage
       category: testing
       pattern: >-
@@ -4156,6 +5783,14 @@ rules:
         Verify test files remain typechecked via a dedicated tsconfig (e.g. `tsconfig.test.json`) wired into lint/typecheck scripts, so excluding them from the prod build config does not silently drop type checking for tests
       source: copilot:PR#596
       added: "2026-05-11"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.json'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: procfs-permission-errors
       category: error-handling
       pattern: >-
@@ -4164,6 +5799,9 @@ rules:
         Distinguish ENOENT (process really gone) from EACCES/EPERM (cannot verify due to hidepid or other restrictions). Permission errors must be returned as non-nil errors so callers fall back to the safe 'assume alive' path rather than treating the process as dead. Confirm the function's doc comment accurately describes this semantics.
       source: copilot:PR#597
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-fallback-paths
       category: testing
       pattern: >-
@@ -4172,6 +5810,9 @@ rules:
         Verify that unit tests cover the fallback path(s), not just the primary path. Add tests that force the fallback condition (e.g., by making the primary source unreadable) and assert correct behavior.
       source: copilot:PR#597
       added: "2026-05-11"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: brittle-regex-test-assertions
       category: testing
       pattern: >-
@@ -4180,6 +5821,13 @@ rules:
         Verify the regex tolerates harmless formatting variations (whitespace, newlines, single-line vs multi-line, fragment wrappers, `className={'...'}` / template-string forms) and that the assertion targets the general invariant (e.g. no `max-w-*` class at all) rather than one specific token, so the test won't break on incidental refactors and won't miss equivalent violations
       source: copilot:PR#598
       added: "2026-05-11"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: vitest-hoisted-mocks
       category: testing
       pattern: >-
@@ -4188,6 +5836,11 @@ rules:
         Ensure mock functions used inside vi.mock() factories are created via vi.hoisted(() => vi.fn()) or defined inside the factory itself, since vi.mock() is hoisted above module-scope declarations and will trigger TDZ 'Cannot access before initialization' errors
       source: copilot:PR#599
       added: "2026-05-11"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: respect-ctx-and-timeout
       category: concurrency
       pattern: >-
@@ -4196,6 +5849,10 @@ rules:
         Verify the function threads the parent ctx through (or derives a context.WithTimeout from step.Timeout) and checks for cancellation during loops/walks, so the work stops promptly when the Temper context is cancelled or the configured timeout elapses
       source: copilot:PR#601
       added: "2026-05-12"
+      paths:
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.md'
     - id: validate-allows-documented-config
       category: error-handling
       pattern: >-
@@ -4204,6 +5861,10 @@ rules:
         Verify that Config.Validate() is updated to match the documented semantics of the new field — when the flag relaxes or replaces a previously required sibling (e.g. allowing empty command when verify_no_conflict_markers is set), Validate must permit that combination, and any newly-implied constraints (e.g. args must also be empty) should be enforced. Confirm docs, struct tags, and validation agree.
       source: copilot:PR#601
       added: "2026-05-12"
+      paths:
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.md'
     - id: case-insensitive-map-lookup-ambiguity
       category: error-handling
       pattern: >-
@@ -4212,6 +5873,9 @@ rules:
         Verify the lookup detects multiple case-insensitive matches and returns no result (or an explicit ambiguity error) rather than relying on nondeterministic map iteration order to pick one
       source: copilot:PR#602
       added: "2026-05-12"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: prompt-claims-match-enforcement
       category: security
       pattern: >-
@@ -4220,6 +5884,9 @@ rules:
         Verify the claimed restrictions are technically enforced (e.g. stage-specific tool allowlist limited to Read/Grep/Glob, provider flags that drop --dangerously-skip-permissions, sandboxed permissions) rather than relying on prompt wording alone; if enforcement isn't in place, soften the prompt so it doesn't promise isolation the runtime doesn't guarantee
       source: copilot:PR#602
       added: "2026-05-12"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-n-plus-1-queries-in-loops
       category: performance
       pattern: >-
@@ -4228,6 +5895,9 @@ rules:
         Verify the code does not introduce N+1 query patterns on hot/periodic paths; prefer a single batched query (e.g., JOIN or IN-clause) that returns all needed rows at once, especially for code that runs on a recurring poll interval
       source: copilot:PR#604
       added: "2026-05-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: composite-index-for-frequent-lookups
       category: performance
       pattern: >-
@@ -4236,6 +5906,9 @@ rules:
         Verify the table has a composite index covering the lookup columns (e.g., prs(anvil, number)) rather than only a single-column index, and add a `CREATE INDEX IF NOT EXISTS` migration if missing to prevent row scans as the table grows
       source: copilot:PR#604
       added: "2026-05-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-matches-reconcile-semantics
       category: documentation
       pattern: >-
@@ -4244,6 +5917,9 @@ rules:
         Verify the documented behavior matches the actual reconcile/persistence semantics end-to-end: either the comment must state the companion flag (or follow-up call) required to make the state durable, or the INSERT/UPDATE must persist the companion flag so the documented pre-pin actually survives reconcile
       source: copilot:PR#606
       added: "2026-05-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cache-timestamp-consistency
       category: concurrency
       pattern: >-
@@ -4252,6 +5928,11 @@ rules:
         Verify that in-memory state mirroring a persisted snapshot is only updated after the persistence call succeeds, so readers never observe new metadata paired with stale persisted data on write failure
       source: copilot:PR#608
       added: "2026-05-13"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: sort-comparator-nan-handling
       category: ui
       pattern: >-
@@ -4260,6 +5941,12 @@ rules:
         Verify that missing/unparseable values are ordered consistently with the sort direction and the user-visible label (e.g., 'oldest first' should place missing-as-oldest items first in asc and last in desc), that the code comments match the actual behavior, and that a test covers the missing-value case in both directions
       source: copilot:PR#610
       added: "2026-05-13"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: no-unsafe-type-casts-in-tests
       category: testing
       pattern: >-
@@ -4268,6 +5955,12 @@ rules:
         Verify tests model missing/empty values the same way the app and API do (e.g., empty string for an optional-in-practice field) rather than bypassing the type system with unsafe casts; if the field can truly be absent, update the type definition instead of casting around it
       source: copilot:PR#610
       added: "2026-05-13"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: precompute-sort-keys
       category: performance
       pattern: >-
@@ -4276,6 +5969,12 @@ rules:
         Verify expensive per-comparison work is hoisted out of the comparator — precompute each item's sort key once (decorate-sort-undecorate) so the derivation runs O(n) instead of O(n log n) times
       source: copilot:PR#610
       added: "2026-05-13"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: iterate-centralized-keys
       category: style
       pattern: >-
@@ -4284,6 +5983,12 @@ rules:
         Iterate over the centralized key list to build the result instead of repeating per-key blocks, so adding/renaming a key only requires updating the central list
       source: copilot:PR#610
       added: "2026-05-13"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: trim-filter-ui-consistency
       category: ui
       pattern: >-
@@ -4292,6 +5997,12 @@ rules:
         Verify that conditional rendering and styling use the same transformation as the underlying logic, so UI state matches behavior (e.g., a clear button tied to a filter should appear only when the filter is actually active after trimming)
       source: copilot:PR#611
       added: "2026-05-13"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: focus-after-conditional-unmount
       category: ui
       pattern: >-
@@ -4300,6 +6011,12 @@ rules:
         Verify keyboard focus is preserved after the element unmounts — either move focus back to a related element via a ref, or keep the element mounted and toggle visibility/disabled instead of conditionally rendering it
       source: copilot:PR#611
       added: "2026-05-13"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: independent-subprocess-timeout-budget
       category: concurrency
       pattern: >-
@@ -4308,6 +6025,9 @@ rules:
         Verify each independent bd subprocess invocation gets its own fresh context with the project's DefaultBdTimeout (or equivalent full budget), rather than inheriting/sharing a parent context that may already be expired or cancelled, especially when the secondary call is meant to be independent and non-fatal
       source: copilot:PR#613
       added: "2026-05-14"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: optimistic-update-dedup
       category: ui
       pattern: >-
@@ -4316,6 +6036,14 @@ rules:
         Verify that optimistic local entries are reconciled with server data so the same item is not displayed twice — either dedupe by stable content fields (author/body/timestamp), drop all unsynced local entries once the server list contains newer items, or clear the local buffer after any successful server refresh post-submission. Matching only by client-generated ID will never reconcile, since the server's ID will differ.
       source: copilot:PR#615
       added: "2026-05-14"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: bd-json-array-or-object
       category: error-handling
       pattern: Decoding `bd ... --json` output into a single struct via executil.DecodeJSON
@@ -4323,6 +6051,14 @@ rules:
         Verify the handler tolerates both array and object payloads from bd (e.g., try decoding as a slice and use the last element when an array is returned), or document the exact bd output contract relied upon, so a successful bd call isn't silently turned into a 204.
       source: copilot:PR#615
       added: "2026-05-14"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: case-insensitive-anvil-lookup
       category: error-handling
       pattern: >-
@@ -4331,6 +6067,14 @@ rules:
         Verify the anvil name is normalized case-insensitively (e.g. lowercased or scanned with case-insensitive comparison) before the registry lookup, matching the daemon's IPC handler behavior, so requests like 'Forge' vs 'forge' are treated consistently across all API surfaces
       source: copilot:PR#615
       added: "2026-05-14"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: safe-storage-access-in-helpers
       category: error-handling
       pattern: >-
@@ -4339,6 +6083,10 @@ rules:
         Verify every direct read of window.sessionStorage or window.localStorage (including target-list construction before the try block) goes through the safe storage accessor or is individually wrapped in try/catch, so SecurityError cannot escape the helper
       source: copilot:PR#619
       added: "2026-05-18"
+      paths:
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: test-scroll-restoration
       category: testing
       pattern: >-
@@ -4347,6 +6095,12 @@ rules:
         Verify tests assert end-to-end scroll restoration: set scrollTop, fire a scroll event, simulate navigating away and back (unmount/remount), and assert scrollTop is restored to the persisted value — not just that the storage key is written
       source: copilot:PR#620
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: comment-matches-ui-ordering
       category: ui
       pattern: >-
@@ -4355,6 +6109,12 @@ rules:
         Verify that ordering comments accurately reflect the actual rendered order — when items are grouped, confirm whether the stated ordering applies globally or only within groups, and either fix the grouping to match the comment or update the comment to match the UI semantics
       source: copilot:PR#621
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: test-ui-persistence
       category: testing
       pattern: >-
@@ -4363,6 +6123,12 @@ rules:
         Verify component tests cover the persistence behaviors: state restored on remount/back-nav, storage keys are written/read correctly, and edge cases like missing/corrupt stored values. Mirror existing persistence test patterns (e.g., QueuePane.persistence.test.tsx) when present.
       source: copilot:PR#621
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: stable-usememo-deps
       category: performance
       pattern: >-
@@ -4371,6 +6137,12 @@ rules:
         Verify that all dependencies passed to useMemo/useCallback/useEffect are stable references (memoized themselves or primitive values). Inline-computed arrays/objects create a new reference every render, defeating memoization. Either memoize the intermediate value with its own useMemo (depending on stable inputs), depend on the underlying stable source directly, or remove the outer useMemo if it provides no benefit.
       source: copilot:PR#621
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: raf-cleanup-on-unmount
       category: concurrency
       pattern: >-
@@ -4379,6 +6151,12 @@ rules:
         Verify the rAF/timer id is tracked and cancelled in the effect's cleanup function (and/or guarded with an unmounted flag) so pending callbacks cannot call state setters or trigger debounced writes after the component unmounts
       source: copilot:PR#621
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: fake-timers-cleanup
       category: testing
       pattern: >-
@@ -4387,6 +6165,12 @@ rules:
         Verify vi.useRealTimers() is guaranteed to run via try/finally wrapping the entire test body or an afterEach hook, so a failed assertion cannot leak fake timers into subsequent tests
       source: copilot:PR#621
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: paused-state-snapshot-empty-buffer
       category: ui
       pattern: >-
@@ -4395,6 +6179,11 @@ rules:
         Verify that restoring a paused state from storage does not freeze an empty buffer before initial async data (e.g. SSE replay) arrives; either defer the freeze until the data source has delivered its initial payload, or restore the buffered items from storage alongside the paused flag
       source: copilot:PR#622
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: no-cross-component-filter-comparison-comments
       category: style
       pattern: >-
@@ -4403,6 +6192,11 @@ rules:
         Verify such comparison comments are accurate and remove them if they describe unrelated logic — cross-component comparisons drift out of sync and mislead future changes to either side
       source: copilot:PR#622
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: changelog-storage-scope-accuracy
       category: style
       pattern: >-
@@ -4411,6 +6205,11 @@ rules:
         Verify the changelog wording accurately reflects the storage scope and lifetime — e.g., sessionStorage persists within a tab session but resets when the tab/session closes (not across browser restarts), while localStorage persists across restarts. Distinguish per-field storage scopes when multiple are used.
       source: copilot:PR#622
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: validate-persisted-ui-state
       category: error-handling
       pattern: >-
@@ -4419,6 +6218,12 @@ rules:
         Verify hydrated values are validated against the allowed set (e.g. SORT_OPTIONS) or guarded with a runtime default before being used, so stale/corrupted persisted state cannot cause downstream functions to return undefined and crash
       source: copilot:PR#623
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: normalize-prefix-in-search
       category: ui
       pattern: >-
@@ -4427,6 +6232,12 @@ rules:
         Verify the comparison normalizes or accepts the visible prefixed form — strip a leading prefix like '#' before comparing, or match against both the bare value and the prefixed form (e.g. String(pr.number) and `#${pr.number}`)
       source: copilot:PR#623
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: no-heading-in-button
       category: ui
       pattern: >-
@@ -4435,6 +6246,12 @@ rules:
         Verify that block-level heading elements are not nested inside <button> elements; use a phrasing element styled as a heading inside the button, or keep the heading outside and link the button via aria-labelledby/aria-controls
       source: copilot:PR#623
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: fetch-base-before-ancestry-check
       category: error-handling
       pattern: >-
@@ -4443,6 +6260,9 @@ rules:
         Verify the base ref is refreshed (git fetch of the resolved base branch, including any override) or its existence is confirmed via ls-remote before the ancestry/merge-base test, so stale local refs don't cause merged branches to be misclassified as stranded (or vice versa)
       source: copilot:PR#626
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-base-branch-override
       category: testing
       pattern: >-
@@ -4451,6 +6271,9 @@ rules:
         Verify tests cover the non-empty baseBranch override path, including a case where the branch is reachable from origin/<baseBranch> but not origin/main, ensuring correct classification (e.g., merged vs. stranded)
       source: copilot:PR#626
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: clean-up-pending-worker-on-early-dispatch-return
       category: error-handling
       pattern: >-
@@ -4459,6 +6282,9 @@ rules:
         Verify that every early-return path after the pending worker row is inserted updates or deletes that row (using the claim worker ID) to a terminal status such as failed/done/monitoring, so Hearth does not display a permanently stuck pending worker
       source: copilot:PR#626
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: distinguish-lookup-errors-from-empty-results
       category: error-handling
       pattern: >-
@@ -4467,6 +6293,9 @@ rules:
         Verify that lookup/API errors are handled explicitly (logged or retried) and distinguished from genuine empty results, so transient failures don't trigger false escalations. Also confirm already-fetched values are reused instead of being looked up again in helper functions.
       source: copilot:PR#626
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sanitize-log-and-event-consistently
       category: style
       pattern: >-
@@ -4475,6 +6304,9 @@ rules:
         Verify that when a value is sanitized for one output, all sinks (logs, events, audit records) receive the same sanitized value — either by returning the sanitized value from the shared helper or by applying the same sanitization at every emission site, so log lines and audit events stay consistent and greppable
       source: copilot:PR#627
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: preserve-operational-logs-on-refactor
       category: other
       pattern: >-
@@ -4483,6 +6315,9 @@ rules:
         Verify that operationally-significant log messages (especially info/warn logs about worker lifecycle, signalling, or state transitions) are preserved after the refactor — either emitted from the new location or surfaced back to the caller so the original log site can retain visibility
       source: copilot:PR#627
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: preserve-response-wording-on-refactor
       category: other
       pattern: >-
@@ -4491,6 +6326,9 @@ rules:
         Verify that distinct response/message wordings are preserved across all branches (e.g., circuit-breaker vs. no-circuit-breaker paths). If wording is intentionally unified, confirm no downstream consumer or test relies on the prior distinction, or derive the wording from the underlying state to maintain the signal.
       source: copilot:PR#627
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: multi-forge-id-mismatch-check
       category: error-handling
       pattern: >-
@@ -4499,6 +6337,9 @@ rules:
         Verify that asymmetric empty-ID cases are handled deliberately: when one side is empty and the other is set, the validation should either reject the mismatch, require both to be non-empty, or explicitly document why the check is skipped. Silently passing validation when local config is unset defeats the safety check precisely when isolation matters most.
       source: copilot:PR#627
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: canonicalize-anvil-name-ipc
       category: error-handling
       pattern: >-
@@ -4507,6 +6348,9 @@ rules:
         Verify the handler passes the input anvil name through d.resolveAnvilConfig (when non-empty) to canonicalize case before delegating to queueactions or performing GetRetry/ActiveWorkerByBeadAndAnvil lookups, matching the pattern used by legacy retry_bead/clear_bead handlers
       source: copilot:PR#628
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: capture-stderr-in-git-runner
       category: error-handling
       pattern: >-
@@ -4515,6 +6359,9 @@ rules:
         Verify the command runner captures stderr (e.g. cmd.Stderr = &buf) and includes the captured text in the wrapped error so diagnostic output contains the tool's actual error message rather than just 'exit status N'
       source: copilot:PR#629
       added: "2026-05-18"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: no-unused-locals-ts
       category: style
       pattern: TypeScript variables, refs, or imports declared but never read in frontend code
@@ -4522,6 +6369,12 @@ rules:
         Verify no unused locals exist (noUnusedLocals: true will fail tsc build) — remove the declaration or actually use it
       source: copilot:PR#630
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: react-stable-identity-actions
       category: ui
       pattern: >-
@@ -4530,6 +6383,12 @@ rules:
         Verify the actions object is memoized independently of changing state (deps limited to the underlying callbacks like run/reset/setEntry), or update the documentation/API to reflect the actual stability guarantee so consumers' effects don't re-run unexpectedly
       source: copilot:PR#630
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: comments-match-implementation
       category: style
       pattern: >-
@@ -4538,6 +6397,12 @@ rules:
         Verify the comment accurately describes the actual implementation — e.g., if the comment mentions a 'reducer' or specific state-transition rules (like 'never back to pending without reset'), confirm the code uses a reducer and enforces those transitions. Update the comment or the implementation so they agree.
       source: copilot:PR#630
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
     - id: test-new-store-slices
       category: testing
       pattern: >-
@@ -4546,6 +6411,12 @@ rules:
         Verify that the store's test file includes tests for the new slice covering all status transitions (idle/loading/success/error) and any caching invariants like preserving prior data during loading/error states
       source: copilot:PR#632
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: unique-form-control-ids
       category: ui
       pattern: >-
@@ -4554,6 +6425,12 @@ rules:
         Verify that id values are generated per-instance (e.g., React useId() or composed with a unique prop like an entity ID) so multiple instances on the same page don't produce duplicate IDs that break label/htmlFor association for assistive tech
       source: copilot:PR#632
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: guard-actions-on-empty-required-field
       category: ui
       pattern: >-
@@ -4562,6 +6439,12 @@ rules:
         Verify the action is gated on the required field being non-empty — either disable the buttons with an explanatory message or hide them — so operators aren't shown actions that will always fail when the backend returned an empty/ambiguous value
       source: copilot:PR#633
       added: "2026-05-18"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: reuse-existing-modal-component
       category: ui
       pattern: >-
@@ -4570,6 +6453,11 @@ rules:
         Verify whether an existing shared modal component (e.g., a ConfirmModal or similar primitive already in the codebase) can be reused or extracted instead of introducing a duplicate inline modal implementation
       source: copilot:PR#634
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: unique-aria-labelledby-ids
       category: ui
       pattern: >-
@@ -4578,6 +6466,11 @@ rules:
         Verify that ARIA reference IDs (aria-labelledby, aria-describedby, etc.) use per-instance unique IDs generated via React's useId() hook rather than hard-coded strings, to avoid duplicate IDs when multiple instances are mounted
       source: copilot:PR#634
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: modal-confirm-button-idempotency
       category: concurrency
       pattern: >-
@@ -4586,6 +6479,11 @@ rules:
         Verify the confirm button is guarded against double-clicks by either using a local busy/disabled state, closing the modal synchronously before dispatching, or otherwise making the action idempotent per modal open
       source: copilot:PR#634
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: typed-set-literal
       category: style
       pattern: >-
@@ -4594,6 +6492,11 @@ rules:
         Verify the Set is type-constrained via an explicit generic (`new Set<TypeName>(...)`), `as const`, or `satisfies`, so non-matching strings cannot be added later
       source: copilot:PR#634
       added: "2026-05-18"
+      paths:
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.tsx'
     - id: omitempty-zero-duration-marshal
       category: other
       pattern: >-
@@ -4602,6 +6505,9 @@ rules:
         Verify that omitempty actually omits the field when the underlying value is zero: either guard the assignment (only set the shadow field when value > 0) or ensure the stringifier returns "" for the zero value. Otherwise the zero/default case will always be serialized, defeating omitempty.
       source: copilot:PR#637
       added: "2026-05-19"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sync-package-level-mutable-state
       category: concurrency
       pattern: >-
@@ -4610,6 +6516,9 @@ rules:
         Verify that any package-level mutable state accessed from multiple goroutines is protected against data races — either via atomic.Value, sync.RWMutex, or accessor helpers (GetX/SetX). Flag any direct read/write of a package-level var that crosses goroutine boundaries, since this triggers Go's race detector and can cause torn reads.
       source: copilot:PR#638
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: config-default-comment-mismatch
       category: other
       pattern: >-
@@ -4618,6 +6527,9 @@ rules:
         Verify that the resolver's behavior matches the field's documented semantics and any consuming logic — if the comment says zero/negative disables a cap, the resolver must not silently substitute a default; align the comment, resolver, and consumer (or introduce an explicit tri-state) so operators can actually disable the feature via config
       source: copilot:PR#638
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: avoid-full-split-on-large-strings
       category: performance
       pattern: >-
@@ -4626,6 +6538,9 @@ rules:
         Verify large strings are scanned without allocating a full slice of lines — use strings.Index loops, bufio.Scanner, or bufio.Reader over strings.NewReader to keep allocations bounded
       source: copilot:PR#638
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: validate-against-empty-registry
       category: error-handling
       pattern: >-
@@ -4634,6 +6549,9 @@ rules:
         Ensure non-empty identifiers are rejected when the registry is empty rather than silently passing; only an empty/unspecified identifier should be allowed in that case
       source: copilot:PR#639
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: test-empty-registry-edge-case
       category: testing
       pattern: >-
@@ -4642,6 +6560,9 @@ rules:
         Verify there is a test case for the empty-registry/empty-collection scenario when a non-empty input is provided, to lock in the intended behavior (accept or reject) and prevent regressions
       source: copilot:PR#639
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: changelog-config-key-paths
       category: other
       pattern: Changelog fragment references configuration keys for a new feature
@@ -4649,6 +6570,9 @@ rules:
         Verify config key paths in the changelog match the actual paths used in the implementation (including parent sections like `settings.`), so users can configure the feature correctly
       source: copilot:PR#640
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: doc-references-existing-behavior
       category: style
       pattern: >-
@@ -4657,6 +6581,9 @@ rules:
         Verify that comments accurately reflect current code state — if referenced fields/components aren't implemented yet, reword to indicate future/planned behavior or point at the component that will provide it
       source: copilot:PR#640
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: union-find-aggregate-merge
       category: other
       pattern: >-
@@ -4665,6 +6592,9 @@ rules:
         Verify that aggregate values keyed by root are merged into the surviving root during union operations, or recomputed in a second pass after all unions complete — otherwise values stored on the old root become orphaned and clusters report stale or zero values
       source: copilot:PR#642
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: rune-vs-byte-length
       category: other
       pattern: >-
@@ -4673,6 +6603,9 @@ rules:
         Verify that len() is not being used where rune/character count is intended; use utf8.RuneCountInString or range over runes when the semantic intent is character length rather than byte length
       source: copilot:PR#642
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: commit-subject-reflects-consolidation
       category: other
       pattern: >-
@@ -4681,6 +6614,9 @@ rules:
         Verify the commit subject accurately reflects all changes made — if the primary counter is 0 but other modifications occurred (e.g., consolidationSummary non-empty), the subject should be adjusted to include those changes (e.g., consolidated cluster count) rather than misleadingly reporting '0' items
       source: copilot:PR#642
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: merged-id-distinct-from-replaced
       category: other
       pattern: >-
@@ -4689,6 +6625,9 @@ rules:
         Verify the merged ID cannot collide with any of the IDs being archived/replaced — either guarantee the merged ID is distinct from all ReplacedIDs, or special-case archive metadata when mergedID == replacedID (e.g., omit superseded_by for that entry) so archived rows don't reference themselves and an active ID doesn't also appear in the archive
       source: copilot:PR#642
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: exact-threshold-boundary-tests
       category: testing
       pattern: >-
@@ -4697,6 +6636,9 @@ rules:
         Verify boundary tests use the exact computed value (e.g., 2.0/6.0) rather than a rounded approximation, or that comments accurately describe the test as approximate rather than exact
       source: copilot:PR#642
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: timezone-consistent-date-math
       category: other
       pattern: >-
@@ -4705,6 +6647,9 @@ rules:
         Verify both sides of time arithmetic use a consistent location — either parse with time.ParseInLocation using the same location as the comparison value, or normalize both times to UTC — so day/duration boundaries aren't skewed by timezone offset
       source: copilot:PR#644
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: redundant-boolean-conditions
       category: style
       pattern: >-
@@ -4713,6 +6658,9 @@ rules:
         Verify that each subsequent condition only includes comparisons that add new information; remove redundant bounds that are implied by the prior branch failing, and update accompanying comments to match
       source: copilot:PR#644
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: extract-all-regex-matches
       category: other
       pattern: >-
@@ -4721,6 +6669,9 @@ rules:
         Verify the code uses FindAll-style regex methods to capture all matches rather than only the first, and that tests cover multi-token source values
       source: copilot:PR#645
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: cache-per-pr-api-calls
       category: performance
       pattern: >-
@@ -4729,6 +6680,9 @@ rules:
         Verify results are cached per key for the duration of the pass and reused across iterations to avoid redundant API calls and rate limiting; consider negative/error caching where appropriate
       source: copilot:PR#645
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: sanitize-id-lists-in-commit-messages
       category: error-handling
       pattern: >-
@@ -4737,6 +6691,9 @@ rules:
         Verify that ID slices are filtered or mapped through a display helper to drop empties before joining, and that tests cover the empty-ID case to prevent malformed output like 'm ← , '
       source: copilot:PR#646
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: pr-body-reflects-all-changes
       category: other
       pattern: >-
@@ -4745,6 +6702,9 @@ rules:
         Verify the PR/commit body accurately reflects all change categories produced by the pipeline, not just one. When multi-pass or multi-outcome logic is introduced, ensure the message-generation function receives and describes all relevant counts/results rather than a single count that may be zero while other passes produced changes.
       source: copilot:PR#646
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: log-message-reflects-all-work
       category: other
       pattern: >-
@@ -4753,6 +6713,9 @@ rules:
         Verify that summary log/event messages derive their content from the full result set (e.g., PassResults) and include counts for all change types performed, so operational logs accurately reflect the work done rather than misleadingly reporting zero when other changes occurred
       source: copilot:PR#646
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: help-text-matches-behavior
       category: style
       pattern: >-
@@ -4761,6 +6724,9 @@ rules:
         Verify the help text accurately reflects conditional behavior — if an output file is only written under certain conditions, the help should say so (e.g., 'writes Y only when needed') rather than implying it is always produced
       source: copilot:PR#647
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: conditional-output-messages
       category: ui
       pattern: >-
@@ -4769,6 +6735,9 @@ rules:
         Verify that output messages referencing created artifacts (file paths, archives, etc.) are only printed when those artifacts actually exist or were modified during the run; otherwise omit them or report 'unchanged/not created'
       source: copilot:PR#647
       added: "2026-05-20"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
     - id: scoped-stash-no-data-loss
       category: error-handling
       pattern: >-
@@ -4777,6 +6746,9 @@ rules:
         Verify the stash is scoped to the specific paths the script intends to preserve (use a pathspec like `git stash push -- <path>`), and that the drop targets the exact stash ref created by this run (capture from `git stash create`/`stash push` output) rather than blindly dropping `stash@{0}`. Otherwise unrelated dirty changes or a pre-existing stash entry can be silently discarded. Consider failing fast if unexpected files are dirty.
       source: copilot:PR#648
       added: "2026-05-20"
+      paths:
+        - '**/*.md'
+        - '**/*.sh'
     - id: bash-pipeline-exit-status
       category: error-handling
       pattern: >-
@@ -4785,3 +6757,307 @@ rules:
         Verify `set -o pipefail` is enabled (or the pipeline is restructured) so upstream command failures aren't masked by the exit status of the final pipeline stage
       source: copilot:PR#648
       added: "2026-05-20"
+      paths:
+        - '**/*.md'
+        - '**/*.sh'
+    - id: respect-configured-timeouts
+      category: other
+      pattern: >-
+        HTTP handler wraps request context with a hardcoded timeout (e.g., context.WithTimeout(r.Context(), 2*time.Minute)) before invoking a downstream runner/component that has its own configurable timeout
+      check: >-
+        Verify the handler does not impose a shorter hardcoded deadline that overrides a configurable downstream timeout. Either pass r.Context() directly and let the downstream component enforce its own timeout, or derive the handler deadline from the same configuration setting so user-configured timeouts actually take effect.
+      source: copilot:PR#650
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+    - id: comment-matches-marshal-behavior
+      category: style
+      pattern: >-
+        Struct field comments describing JSON/YAML marshal behavior (e.g., 'omitted when X') alongside omitempty tags or custom marshalers
+      check: >-
+        Verify the comment accurately reflects actual marshal behavior — confirm that the documented omission condition matches what Defaults()/Load() produce and the omitempty semantics (zero-value vs. default-value), and either fix the comment or add special-casing so the field is omitted under the stated condition
+      source: copilot:PR#650
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+    - id: deterministic-timeout-tests
+      category: testing
+      pattern: >-
+        Test relies on wall-clock timing (e.g., a very short timeout) to trigger a deadline-exceeded or context-cancellation code path
+      check: >-
+        Verify the test makes the timeout deterministic by passing a parent context with an already-expired deadline (or otherwise guaranteeing the deadline has fired) rather than racing setup work against a short wall-clock timeout, to prevent flakiness on fast machines
+      source: copilot:PR#651
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+    - id: portable-test-paths
+      category: testing
+      pattern: >-
+        Test uses hard-coded absolute filesystem path (e.g. /nonexistent/...) for a missing executable or file
+      check: >-
+        Verify the test constructs the path under t.TempDir() via filepath.Join instead of hard-coding an absolute Unix-style path, so the missing-path assumption holds across platforms
+      source: copilot:PR#651
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+    - id: comment-matches-actual-contract
+      category: style
+      pattern: >-
+        Code comments that describe what a config field or API is used for, especially when the field has a resolver/wrapper method (e.g. ResolvedX()) that applies defaults or clamping
+      check: >-
+        Verify the comment accurately describes the actual contract being relied on by callers — if callers use a resolver method (ResolvedTurnTimeout()) rather than the raw field (TurnTimeout), the comment should reflect that, including any defaulting or clamping behavior the resolver provides
+      source: copilot:PR#651
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+    - id: lifo-defer-channel-close-order
+      category: concurrency
+      pattern: >-
+        Multiple deferred close() calls on related channels (e.g., Done and Events) in the same function, where consumers rely on a documented close ordering
+      check: >-
+        Verify deferred channel closes execute in the order required by the documented contract. Since defers run LIFO, the channel that must close LAST should be deferred FIRST. Confirm the actual close order matches doc comments (e.g., 'Events closed after Done') and won't surprise consumers selecting on one channel while draining another.
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: async-goroutine-context-shutdown
+      category: concurrency
+      pattern: >-
+        Handler spawns a goroutine for async work using context.Background() (or a fresh context) instead of deriving from a server/shutdown-scoped context
+      check: >-
+        Verify async work started from HTTP handlers derives its context from a server-scoped context (cancelled on shutdown) — e.g. context.WithoutCancel(r.Context()) + WithTimeout, or a daemon context — so in-flight work is cancelled on shutdown rather than running until timeout
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: goroutine-panic-recovery
+      category: error-handling
+      pattern: >-
+        Long-running goroutines (especially async task runners) that comments or contracts claim cannot panic or always complete cleanly
+      check: >-
+        Verify the goroutine has a deferred recover() that records an error status and emits an error event for panics (nil deref, send on closed channel, etc.), OR that any comment claiming panic-safety is removed/softened to match actual behavior
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: json-tags-for-serialized-structs
+      category: style
+      pattern: >-
+        Struct types whose values are serialized to JSON (e.g., embedded in API responses, snapshots, or DTOs)
+      check: >-
+        Verify all exported fields have explicit json tags matching the project's casing convention (typically snake_case), or that a dedicated transport DTO is used; without tags, fields serialize as Go-style PascalCase and break API consistency
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: doc-matches-default-behavior
+      category: style
+      pattern: >-
+        Function/struct comments describing behavior for sentinel parameter values (e.g., 0, nil, empty) when the implementation applies defaults
+      check: >-
+        Verify that doc comments accurately describe the actual behavior for sentinel/zero values — if the code defaults <=0 to a fallback, the comment must say so rather than describing literal zero-value semantics
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: doc-comment-api-name-match
+      category: style
+      pattern: >-
+        Field or method documentation comments that reference other API names (e.g., 'see SetFoo' or 'used by SetBar')
+      check: >-
+        Verify that any API names mentioned in doc comments match the actual exported identifier names in the code; rename references when methods/fields are renamed to prevent stale documentation.
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: use-shared-config-constants
+      category: style
+      pattern: >-
+        A package hard-codes a value (timeout, limit, threshold) that has a corresponding exported constant defined in internal/config or a shared config package
+      check: >-
+        Verify the code references the shared config constant instead of a hard-coded literal, so the value stays aligned if the config cap changes
+      source: copilot:PR#652
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+        - '**/*.mod'
+    - id: shared-channel-fanout
+      category: concurrency
+      pattern: >-
+        Handler or subscriber reads directly from a shared channel field on a state object intended to serve multiple concurrent consumers (e.g., SSE/WebSocket handlers reading `state.Events`)
+      check: >-
+        Verify each concurrent consumer gets its own subscription channel via a fan-out/broadcaster mechanism (e.g., `Subscribe(ctx)` returning a dedicated channel) rather than competing for events on a single shared channel, which would cause consumers to miss frames consumed by others
+      source: copilot:PR#653
+      added: "2026-05-22"
+      paths:
+        - '**/*.go'
+        - '**/*.md'
+    - id: clear-busy-on-stream-cancel
+      category: ui
+      pattern: >-
+        Cancelling an in-flight stream/async operation where a `busy`/loading state is only cleared by terminal stream callbacks
+      check: >-
+        Verify that cancellation paths (e.g. `cancelActiveStream`, session switches, unmount cleanup) explicitly reset `busy`/loading state, otherwise cancelling without a follow-up start can leave the UI permanently disabled
+      source: copilot:PR#654
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: preserve-input-on-submit-failure
+      category: ui
+      pattern: >-
+        Optimistic UI clears user input (composer/form field) before async submission completes
+      check: >-
+        Verify the original input is restored to the field if the submission fails, either by passing the text to the async handler for rollback or by reporting failure back to the caller
+      source: copilot:PR#654
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: clear-reconnect-state-on-success
+      category: ui
+      pattern: >-
+        UI state flag (e.g. 'reconnecting') is set on transient errors and only cleared in a one-shot connection handler (e.g. onOpen guarded by an 'opened' flag)
+      check: >-
+        Verify the state flag is also cleared on any successful subsequent event (data delta, tool event, successful poll) so the UI doesn't get stuck after the first connection when later transient errors occur during fallback/polling
+      source: copilot:PR#654
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: eventsource-closed-terminal-error
+      category: error-handling
+      pattern: >-
+        EventSource error handler that ignores errors without MessageEvent.data, assuming the browser will auto-reconnect
+      check: >-
+        Verify the error handler inspects es.readyState (or tracks repeated errors) and surfaces a terminal onError when readyState === EventSource.CLOSED, so the UI does not get stuck in a perpetual reconnecting state
+      source: copilot:PR#654
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: transport-recovery-callback
+      category: ui
+      pattern: >-
+        Polling or streaming fallback transports that expose an onOpen/recovered callback to consumers
+      check: >-
+        Verify the recovery callback fires on every transition from failed to successful (not only the first success) so UI consumers can reliably clear reconnecting/error state after transient failures, or that a distinct recovery handler is provided
+      source: copilot:PR#654
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: ipc-payload-note-field-parity
+      category: ui
+      pattern: >-
+        SPA/UI resolve action sends an optional field (e.g., audit note) to a daemon IPC payload struct
+      check: >-
+        Verify the IPC payload struct and daemon handler accept and persist the field (e.g., note) for every resolve verb, or that the field is explicitly suppressed/disabled in the UI for verbs that don't support it — never silently drop user-supplied data
+      source: copilot:PR#655
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: audit-note-plumbing
+      category: ui
+      pattern: >-
+        Operator action dispatch handlers (e.g., IPC payloads for verbs like warden-rerun, approve, etc.) that accept a note/comment field from the UI
+      check: >-
+        Verify that operator-entered audit notes are plumbed through IPC/daemon logging for every action verb. If a verb cannot accept notes, ensure the UI hides/disables the note input or the backend clearly documents that notes don't apply, so context isn't silently dropped.
+      source: copilot:PR#655
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: comment-accuracy-vs-behavior
+      category: style
+      pattern: >-
+        Explanatory comments describing why a code branch exists or what states it covers (e.g., constants, lookup tables, guard clauses)
+      check: >-
+        Verify the comment's claim matches the actual runtime behavior and all use cases that reach the code; reword to reflect the true distinction (e.g., 'no currently running worker' vs 'no worker ever started') when the code handles post-start failure modes too
+      source: copilot:PR#655
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: comment-count-accuracy
+      category: testing
+      pattern: >-
+        Test file comments that describe the number or set of items being asserted (e.g., 'checks five verbs', 'validates all four states')
+      check: >-
+        Verify the comment's stated count or enumeration matches the actual assertions in the following block; update the comment when assertions are added, removed, or intentionally omitted so it doesn't mislead future edits.
+      source: copilot:PR#655
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'
+    - id: test-doc-comment-accuracy
+      category: testing
+      pattern: Test functions with doc comments describing what is being asserted
+      check: >-
+        Verify the test's doc comment accurately describes what the test actually asserts, not a different or outdated behavior
+      source: copilot:PR#655
+      added: "2026-05-22"
+      paths:
+        - '**/*.css'
+        - '**/*.go'
+        - '**/*.html'
+        - '**/*.js'
+        - '**/*.md'
+        - '**/*.ts'
+        - '**/*.tsx'


### PR DESCRIPTION
Automated batch update of warden rules.

- 23 new rule(s) learned from Copilot review comments.
- 635 rule(s) with paths backfilled from PR changed files.

Generated by the Forge Smelter.