### PR TITLE
Bellows does not re-emit EventPRConflicting when PR stays conflicting across a failed rebase cycle (Forge-h2a6)

### DIFF
--- a/changelog.d/Forge-h2a6.md
+++ b/changelog.d/Forge-h2a6.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Bellows re-emits EventPRConflicting when PR stays conflicting across a failed rebase cycle** - Mirror the CI still-failing and review still-unresolved retry branches on the rebase path so a transient `git fetch` failure (or any aborted rebase) no longer permanently strands a CONFLICTING PR. (Forge-h2a6)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -68,6 +68,7 @@ type Monitor struct {
 	autoLearnRules       func() bool            // auto-learn warden rules from Copilot comments on PR merge
 	maxCIFixAttempts     func() int             // returns current max CI fix attempts from config
 	maxReviewFixAttempts func() int             // returns current max review fix attempts from config
+	maxRebaseAttempts    func() int             // returns current max rebase attempts from config
 	learnMuGuard     sync.Mutex             // protects learnMu map
 	learnMu          map[string]*sync.Mutex // per-anvil mutex serializing auto-learn
 	learnSem         chan struct{}          // caps overall concurrent auto-learn goroutines
@@ -93,11 +94,11 @@ type prSnapshot struct {
 // provider for a given anvil name, enabling per-anvil platform support.
 // The autoLearnRules function is called on each PR merge to check whether
 // warden rule learning is enabled, so hot-reloaded config changes take effect
-// without restarting the daemon. The maxCIFixAttempts and maxReviewFixAttempts
-// functions return the current max fix attempts from config (either may be nil,
-// in which case state.DefaultMaxCIFixAttempts / state.DefaultMaxReviewFixAttempts
-// is used).
-func New(db *state.DB, vcsLookup func(anvil string) vcs.Provider, interval time.Duration, anvilPaths map[string]string, autoLearnRules func() bool, maxCIFixAttempts func() int, maxReviewFixAttempts func() int) *Monitor {
+// without restarting the daemon. The maxCIFixAttempts, maxReviewFixAttempts,
+// and maxRebaseAttempts functions return the current max fix attempts from
+// config (any may be nil, in which case the corresponding state.Default* is
+// used).
+func New(db *state.DB, vcsLookup func(anvil string) vcs.Provider, interval time.Duration, anvilPaths map[string]string, autoLearnRules func() bool, maxCIFixAttempts func() int, maxReviewFixAttempts func() int, maxRebaseAttempts func() int) *Monitor {
 	if interval < 30*time.Second {
 		interval = 30 * time.Second
 	}
@@ -106,6 +107,9 @@ func New(db *state.DB, vcsLookup func(anvil string) vcs.Provider, interval time.
 	}
 	if maxReviewFixAttempts == nil {
 		maxReviewFixAttempts = func() int { return state.DefaultMaxReviewFixAttempts }
+	}
+	if maxRebaseAttempts == nil {
+		maxRebaseAttempts = func() int { return state.DefaultMaxRebaseAttempts }
 	}
 	return &Monitor{
 		db:                   db,
@@ -117,6 +121,7 @@ func New(db *state.DB, vcsLookup func(anvil string) vcs.Provider, interval time.
 		autoLearnRules:       autoLearnRules,
 		maxCIFixAttempts:     maxCIFixAttempts,
 		maxReviewFixAttempts: maxReviewFixAttempts,
+		maxRebaseAttempts:    maxRebaseAttempts,
 		learnMu:              make(map[string]*sync.Mutex),
 		learnSem:             make(chan struct{}, 4), // allow up to 4 concurrent auto-learn goroutines
 		wasUnmanaged:         make(map[string]bool),
@@ -655,6 +660,29 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 		_ = m.db.LogEvent(state.EventPRConflicting,
 			fmt.Sprintf("PR #%d: merge conflict detected", pr.Number),
 			pr.BeadID, pr.Anvil)
+	} else if newSnap.IsConflicting && lastSnap.IsConflicting {
+		// PR is still conflicting with no transition. Catches the gap where a
+		// rebase action dispatched but failed at the prep step (e.g. transient
+		// git fetch failure) or where rebase itself failed and the PR stayed
+		// CONFLICTING. Without this, the seeding guard's RebaseCount > 0 clause
+		// keeps lastSnap.IsConflicting=true forever and no new event ever fires.
+		// Mirrors the CI still-failing and review still-unresolved branches.
+		maxR := m.maxRebaseAttempts()
+		if pr.Status != state.PRNeedsFix && pr.RebaseCount > 0 && pr.RebaseCount < maxR {
+			m.emit(ctx, PREvent{
+				PRNumber:  pr.Number,
+				BeadID:    pr.BeadID,
+				Anvil:     pr.Anvil,
+				Branch:    status.HeadRefName,
+				EventType: EventPRConflicting,
+				Details:   fmt.Sprintf("PR still has merge conflicts after rebase attempt %d/%d", pr.RebaseCount, maxR),
+				Timestamp: time.Now(),
+			})
+			_ = m.db.UpdatePRStatus(pr.ID, state.PRNeedsFix)
+			_ = m.db.LogEvent(state.EventPRConflicting,
+				fmt.Sprintf("PR #%d rebase retry needed (attempt %d/%d)", pr.Number, pr.RebaseCount, maxR),
+				pr.BeadID, pr.Anvil)
+		}
 	}
 
 	// Trigger on "CHANGES_REQUESTED" or transition from 0 to >0 unresolved threads (Bug 1)

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -18,22 +18,22 @@ import (
 
 func TestNew_MinimumInterval(t *testing.T) {
 	// Intervals below 30s should be clamped to 30s
-	m := New(nil, nil, 5*time.Second, nil, nil, nil, nil)
+	m := New(nil, nil, 5*time.Second, nil, nil, nil, nil, nil)
 	assert.Equal(t, 30*time.Second, m.interval)
 }
 
 func TestNew_IntervalAboveMin(t *testing.T) {
-	m := New(nil, nil, 2*time.Minute, nil, nil, nil, nil)
+	m := New(nil, nil, 2*time.Minute, nil, nil, nil, nil, nil)
 	assert.Equal(t, 2*time.Minute, m.interval)
 }
 
 func TestNew_ExactMinimum(t *testing.T) {
-	m := New(nil, nil, 30*time.Second, nil, nil, nil, nil)
+	m := New(nil, nil, 30*time.Second, nil, nil, nil, nil, nil)
 	assert.Equal(t, 30*time.Second, m.interval)
 }
 
 func TestOnEvent_RegistersHandler(t *testing.T) {
-	m := New(nil, nil, time.Minute, nil, nil, nil, nil)
+	m := New(nil, nil, time.Minute, nil, nil, nil, nil, nil)
 	m.mu.Lock()
 	initial := len(m.handlers)
 	m.mu.Unlock()
@@ -48,7 +48,7 @@ func TestOnEvent_RegistersHandler(t *testing.T) {
 }
 
 func TestEmit_DispatchesToAllHandlers(t *testing.T) {
-	m := New(nil, nil, time.Minute, nil, nil, nil, nil)
+	m := New(nil, nil, time.Minute, nil, nil, nil, nil, nil)
 
 	var mu sync.Mutex
 	var received []string
@@ -376,7 +376,7 @@ func TestCheckAll_BellowsManagedPRsGetWorkerRow(t *testing.T) {
 	require.NoError(t, db.InsertPR(extUnmanaged))
 	require.NoError(t, db.UpdatePRBellowsManaged(extUnmanaged.ID, false))
 
-	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil, nil)
 	m.checkAll(context.Background())
 
 	workers, err := db.ActiveWorkers()
@@ -408,7 +408,7 @@ func TestCheckAll_WorkerRowNotDuplicatedOnRepeatPolls(t *testing.T) {
 	}
 	require.NoError(t, db.InsertPR(pr))
 
-	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil, nil)
 	m.checkAll(context.Background())
 	m.checkAll(context.Background())
 	m.checkAll(context.Background())
@@ -652,7 +652,7 @@ func TestCheckPR_ReviewStillUnresolved_ReemitsEvent(t *testing.T) {
 	var events []string
 	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
 		map[string]string{"test-anvil": "/fake"}, nil, nil,
-		func() int { return 5 })
+		func() int { return 5 }, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -694,7 +694,7 @@ func TestCheckPR_ReviewStillUnresolved_RespectsMaxAttempts(t *testing.T) {
 	var events []string
 	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
 		map[string]string{"test-anvil": "/fake"}, nil, nil,
-		func() int { return 5 })
+		func() int { return 5 }, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -737,7 +737,7 @@ func TestCheckPR_ReviewStillUnresolved_SkipsInFlightBurnish(t *testing.T) {
 	var events []string
 	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
 		map[string]string{"test-anvil": "/fake"}, nil, nil,
-		func() int { return 5 })
+		func() int { return 5 }, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -746,6 +746,139 @@ func TestCheckPR_ReviewStillUnresolved_SkipsInFlightBurnish(t *testing.T) {
 
 	assert.NotContains(t, events, EventReviewChanges,
 		"EventReviewChanges must NOT fire while a burnish is already in flight (status=needs_fix)")
+}
+
+// TestCheckPR_StillConflicting_ReemitsEvent is the end-to-end regression test
+// for Forge-h2a6: after a rebase action dispatched (whether it ran or bailed
+// at worktree creation) and the PR is still CONFLICTING, the next bellows
+// poll must re-emit EventPRConflicting and flip the PR back to needs_fix so a
+// new rebase dispatches.
+func TestCheckPR_StillConflicting_ReemitsEvent(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	// Insert a PR that already went through one rebase cycle: open status,
+	// RebaseCount=1, conflict still present. The seeding guard at
+	// bellows.go:449-452 preserves IsConflicting=true when RebaseCount > 0,
+	// so lastSnap.IsConflicting=true on the first poll. Combined with
+	// newSnap.IsConflicting=true from the VCS status, the primary transition
+	// branch (new && !last) cannot fire — only the secondary "still
+	// conflicting" branch can.
+	pr := &state.PR{
+		Number:      800,
+		Anvil:       "test-anvil",
+		BeadID:      "forge-stillconflict",
+		Branch:      "forge/forge-stillconflict",
+		Status:      state.PROpen,
+		RebaseCount: 1,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	// InsertPR does not write the mergeability flags; set them explicitly.
+	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, true, false, false, false))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:     "OPEN",
+		Mergeable: "CONFLICTING",
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil, nil,
+		func() int { return 3 })
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.Contains(t, events, EventPRConflicting,
+		"EventPRConflicting must re-fire when the PR stays conflicting across a rebase cycle")
+
+	updated, err := db.GetPRByID(pr.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.PRNeedsFix, updated.Status,
+		"PR must be flipped back to needs_fix so a new rebase dispatches")
+}
+
+// TestCheckPR_StillConflicting_RespectsMaxAttempts verifies that the retry
+// cap honoured by the still-conflicting branch matches max_rebase_attempts.
+func TestCheckPR_StillConflicting_RespectsMaxAttempts(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:      801,
+		Anvil:       "test-anvil",
+		BeadID:      "forge-rebasecap",
+		Branch:      "forge/forge-rebasecap",
+		Status:      state.PROpen,
+		RebaseCount: 3, // at the cap
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, true, false, false, false))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:     "OPEN",
+		Mergeable: "CONFLICTING",
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil, nil,
+		func() int { return 3 })
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventPRConflicting,
+		"EventPRConflicting must NOT fire once the rebase cap is reached")
+
+	updated, err := db.GetPRByID(pr.ID)
+	require.NoError(t, err)
+	assert.Equal(t, state.PROpen, updated.Status,
+		"PR status must not be flipped to needs_fix when the cap is reached")
+}
+
+// TestCheckPR_StillConflicting_SkipsInFlightRebase verifies that a PR
+// already in needs_fix (a rebase is in flight) does not receive a duplicate
+// dispatch from the still-conflicting branch.
+func TestCheckPR_StillConflicting_SkipsInFlightRebase(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:      802,
+		Anvil:       "test-anvil",
+		BeadID:      "forge-rebaseinflight",
+		Branch:      "forge/forge-rebaseinflight",
+		Status:      state.PRNeedsFix,
+		RebaseCount: 1,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, true, false, false, false))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:     "OPEN",
+		Mergeable: "CONFLICTING",
+	}}
+
+	var events []string
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil, nil,
+		func() int { return 3 })
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventPRConflicting,
+		"EventPRConflicting must NOT fire while a rebase is already in flight (status=needs_fix)")
 }
 
 // TestCheckPR_CIInProgressDoesNotTriggerFailure verifies that bellows does not
