### PR TITLE
Needs Attention shows schematic reasoning instead of the Smith escalation message (Forge-gbzn)

### DIFF
--- a/changelog.d/Forge-gbzn.md
+++ b/changelog.d/Forge-gbzn.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Needs Attention shows the Smith escalation, not schematic reasoning** - Reordered the needs-human reason ladder so an explicit Smith escalation takes priority over the Schematic's decomposition rationale. When a schematic ran earlier in the same pipeline, the panel and bead detail page now surface Smith's actual, actionable escalation; a schematic reason still surfaces when nothing more specific exists, but is labelled "Schematic:" so it can never masquerade as a bare escalation. (Forge-gbzn)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2739,16 +2739,7 @@ normalPipeline:
 			// Bead needs human attention — mark it immediately so it appears
 			// in Hearth's Needs Attention panel without waiting for the
 			// circuit breaker to trip after multiple failures.
-			reason := "Smith produced no diff, needs human attention"
-			if outcome.SchematicResult != nil && outcome.SchematicResult.Reason != "" {
-				reason = outcome.SchematicResult.Reason
-			} else if outcome.ReviewResult != nil && outcome.ReviewResult.Summary != "" && outcome.ReviewResult.NoDiff {
-				reason = "Warden rejected (no diff): " + outcome.ReviewResult.Summary
-			} else if outcome.SmithResult != nil {
-				if r := pipeline.ExtractNeedsHuman(outcome.SmithResult.FullOutput); r != "" {
-					reason = "Smith escalated: " + r
-				}
-			}
+			reason := needsHumanReason(outcome)
 
 			if err := d.db.MarkNeedsHuman(bead.ID, bead.Anvil, reason); err != nil {
 				d.logger.Error("failed to mark bead as needs_human", "bead", bead.ID, "error", err)
@@ -2775,6 +2766,31 @@ normalPipeline:
 
 	// Pipeline succeeded — finalize (create PR, notify, close bead).
 	d.finalizePipeline(pipelineCtx, outcome, bead, anvilCfg.Path, claimWorkerID)
+}
+
+// needsHumanReason selects the operator-facing reason to surface in the Needs
+// Attention panel (via retries.last_error) when a pipeline releases a bead for
+// human attention. The priority is most-specific-first: an explicit Smith
+// escalation reflects a deliberate decision made after looking at the actual
+// work, so it must win over the Schematic's decomposition rationale. The
+// Schematic reason is the weakest signal — it nearly always exists (the
+// Schematic ran and has an opinion), so it is both labelled ("Schematic: ")
+// and ranked last so it can never again masquerade as a bare escalation.
+func needsHumanReason(outcome *pipeline.Outcome) string {
+	if outcome != nil {
+		if outcome.SmithResult != nil {
+			if r := pipeline.ExtractNeedsHuman(outcome.SmithResult.FullOutput); r != "" {
+				return "Smith escalated: " + r
+			}
+		}
+		if outcome.ReviewResult != nil && outcome.ReviewResult.NoDiff && outcome.ReviewResult.Summary != "" {
+			return "Warden rejected (no diff): " + outcome.ReviewResult.Summary
+		}
+		if outcome.SchematicResult != nil && outcome.SchematicResult.Reason != "" {
+			return "Schematic: " + outcome.SchematicResult.Reason
+		}
+	}
+	return "Smith produced no diff, needs human attention"
 }
 
 // finalizePipeline handles the post-success pipeline flow: create PR, clear