@@ -775,7 +908,7 @@ func TestCheckPR_CIInProgressDoesNotTriggerFailure(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -819,7 +952,7 @@ func TestCheckPR_CICompletedFailureTriggersCIFailed(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -850,7 +983,7 @@ func TestCheckPR_PassingThenInProgressThenFailure(t *testing.T) {
 
 	fake := &fakeVCSProvider{}
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -907,7 +1040,7 @@ func TestCheckPR_StatusContextPendingBlocksCIFailed(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -946,7 +1079,7 @@ func TestCheckPR_CompletedEmptyConclusionBlocksCIFailed(t *testing.T) {
 	}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -979,7 +1112,7 @@ func TestCheckPR_TitleBackfill(t *testing.T) {
 		Title: "My PR title",
 	}}
 
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.checkAll(context.Background())
 
 	updated, err := db.GetPRByID(pr.ID)
@@ -1068,7 +1201,7 @@ func TestCheckPR_PRMergedUpdatesIngotStatus(t *testing.T) {
 	seedIngot(t, db.Conn(), pr.BeadID, pr.Anvil)
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 
 	m.checkAll(context.Background())
 
@@ -1095,7 +1228,7 @@ func TestCheckPR_PRClosedUpdatesIngotStatus(t *testing.T) {
 	seedIngot(t, db.Conn(), pr.BeadID, pr.Anvil)
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "CLOSED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 
 	m.checkAll(context.Background())
 
@@ -1124,7 +1257,7 @@ func TestCheckPR_MissingIngotIsNoOp(t *testing.T) {
 
 	var events []string
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -1171,7 +1304,7 @@ func TestCheckPR_NeedsFixToMergedTransition(t *testing.T) {
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -1206,7 +1339,7 @@ func TestCheckPR_NeedsFixToClosedTransition(t *testing.T) {
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "CLOSED"}}
 
 	var events []string
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.OnEvent(func(_ context.Context, e PREvent) {
 		events = append(events, e.EventType)
 	})
@@ -1245,7 +1378,7 @@ func TestCheckPR_OpenWithCIFailureStillTransitionsToNeedsFix(t *testing.T) {
 		},
 	}}
 
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 	m.checkAll(context.Background())
 
 	updated, err := db.GetPRByID(pr.ID)
@@ -1276,7 +1409,7 @@ func TestReconcileTerminalStates(t *testing.T) {
 	seedIngot(t, db.Conn(), mergedPR.BeadID, mergedPR.Anvil)
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{State: "MERGED"}}
-	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil)
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute, map[string]string{"test-anvil": "/fake"}, nil, nil, nil, nil)
 
 	m.reconcileTerminalStates(context.Background())
 
@@ -1369,7 +1502,7 @@ func TestSweepOrphanedMonitoringWorkers_TerminalPR(t *testing.T) {
 				StartedAt: time.Now(),
 			}))
 
-			m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil)
+			m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil, nil)
 			m.sweepOrphanedMonitoringWorkers()
 
 			workers, err := db.WorkersByBead(pr.BeadID, pr.Anvil, 0)
@@ -1416,7 +1549,7 @@ func TestSweepOrphanedMonitoringWorkers_MissingPR(t *testing.T) {
 		StartedAt: time.Now(),
 	}))
 
-	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil, nil)
 	m.sweepOrphanedMonitoringWorkers()
 
 	workers, err := db.WorkersByBead("ext-9999", "munin", 0)
@@ -1457,7 +1590,7 @@ func TestSweepOrphanedMonitoringWorkers_IgnoresNonBellowsWorkers(t *testing.T) {
 		StartedAt: time.Now(),
 	}))
 
-	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil)
+	m := New(db, nil, time.Minute, map[string]string{"munin": "/fake"}, nil, nil, nil, nil)
 	m.sweepOrphanedMonitoringWorkers()
 
 	w, err := db.WorkersByBead(pr.BeadID, pr.Anvil, 0)

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -758,12 +758,11 @@ func TestCheckPR_StillConflicting_ReemitsEvent(t *testing.T) {
 	defer cleanup()
 
 	// Insert a PR that already went through one rebase cycle: open status,
-	// RebaseCount=1, conflict still present. The seeding guard at
-	// bellows.go:449-452 preserves IsConflicting=true when RebaseCount > 0,
-	// so lastSnap.IsConflicting=true on the first poll. Combined with
-	// newSnap.IsConflicting=true from the VCS status, the primary transition
-	// branch (new && !last) cannot fire — only the secondary "still
-	// conflicting" branch can.
+	// RebaseCount=1, conflict still present. The seeding guard preserves
+	// IsConflicting=true when RebaseCount > 0, so lastSnap.IsConflicting=true
+	// on the first poll. Combined with newSnap.IsConflicting=true from the
+	// VCS status, the primary transition branch (new && !last) cannot fire —
+	// only the secondary "still conflicting" branch can.
 	pr := &state.PR{
 		Number:      800,
 		Anvil:       "test-anvil",

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -774,7 +774,8 @@ func TestCheckPR_StillConflicting_ReemitsEvent(t *testing.T) {
 		CreatedAt:   time.Now(),
 	}
 	require.NoError(t, db.InsertPR(pr))
-	// InsertPR does not write the mergeability flags; set them explicitly.
+	// InsertPR does not persist rebase_count or mergeability flags; set them explicitly.
+	require.NoError(t, db.UpdatePRLifecycle(pr.ID, 0, 0, 1, true))
 	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, true, false, false, false))
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{
@@ -817,6 +818,7 @@ func TestCheckPR_StillConflicting_RespectsMaxAttempts(t *testing.T) {
 		CreatedAt:   time.Now(),
 	}
 	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRLifecycle(pr.ID, 0, 0, 3, true))
 	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, true, false, false, false))
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{
@@ -860,6 +862,7 @@ func TestCheckPR_StillConflicting_SkipsInFlightRebase(t *testing.T) {
 		CreatedAt:   time.Now(),
 	}
 	require.NoError(t, db.InsertPR(pr))
+	require.NoError(t, db.UpdatePRLifecycle(pr.ID, 0, 0, 1, true))
 	require.NoError(t, db.UpdatePRMergeability(pr.ID, true, true, false, false, false))
 
 	fake := &fakeVCSProvider{status: &vcs.PRStatus{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1526,9 +1526,11 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 			// by its pr.Status != needs_fix guard. Mirror the CI-fix and
 			// review-fix paths.
 			d.lifecycleMgr.NotifyRebaseCompleted(req.Anvil, req.PRNumber)
-			// Reset the snapshot cache so the next poll can detect a fresh
-			// conflict transition rather than seeing the same still-conflicting
-			// snapshot and falling through to the still-conflicting branch.
+			// Reset the snapshot cache so Bellows re-seeds from the DB on
+			// the next poll. Without this, the cached snapshot would still
+			// have IsConflicting=true and the seeding guard would preserve
+			// that value, preventing the still-conflicting branch from
+			// re-emitting EventPRConflicting after the status is reset.
 			if d.bellowsMonitor != nil {
 				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
 			}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -967,6 +967,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return d.cfg.Load().Settings.MaxCIFixAttempts
 	}, func() int {
 		return d.cfg.Load().Settings.MaxReviewFixAttempts
+	}, func() int {
+		return d.cfg.Load().Settings.MaxRebaseAttempts
 	})
 	d.lifecycleMgr = lifecycle.New(d.db, d.logger, d.handleLifecycleAction)
 	d.lifecycleMgr.SetThresholds(

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1261,6 +1261,16 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 		wt, err := d.worktreeMgr.Create(ctx, anvilCfg.Path, lockKey, req.Branch)
 		if err != nil {
 			d.logger.Error("failed to create worktree for lifecycle fix", "error", err)
+			// Reset rebase state so Bellows can re-emit on the next poll.
+			// Without this the PR stays needs_fix after a worktree-creation
+			// failure (e.g. transient git fetch error) and the still-conflicting
+			// branch is permanently suppressed by its needs_fix guard.
+			if req.Action == lifecycle.ActionRebase {
+				d.lifecycleMgr.NotifyRebaseCompleted(req.Anvil, req.PRNumber)
+				if d.bellowsMonitor != nil {
+					d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
+				}
+			}
 			return
 		}
 		defer d.worktreeMgr.Remove(ctx, anvilCfg.Path, wt)
@@ -1509,6 +1519,19 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 				d.logger.Info("rebase succeeded", "pr", req.PRNumber, "bead", req.BeadID)
 			}
 			_ = d.db.UpdateWorkerStatus(workerID, status)
+			// Always notify lifecycle that the rebase cycle has completed so it
+			// resets pr.Status to open and allows Bellows to re-emit
+			// EventPRConflicting on the next poll if the PR is still conflicting.
+			// Without this the still-conflicting branch is permanently suppressed
+			// by its pr.Status != needs_fix guard. Mirror the CI-fix and
+			// review-fix paths.
+			d.lifecycleMgr.NotifyRebaseCompleted(req.Anvil, req.PRNumber)
+			// Reset the snapshot cache so the next poll can detect a fresh
+			// conflict transition rather than seeing the same still-conflicting
+			// snapshot and falling through to the still-conflicting branch.
+			if d.bellowsMonitor != nil {
+				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
+			}
 		}
 	}()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1261,15 +1261,21 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 		wt, err := d.worktreeMgr.Create(ctx, anvilCfg.Path, lockKey, req.Branch)
 		if err != nil {
 			d.logger.Error("failed to create worktree for lifecycle fix", "error", err)
-			// Reset rebase state so Bellows can re-emit on the next poll.
-			// Without this the PR stays needs_fix after a worktree-creation
-			// failure (e.g. transient git fetch error) and the still-conflicting
-			// branch is permanently suppressed by its needs_fix guard.
-			if req.Action == lifecycle.ActionRebase {
+			// Reset lifecycle and bellows state so the next Bellows poll can
+			// re-emit the appropriate event and retry. Without this, CINeedsFix /
+			// ReviewNeedsFix / Conflicting stay set after a transient worktree
+			// failure (e.g. git fetch error) and the still-failing/still-unresolved/
+			// still-conflicting re-emit branches are permanently suppressed.
+			switch req.Action {
+			case lifecycle.ActionRebase:
 				d.lifecycleMgr.NotifyRebaseCompleted(req.Anvil, req.PRNumber)
-				if d.bellowsMonitor != nil {
-					d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
-				}
+			case lifecycle.ActionFixCI:
+				d.lifecycleMgr.NotifyCIFixCompleted(req.Anvil, req.PRNumber)
+			case lifecycle.ActionFixReview:
+				d.lifecycleMgr.NotifyReviewFixCompleted(req.Anvil, req.PRNumber)
+			}
+			if d.bellowsMonitor != nil {
+				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
 			}
 			return
 		}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -624,7 +624,7 @@ func TestHandleIPC_RetryBead_ExhaustedPR(t *testing.T) {
 	lm := lifecycle.New(db, logger, func(_ context.Context, _ lifecycle.ActionRequest) {})
 
 	// Create bellows monitor (won't actually run, just needs to exist for reset).
-	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil, nil)
+	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil, nil, nil)
 
 	d := &Daemon{
 		db:             db,
@@ -775,7 +775,7 @@ func TestHandleIPC_RetryBead_NonBeadPR(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	lm := lifecycle.New(db, logger, func(_ context.Context, _ lifecycle.ActionRequest) {})
-	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil, nil)
+	bm := bellows.New(db, nil, time.Minute, map[string]string{"test-anvil": tmpDir}, nil, nil, nil, nil)
 
 	d := &Daemon{
 		db:             db,

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -502,3 +502,38 @@ func (m *Manager) NotifyReviewFixCompleted(anvil string, prNumber int) {
 		}
 	}
 }