--- a/internal/daemon/needs_human_reason_test.go
+++ b/internal/daemon/needs_human_reason_test.go
@@ -1,0 +1,79 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/Robin831/Forge/internal/pipeline"
+	"github.com/Robin831/Forge/internal/schematic"
+	"github.com/Robin831/Forge/internal/smith"
+	"github.com/Robin831/Forge/internal/warden"
+)
+
+func TestNeedsHumanReason(t *testing.T) {
+	const smithEscalation = "Bead premise is wrong — choose scope a/b/c"
+
+	tests := []struct {
+		name    string
+		outcome *pipeline.Outcome
+		want    string
+	}{
+		{
+			name: "smith escalation wins over schematic reason",
+			outcome: &pipeline.Outcome{
+				SchematicResult: &schematic.Result{Reason: "decomposing would create artificial splits"},
+				SmithResult:     &smith.Result{FullOutput: "Some work...\nNEEDS_HUMAN: " + smithEscalation + "\nI have not committed anything."},
+			},
+			want: "Smith escalated: " + smithEscalation,
+		},
+		{
+			name: "smith escalation wins over warden no-diff",
+			outcome: &pipeline.Outcome{
+				ReviewResult: &warden.ReviewResult{NoDiff: true, Summary: "no changes detected"},
+				SmithResult:  &smith.Result{FullOutput: "NEEDS_HUMAN: " + smithEscalation},
+			},
+			want: "Smith escalated: " + smithEscalation,
+		},
+		{
+			name: "warden no-diff wins over schematic reason",
+			outcome: &pipeline.Outcome{
+				SchematicResult: &schematic.Result{Reason: "single cohesive change"},
+				ReviewResult:    &warden.ReviewResult{NoDiff: true, Summary: "no changes detected"},
+				SmithResult:     &smith.Result{FullOutput: "Smith ran but did not escalate"},
+			},
+			want: "Warden rejected (no diff): no changes detected",
+		},
+		{
+			name: "schematic reason is labelled when nothing more specific exists",
+			outcome: &pipeline.Outcome{
+				SchematicResult: &schematic.Result{Reason: "single cohesive change"},
+			},
+			want: "Schematic: single cohesive change",
+		},
+		{
+			name: "warden no-diff requires NoDiff flag",
+			outcome: &pipeline.Outcome{
+				ReviewResult: &warden.ReviewResult{NoDiff: false, Summary: "requested changes"},
+			},
+			want: "Smith produced no diff, needs human attention",
+		},
+		{
+			name:    "nil outcome falls back to default",
+			outcome: nil,
+			want:    "Smith produced no diff, needs human attention",
+		},
+		{
+			name:    "empty outcome falls back to default",
+			outcome: &pipeline.Outcome{},
+			want:    "Smith produced no diff, needs human attention",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needsHumanReason(tt.outcome)
+			if got != tt.want {
+				t.Errorf("needsHumanReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

- **Needs Attention shows the Smith escalation, not schematic reasoning** - Reordered the needs-human reason ladder so an explicit Smith escalation takes priority over the Schematic's decomposition rationale. When a schematic ran earlier in the same pipeline, the panel and bead detail page now surface Smith's actual, actionable escalation; a schematic reason still surfaces when nothing more specific exists, but is labelled "Schematic:" so it can never masquerade as a bare escalation. (Forge-gbzn)

## Original Issue (bug): Needs Attention shows schematic reasoning instead of the Smith escalation message

## Problem

When a bead is marked needs-human, Hearth 2.0’s Needs Attention panel (and the bead detail page) display `retries.last_error`. For a bead where **Smith explicitly escalated** (wrote a `<!-- NEEDS_HUMAN: ... -->`-style marker that `pipeline.ExtractNeedsHuman` parses) AND a **schematic ran earlier in the same pipeline**, the surfaced message is the **schematic’s decomposition reasoning** — i.e. the schematic explaining why it did NOT decompose the bead — rather than Smith’s actual escalation. The schematic text reads as a justification for proceeding, so as an “escalation reason” it is a confusing non-sequitur.

### Observed (skybert-forge, 2026-05-29) — Fhi.Metadata-lyhye

What the operator saw in Needs Attention (`retries.last_error`):
> Single cohesive profile addition that mirrors an existing, proven sibling pattern (helsedata). The four parts (seed, migration, tests, changelog) are interdependent and must land atomically — decomposing would create artificial splits...

That is the **schematic’s** output (`SchematicResult.Reason`) — a "why I didn’t split this" rationale. Meanwhile the real, actionable escalation was logged in the `smith_failed` event but NOT surfaced:
> Smith escalated — needs human: Bead premise is wrong — the design doc requires ~30 new rules (entire `agent` bucket + all 13 Forskningsprosjekt rules), not the "three" the bead assumes, and the bead forbids inlining them. Two of the four required tests are unachievable as specified... Please choose the scope: (a) expand...; (b) split into prerequisite rule-seed micro-beads...; (c) descope... I have not committed or pushed anything.

The operator could not act on lyhye from the panel because the message shown bore no relation to the actual blocker. They had to be walked through the `smith_failed` event by hand.

## Root cause

`internal/daemon/daemon.go`, the `outcome.NeedsHuman` branch of the dispatch handler (around line 2738-2756). The reason-selection ladder is ordered worst-first:

```go
reason := "Smith produced no diff, needs human attention"
if outcome.SchematicResult != nil && outcome.SchematicResult.Reason != "" {
    reason = outcome.SchematicResult.Reason            // checked FIRST — wins
} else if outcome.ReviewResult != nil && outcome.ReviewResult.Summary != "" && outcome.ReviewResult.NoDiff {
    reason = "Warden rejected (no diff): " + outcome.ReviewResult.Summary
} else if outcome.SmithResult != nil {
    if r := pipeline.ExtractNeedsHuman(outcome.SmithResult.FullOutput); r != "" {
        reason = "Smith escalated: " + r               // checked LAST — only if schematic+warden absent
    }
}

if err := d.db.MarkNeedsHuman(bead.ID, bead.Anvil, reason); err != nil { ... }
d.recordDispatchFailure(bead.ID, bead.Anvil, reason, true)
```

Because the schematic almost always produces a `Reason` (it ran, it has an opinion), the first branch wins whenever a schematic ran — even when Smith later escalated with a far more specific, actionable message. `MarkNeedsHuman` then writes that schematic text to `retries.last_error`, and `recordDispatchFailure` logs the same wrong text as the `dispatch_failed` event. The correct Smith escalation survives only in the separately-logged `smith_failed` event, which the panel does not read.

There is a second `outcome.NeedsHuman` branch earlier in the same function (the warden-max-iterations path, ~line 2687) that uses a fixed `"Warden rejected after max iterations: ..."` reason — that one is fine and out of scope.

## Proposed fix

Reorder the ladder so the **most specific, operator-actionable** source wins: an explicit Smith escalation is the strongest signal of intent and must take priority over the schematic’s decomposition rationale. Suggested order:

1. **Smith escalation** — `pipeline.ExtractNeedsHuman(outcome.SmithResult.FullOutput)` non-empty → `"Smith escalated: " + r`. (Highest priority — Smith looked at the actual work and chose to escalate with specifics.)
2. **Warden no-diff rejection** — `outcome.ReviewResult.NoDiff && Summary != ""` → `"Warden rejected (no diff): " + summary`.
3. **Schematic reason** — `outcome.SchematicResult.Reason != ""` → the schematic text. (Lowest — only relevant when nothing more specific exists; and even then, prefer to label it as schematic context, e.g. prefix `"Schematic: "`, so it never again masquerades as an unlabelled escalation.)
4. Fallback default string.

Apply the same priority everywhere this ladder is duplicated — grep for `ExtractNeedsHuman` and `SchematicResult.Reason` in daemon.go; there is at least one sibling site (the crucible/child dispatch path around line 3000+ also calls `MarkNeedsHuman`). Factor the selection into a small helper (e.g. `needsHumanReason(outcome) string`) so the priority is defined once and unit-testable, rather than copy-pasted with potentially divergent ordering.

## Acceptance

- When Smith explicitly escalates needs-human, `retries.last_error` (and therefore the Needs Attention panel + bead detail page) shows the Smith escalation message, regardless of whether a schematic ran.
- When there is no Smith escalation but the schematic produced a reason, that reason still surfaces — but prefixed/labelled as schematic context, not as a bare escalation.
- Warden-no-diff path unchanged in behaviour.
- A unit test covers the priority: given an outcome with BOTH a SchematicResult.Reason and a Smith-escalation marker in SmithResult.FullOutput, the selected reason is the Smith escalation.
- Retroactive note: existing stranded needs-human rows (like lyhye) will only get the corrected message on their NEXT escalation; this fix is forward-looking (no backfill of historical last_error).

## Notes

Forge-side change (internal/daemon + a unit test). Sister to bead 17 — 17 makes needs-attention beads findable in Hearth regardless of worker-row state; 18 makes the message they show correct. Both are needed for the Needs Attention panel to be trustworthy: 17 = "is it shown?", 18 = "does the shown message make sense?".

The immediate trigger (lyhye) is being retried by the operator after fixing the bead premise; this bead is about the message-surfacing bug, independent of lyhye’s own resolution. The next graceful Smith escalation on any bead would hit the same wrong-message path until this lands.

The escalation that finally made sense was sitting in the smith_failed event the whole time — the panel was just reading over its shoulder at the schematic’s notes instead.

---
Bead: Forge-gbzn | Branch: forge/Forge-gbzn
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->