+
+// NotifyRebaseCompleted clears the Conflicting flag after a rebase cycle
+// finishes (success or failure) and persists the transition needs_fix → open
+// so the Bellows still-conflicting branch can re-emit EventPRConflicting on
+// the next poll if the PR is still conflicting.
+//
+// Without this, pr.Status stays needs_fix after a rebase attempt completes.
+// The still-conflicting branch is gated on pr.Status != needs_fix, so it
+// would be permanently suppressed and the PR would be permanently stuck.
+func (m *Manager) NotifyRebaseCompleted(anvil string, prNumber int) {
+	m.mu.Lock()
+	st, ok := m.states[m.key(anvil, prNumber)]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	st.Conflicting = false
+	dbID := st.ID
+	ciNeedsFix := st.CINeedsFix
+	reviewNeedsFix := st.ReviewNeedsFix
+	m.mu.Unlock()
+
+	m.logger.Info("rebase cycle completed, cleared Conflicting", "pr", prNumber, "anvil", anvil)
+
+	// Persist the cleared state so Bellows can re-detect the conflict on the
+	// next poll. Only transition needs_fix → open when no other fix cycle is
+	// active; if CINeedsFix or ReviewNeedsFix is set the DB status must stay
+	// needs_fix so those fix cycles are preserved across daemon restarts.
+	if dbID > 0 && !ciNeedsFix && !reviewNeedsFix {
+		if err := m.db.UpdatePRStatusIfNeedsFix(dbID, state.PROpen); err != nil {
+			m.logger.Warn("failed to persist PROpen after rebase completed",
+				"pr", prNumber, "anvil", anvil, "error", err)
+		}
+	}
+}

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -925,6 +925,140 @@ func TestNotifyCIFixCompleted_Noop(t *testing.T) {
 	m.NotifyCIFixCompleted("nonexistent-anvil", 999)
 }
 
+// TestNotifyRebaseCompleted_ResetsToOpen verifies that NotifyRebaseCompleted
+// clears the Conflicting flag and, when no other fix cycle is active,
+// transitions the DB status from needs_fix back to open. This allows the
+// Bellows still-conflicting branch to re-emit EventPRConflicting on the next
+// poll and dispatch a fresh rebase if the PR is still conflicting.
+func TestNotifyRebaseCompleted_ResetsToOpen(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Insert a PR whose DB status is needs_fix (simulating the state left
+	// after a rebase cycle was dispatched and set the status).
+	pr := &state.PR{
+		Number:    801,
+		Anvil:     "test-anvil",
+		BeadID:    "bead-rebase",
+		Branch:    "forge/bead-rebase",
+		Status:    state.PRNeedsFix,
+		CreatedAt: time.Now(),
+	}
+	if err := db.InsertPR(pr); err != nil {
+		t.Fatalf("InsertPR: %v", err)
+	}
+
+	// Load the PR into a fresh lifecycle manager. Load preserves needs_fix
+	// in the DB when CIPassing=false and sets CINeedsFix=false in memory.
+	m := New(db, testLogger(), nil)
+	if err := m.Load(ctx); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	st := m.GetState("test-anvil", 801)
+	if st == nil {
+		t.Fatal("expected lifecycle state for PR #801 after Load")
+	}
+	// Manually mark Conflicting=true to simulate the in-flight rebase state.
+	// In production this would have been set by HandleEvent(EventPRConflicting).
+	st.Conflicting = true
+
+	// Rebase worker finishes with no other active fix cycles.
+	m.NotifyRebaseCompleted("test-anvil", 801)
+
+	st = m.GetState("test-anvil", 801)
+	if st.Conflicting {
+		t.Error("expected Conflicting=false after NotifyRebaseCompleted")
+	}
+
+	// Verify the DB status was transitioned needs_fix → open.
+	dbPR, err := db.GetPRByNumber("test-anvil", 801)
+	if err != nil {
+		t.Fatalf("GetPRByNumber: %v", err)
+	}
+	if dbPR == nil {
+		t.Fatal("PR #801 not found in DB")
+	}
+	if dbPR.Status != state.PROpen {
+		t.Errorf("expected DB status PROpen after rebase completed, got %s", dbPR.Status)
+	}
+}
+
+// TestNotifyRebaseCompleted_KeepsNeedsFixWhenOtherCycleActive verifies that
+// NotifyRebaseCompleted does NOT clear the DB needs_fix status when CINeedsFix
+// or ReviewNeedsFix is still true, so those active fix cycles are preserved
+// across a daemon restart.
+func TestNotifyRebaseCompleted_KeepsNeedsFixWhenOtherCycleActive(t *testing.T) {
+	db := newTestDB(t)
+	var dispatched []ActionRequest
+	handler := func(_ context.Context, req ActionRequest) {
+		dispatched = append(dispatched, req)
+	}
+	ctx := context.Background()
+
+	// Sub-case: both CINeedsFix and ReviewNeedsFix active.
+	t.Run("CIAndReviewBothActive", func(t *testing.T) {
+		m := New(db, testLogger(), handler)
+		m.HandleEvent(ctx, makeEvent(900, bellows.EventCIFailed))
+		m.HandleEvent(ctx, makeEvent(900, bellows.EventReviewChanges))
+		m.HandleEvent(ctx, makeEvent(900, bellows.EventPRConflicting))
+
+		m.NotifyRebaseCompleted("test-anvil", 900)
+
+		st := m.GetState("test-anvil", 900)
+		if st.Conflicting {
+			t.Error("expected Conflicting=false after NotifyRebaseCompleted")
+		}
+		if !st.CINeedsFix {
+			t.Error("CINeedsFix must remain true — CI fix cycle is still active")
+		}
+		if !st.ReviewNeedsFix {
+			t.Error("ReviewNeedsFix must remain true — review fix cycle is still active")
+		}
+	})
+
+	// Sub-case: only CINeedsFix active.
+	t.Run("OnlyCIActive", func(t *testing.T) {
+		m := New(db, testLogger(), handler)
+		m.HandleEvent(ctx, makeEvent(901, bellows.EventCIFailed))
+		m.HandleEvent(ctx, makeEvent(901, bellows.EventPRConflicting))
+		m.NotifyRebaseCompleted("test-anvil", 901)
+
+		st := m.GetState("test-anvil", 901)
+		if st.Conflicting {
+			t.Error("expected Conflicting=false after rebase completed")
+		}
+		if !st.CINeedsFix {
+			t.Error("CINeedsFix must remain true when only CI is active")
+		}
+	})
+
+	// Sub-case: only ReviewNeedsFix active.
+	t.Run("OnlyReviewActive", func(t *testing.T) {
+		m := New(db, testLogger(), handler)
+		m.HandleEvent(ctx, makeEvent(902, bellows.EventReviewChanges))
+		m.HandleEvent(ctx, makeEvent(902, bellows.EventPRConflicting))
+		m.NotifyRebaseCompleted("test-anvil", 902)
+
+		st := m.GetState("test-anvil", 902)
+		if st.Conflicting {
+			t.Error("expected Conflicting=false after rebase completed")
+		}
+		if !st.ReviewNeedsFix {
+			t.Error("ReviewNeedsFix must remain true when only review is active")
+		}
+	})
+}
+
+// TestNotifyRebaseCompleted_Noop verifies NotifyRebaseCompleted is safe to call
+// for unknown PRs.
+func TestNotifyRebaseCompleted_Noop(t *testing.T) {
+	db := newTestDB(t)
+	m := New(db, testLogger(), nil)
+	// Should not panic.
+	m.NotifyRebaseCompleted("nonexistent-anvil", 999)
+}
+
 // TestCIFixRetryFlowToExhaustion exercises the lifecycle CI fix retry loop:
 // repeated EventCIFailed → dispatch → NotifyCIFixCompleted → next EventCIFailed,
 // verifying that each cycle dispatches until maxCI is reached and then stops.


### PR DESCRIPTION
## Changes

- **Bellows re-emits EventPRConflicting when PR stays conflicting across a failed rebase cycle** - Mirror the CI still-failing and review still-unresolved retry branches on the rebase path so a transient `git fetch` failure (or any aborted rebase) no longer permanently strands a CONFLICTING PR. (Forge-h2a6)

## Original Issue (bug): Bellows does not re-emit EventPRConflicting when PR stays conflicting across a failed rebase cycle

## Problem

After a rebase attempt finishes (whether the rebase worker actually ran or it bailed at worktree creation), any subsequent poll that still sees the PR as `Mergeable=CONFLICTING` never fires another EventPRConflicting. The PR is stuck `is_conflicting=1` indefinitely with no further bellows activity. From the operator's perspective, "merge conflict detected" appears once in the event log and then bellows goes silent — even though the conflict is still there.

Observed on skybert-forge today (2026-05-26) for PR #3297 (Fhi.Metadata-h6db8 on munin):

```
09:53:14 [INFO] PR merge conflict detected, dispatching rebase pr=3297 anvil=munin attempt=1
09:53:14 [INFO] lifecycle action requested action=5 pr=3297 bead=Fhi.Metadata-h6db8
09:53:16 [ERROR] failed to create worktree for lifecycle fix error="git fetch: exit status 1"
```

That's the *only* dispatching-rebase line for PR 3297 over the next 20+ minutes, even though the PR row continued to show `is_conflicting=1, rebase_count=1, status=needs_fix` and the GitHub mergeability was still CONFLICTING on every poll. The transient `git fetch` blip (works fine on retry) burned the one and only attempt slot bellows would dispatch, then bellows refused to re-emit because the snapshot stayed `IsConflicting=true → IsConflicting=true` (no transition).

## Root cause

`internal/bellows/bellows.go:644-658` has the *first-transition* branch only:

```go
// Detect merge conflicts (CONFLICTING → fire event so operator / lifecycle can rebase)
if newSnap.IsConflicting && !lastSnap.IsConflicting {
    m.emit(ctx, PREvent{ ..., EventType: EventPRConflicting, ... })
    _ = m.db.UpdatePRStatus(pr.ID, state.PRNeedsFix)
    _ = m.db.LogEvent(state.EventPRConflicting, ...)
}
```

No still-conflicting branch. Combined with the seeding guard at line 449-451:

```go
conflictSeed := pr.IsConflicting
if conflictSeed && pr.Status != state.PRNeedsFix && pr.RebaseCount == 0 {
    conflictSeed = false
}
```

which refuses to clear the seed once `RebaseCount > 0`, the trap is exactly the bead 05 trap on a different code path:

- First poll: 0→1 transition fires once, lifecycle increments RebaseCount=1, action dispatched.
- Rebase action fails at worktree creation (git fetch exit 1). Worker row never inserted. No NotifyRebaseCompleted equivalent runs (and even if it did, the seeding guard would still refuse to clear the seed because RebaseCount=1).
- Second poll onward: lastSnap.IsConflicting=true (seeded), newSnap.IsConflicting=true. Transition `(new && !last)` = false. No emit. No rebase. Stuck.

This is the **same bug class** as beads 04 and 05 (bellows transition-detection gap), but on the rebase path. The mechanical fix is the mirror of bead 05.

### Compounding issue (Bug A — same fix should also address this)

`internal/lifecycle/lifecycle.go:311-320` increments `RebaseCount` on action *dispatch*, not on rebase *completion*:

```go
case bellows.EventPRConflicting:
    st.Conflicting = true
    if st.RebaseCount < m.maxRebase {
        st.RebaseCount++          // <-- incremented before any work runs
        action = ActionRebase
        m.logger.Info("PR merge conflict detected, dispatching rebase", ..., "attempt", st.RebaseCount)
```

When `handleLifecycleAction` then bails at the pre-rebase worktree creation (daemon.go:1259-1263), the counter is now at 1 with zero actual rebase work done. Combined with the missing still-failing branch above, a single transient `git fetch` failure permanently strands the PR.

The same count-on-dispatch shape exists for CI fixes (CIFixCnt++) and review fixes (ReviewFixCnt++). Beads 04/05 made the review/CI paths tolerant via still-failing re-emits, so an early-bail in those paths self-recovers on the next poll. The rebase path needs the same treatment.

## Proposed fix

Mechanical mirror of bead 05. Add a parallel "still conflicting" branch immediately after the existing conflict block at `internal/bellows/bellows.go:644-658`:

```go
// Existing transition branch (unchanged) at 644-658:
if newSnap.IsConflicting && !lastSnap.IsConflicting {
    // ...emit EventPRConflicting, set PRNeedsFix...
} else if newSnap.IsConflicting && lastSnap.IsConflicting {
    // PR is still conflicting with no transition. Catches the gap where a
    // rebase action dispatched but failed at the prep step (e.g. transient
    // git fetch failure) or where rebase itself failed and the PR stayed
    // CONFLICTING. Without this, the seeding guard's `RebaseCount > 0` clause
    // keeps lastSnap.IsConflicting=true forever and no new event ever fires.
    // Mirrors the CI still-failing and review still-failing branches.
    maxR := m.maxRebaseAttempts()
    if pr.Status != state.PRNeedsFix && pr.RebaseCount > 0 && pr.RebaseCount < maxR {
        m.emit(ctx, PREvent{
            PRNumber:  pr.Number,
            BeadID:    pr.BeadID,
            Anvil:     pr.Anvil,
            Branch:    status.HeadRefName,
            EventType: EventPRConflicting,
            Details:   fmt.Sprintf("PR still has merge conflicts after rebase attempt %d/%d", pr.RebaseCount, maxR),
            Timestamp: time.Now(),
        })
        _ = m.db.UpdatePRStatus(pr.ID, state.PRNeedsFix)
        _ = m.db.LogEvent(state.EventPRConflicting,
            fmt.Sprintf("PR #%d rebase retry needed (attempt %d/%d)", pr.Number, pr.RebaseCount, maxR),
            pr.BeadID, pr.Anvil)
    }
}
```

Guards (mirror of CI / review paths):
- `pr.Status != state.PRNeedsFix` — only re-emit when the PR is currently *not* in a fix cycle. Prevents firing during an in-flight rebase.
- `pr.RebaseCount > 0` — only after at least one attempt was dispatched. The initial 0→1 transition is covered by the existing branch.
- `pr.RebaseCount < maxR` — respect the configured cap. Confirm the helper name on `Monitor`; the CI path uses `m.maxCIFixAttempts()`, review uses `m.maxReviewFixAttempts()` (or its post-bead-05 equivalent), so the rebase counterpart is `m.maxRebaseAttempts()`. Add it as a thin wrapper if it doesn't exist.

### Bug A — fold into the same fix

In `internal/lifecycle/lifecycle.go:311-320`, move `st.RebaseCount++` so it only fires when the rebase actually completed (or at minimum, when the worker row was successfully inserted). Cleanest: track "dispatched but not yet completed" attempts as a separate transient flag, increment the persisted counter only after the rebase worker exits. Simplest acceptable: keep the increment at dispatch but add a corresponding decrement on the `failed to create worktree` early-return path in `daemon.go:1259-1263`. The still-conflicting branch above mostly mitigates this anyway (one wasted slot still leaves max-1 retries available), so this is optional polish — note it in the PR but bead 15 ships with the bellows fix alone if needed.

## Acceptance

- A PR that's already had one dispatched rebase (whether it ran or bailed at prep) and is still CONFLICTING triggers a fresh rebase within one bellows poll, as long as `pr.RebaseCount < max_rebase_attempts`.
- The retry cap is respected: when `pr.RebaseCount == max_rebase_attempts`, no re-emit fires (existing exhausted flow takes over).
- An in-flight rebase (`pr.Status == PRNeedsFix`) does NOT receive duplicate dispatches from this branch.
- A PR that's never been conflicting (lastSnap.IsConflicting=false, newSnap.IsConflicting=false) is unaffected — the branch only fires when both sides are true.
- The first 0→1 transition still works via the existing branch.
- Unit test mirroring the CI still-failing and review still-failing tests exists for this branch.
- Manual end-to-end: induce a transient `git fetch` failure on a conflicting PR (e.g. unset GITHUB_TOKEN for one poll), confirm bellows fires a second EventPRConflicting on the following poll and the rebase worker actually runs.

## Notes

Third instance of the same bug family. Sister beads:
- 04 (`04-bellows-cleanup-external-prs.sh`) — post-merge/close cleanup transition gap.
- 05 (`05-bellows-review-fix-no-reemit.sh`) — review-fix still-failing re-emit gap.
- 15 (this) — rebase still-conflicting re-emit gap.

All three are mechanically identical: an asymmetry between "first transition" detection (covered) and "still in failed state" detection (missing). Fixing them independently is correct — they emit on different events with different cap counters — but the test scaffolding can be shared between 05 and 15 since both branches have the exact same shape.

When this ships, the workaround for stranded conflicting PRs (call `retry_bead` with PRID via IPC, then `pr_action rebase`) becomes unnecessary for the common transient-fetch case. Operators currently have to do this manually via the Hearth 2.0 web UI or the `forge` CLI for any PR that hits this trap.

File of interest: `internal/bellows/bellows.go:644-658` (existing transition branch) and `internal/bellows/bellows.go:564-585` (CI still-failing template, the closest pattern match). Likely also touches `bellows_test.go` and possibly `internal/lifecycle/lifecycle.go:311-320` if Bug A is folded in.

The rebase path has been quietly the most fragile of the three (CI/review/rebase) precisely because the prep step (git fetch in worktree creation) is the most likely to hit a transient GitHub blip. Three retries that each cost a network round-trip is exactly when you want the still-failing branch — anything less is the orchestrator throwing in the towel after the first sneeze.

---
Bead: Forge-h2a6 | Branch: forge/Forge-h2a6
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->