### PR TITLE
Bellows trigger gate, lifecycle action & daemon dispatch wiring (Forge-wxxv)

### DIFF
--- a/changelog.d/Forge-wxxv.md
+++ b/changelog.d/Forge-wxxv.md
@@ -1,0 +1,2 @@
+category: Added
+- **Assay review trigger gate** - Bellows now emits a `pr_review_needed` event and dispatches an Assay review action when a managed, open, non-draft PR's head differs from the last reviewed commit, CI has settled, the per-(anvil, PR) debounce window has elapsed, and the daily Assay cost cap is not exceeded. (Forge-wxxv)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -35,7 +35,16 @@ const (
 	EventPRClosed       = "pr_closed"
 	EventPRConflicting  = "pr_conflicting"
 	EventPRReadyToMerge = "pr_ready_to_merge"
+	// EventPRReviewNeeded signals that a PR's current head should be reviewed
+	// by Assay. It is emitted by the Assay trigger gate in checkPR when the
+	// head SHA differs from the last reviewed SHA and all gating conditions
+	// (managed, open, not draft, CI settled, debounce, daily cost) are met.
+	EventPRReviewNeeded = "pr_review_needed"
 )
+
+// defaultAssayDebounceSeconds is the fallback minimum interval between Assay
+// runs for the same (anvil, PR) when the configured debounce is unset (<= 0).
+const defaultAssayDebounceSeconds = 300
 
 // PREvent is emitted when a PR status changes.
 type PREvent struct {
@@ -49,6 +58,26 @@ type PREvent struct {
 	// PRURL is the GitHub URL of the PR, populated for events that need it
 	// (e.g. pr_ready_to_merge).
 	PRURL string
+	// HeadSHA is the commit OID at the head of the PR branch, populated for
+	// events that need it (e.g. pr_review_needed, so the Assay reviewer knows
+	// which head it is reviewing and can record the run against it).
+	HeadSHA string
+}
+
+// AssayGateConfig holds the resolved Assay settings the trigger gate needs to
+// decide whether to emit EventPRReviewNeeded for a PR. The daemon supplies a
+// per-anvil accessor via Monitor.SetAssayConfig so hot-reloaded config changes
+// take effect without restarting.
+type AssayGateConfig struct {
+	// Enabled gates the whole feature: when false the trigger never fires.
+	Enabled bool
+	// SkipDrafts suppresses the trigger for draft PRs when true.
+	SkipDrafts bool
+	// DebounceSeconds is the minimum interval between Assay runs for the same
+	// (anvil, PR). Values <= 0 fall back to defaultAssayDebounceSeconds.
+	DebounceSeconds int
+	// DailyCostLimitUSD caps total Assay spend per day; 0 means no limit.
+	DailyCostLimitUSD float64
 }
 
 // Handler is called when a PR event is detected.
@@ -75,6 +104,7 @@ type Monitor struct {
 	wasUnmanaged     map[string]bool       // keys of ext- PRs seen as unmanaged (for managed transition detection)
 	autoMergeHandler func(ctx context.Context, anvil string, pr state.PR) // called when a PR becomes ready-to-merge
 	smelterEnabled   func() bool           // when true, route learned rules to pending table instead of PR
+	assayConfig      func(anvil string) AssayGateConfig // resolved Assay gate config; nil disables the trigger
 }
 
 // prSnapshot tracks the last seen state of a PR.
@@ -140,6 +170,26 @@ func (m *Monitor) SetAutoMergeHandler(h func(ctx context.Context, anvil string, 
 // table instead of creating immediate PRs.
 func (m *Monitor) SetSmelterEnabled(f func() bool) {
 	m.smelterEnabled = f
+}
+
+// SetAssayConfig registers an accessor returning the resolved Assay gate config
+// for a given anvil. When set and enabled, the trigger gate in checkPR may emit
+// EventPRReviewNeeded. When nil (the default), the Assay trigger is disabled.
+func (m *Monitor) SetAssayConfig(f func(anvil string) AssayGateConfig) {
+	m.assayConfig = f
+}
+
+// lastReviewedSHA returns the head SHA most recently reviewed by Assay for the
+// given PR, or "" when no review has run (or on DB error). It wraps the
+// state-layer LastReviewedSHA helper (added in sub-task 1) so the trigger gate
+// can compare it against the PR's current head.
+func (m *Monitor) lastReviewedSHA(pr *state.PR) string {
+	sha, err := m.db.LastReviewedSHA(pr.Anvil, pr.Number)
+	if err != nil {
+		log.Printf("[bellows] Failed to query last reviewed SHA for PR #%d (%s): %v", pr.Number, pr.Anvil, err)
+		return ""
+	}
+	return sha
 }
 
 // OnEvent registers a handler for PR events.
@@ -735,6 +785,13 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 		_ = m.db.UpdatePRStatusIfNeedsFix(pr.ID, state.PRApproved)
 	}
 
+	// Assay trigger gate: before ready-to-merge detection, emit
+	// EventPRReviewNeeded when the current head has not yet been reviewed and
+	// all gating conditions hold (see shouldEmitReviewNeeded). Placed here so a
+	// PR's head is offered for AI review once CI has settled but before/while it
+	// awaits merge. No-op unless an Assay config accessor is registered.
+	m.maybeEmitReviewNeeded(ctx, pr, status, newSnap, ciInProgress)
+
 	// Detect transition to fully ready-to-merge state (CI passing +
 	// no conflicts, unresolved threads, or pending reviews).
 	// This matches the ReadyToMergePRs query in state/db.go.
@@ -1014,6 +1071,143 @@ func bellowsGit(ctx context.Context, dir string, args ...string) error {
 		return fmt.Errorf("git %s: %s (%w)", args[0], stderr.String(), err)
 	}
 	return nil
+}
+
+// reviewGateInputs bundles every signal the Assay trigger gate evaluates.
+// Extracting the decision into a pure function (shouldEmitReviewNeeded) keeps
+// it unit-testable in isolation, mirroring the computeTransitionEvents pattern
+// used for the other Bellows transitions.
+type reviewGateInputs struct {
+	enabled         bool
+	managed         bool
+	open            bool
+	draft           bool
+	skipDrafts      bool
+	headSHA         string
+	lastReviewedSHA string
+	ciInProgress    bool
+	ciPassing       bool
+	ciFixCount      int
+	maxCIFix        int
+	lastAssayRun    time.Time // zero when no prior run exists
+	now             time.Time
+	debounceSeconds int
+	dailyCostUSD    float64
+	dailyCostLimit  float64 // 0 = no limit
+}
+
+// shouldEmitReviewNeeded returns true when EventPRReviewNeeded should fire for a
+// PR. It emits only when ALL hold: Assay is enabled; the PR is managed, open,
+// and not a (skipped) draft; the current head differs from the last reviewed
+// head; CI is settled (not in progress) and either passing or past the CI-fix
+// cap; no Assay run occurred within the debounce window; and the daily Assay
+// cost is below the configured limit.
+func shouldEmitReviewNeeded(in reviewGateInputs) bool {
+	if !in.enabled {
+		return false
+	}
+	if !in.managed {
+		return false
+	}
+	if !in.open {
+		return false
+	}
+	if in.draft && in.skipDrafts {
+		return false
+	}
+	// An empty head SHA means GitHub did not report one; we cannot decide it is
+	// unreviewed, so skip rather than risk a spurious review.
+	if in.headSHA == "" || in.headSHA == in.lastReviewedSHA {
+		return false
+	}
+	if in.ciInProgress {
+		return false
+	}
+	if !in.ciPassing && in.ciFixCount < in.maxCIFix {
+		return false
+	}
+	debounce := in.debounceSeconds
+	if debounce <= 0 {
+		debounce = defaultAssayDebounceSeconds
+	}
+	if !in.lastAssayRun.IsZero() && in.now.Sub(in.lastAssayRun) < time.Duration(debounce)*time.Second {
+		return false
+	}
+	if in.dailyCostLimit > 0 && in.dailyCostUSD >= in.dailyCostLimit {
+		return false
+	}
+	return true
+}
+
+// maybeEmitReviewNeeded evaluates the Assay trigger gate for a managed, open PR
+// and emits EventPRReviewNeeded when all conditions hold. It is a no-op when no
+// Assay config accessor has been registered (the feature is disabled).
+func (m *Monitor) maybeEmitReviewNeeded(ctx context.Context, pr *state.PR, status *vcs.PRStatus, newSnap *prSnapshot, ciInProgress bool) {
+	if m.assayConfig == nil {
+		return
+	}
+	cfg := m.assayConfig(pr.Anvil)
+	if !cfg.Enabled {
+		return
+	}
+
+	lastRun, err := m.db.LastAssayRunAt(pr.Anvil, pr.Number)
+	if err != nil {
+		log.Printf("[bellows] Failed to query last Assay run for PR #%d (%s): %v", pr.Number, pr.Anvil, err)
+		return
+	}
+	now := time.Now().UTC()
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	dailyCost, err := m.db.AssayCostUSDSince(dayStart)
+	if err != nil {
+		log.Printf("[bellows] Failed to query daily Assay cost: %v", err)
+		return
+	}
+
+	managed := !(strings.HasPrefix(pr.BeadID, "ext-") && !pr.BellowsManaged)
+	in := reviewGateInputs{
+		enabled:         cfg.Enabled,
+		managed:         managed,
+		open:            !newSnap.IsMerged && !newSnap.IsClosed,
+		draft:           status.IsDraft,
+		skipDrafts:      cfg.SkipDrafts,
+		headSHA:         status.HeadSHA,
+		lastReviewedSHA: m.lastReviewedSHA(pr),
+		ciInProgress:    ciInProgress,
+		ciPassing:       newSnap.CIPassing,
+		ciFixCount:      pr.CIFixCount,
+		maxCIFix:        m.maxCIFixAttempts(),
+		lastAssayRun:    lastRun,
+		now:             now,
+		debounceSeconds: cfg.DebounceSeconds,
+		dailyCostUSD:    dailyCost,
+		dailyCostLimit:  cfg.DailyCostLimitUSD,
+	}
+	if !shouldEmitReviewNeeded(in) {
+		return
+	}
+
+	m.emit(ctx, PREvent{
+		PRNumber:  pr.Number,
+		BeadID:    pr.BeadID,
+		Anvil:     pr.Anvil,
+		Branch:    status.HeadRefName,
+		EventType: EventPRReviewNeeded,
+		Details:   fmt.Sprintf("PR #%d head %s needs Assay review", pr.Number, shortSHA(status.HeadSHA)),
+		Timestamp: now,
+		PRURL:     status.URL,
+		HeadSHA:   status.HeadSHA,
+	})
+	_ = m.db.LogEvent(state.EventPRReviewNeeded, fmt.Sprintf("PR #%d queued for Assay review (head %s)", pr.Number, shortSHA(status.HeadSHA)), pr.BeadID, pr.Anvil)
+}
+
+// shortSHA truncates a commit OID to its first 8 characters for log/event
+// readability, returning the input unchanged when shorter.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
 }
 
 // emit calls all registered handlers with the given event.

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -408,16 +408,31 @@ func (m *Monitor) checkAll(ctx context.Context) {
 		}
 	}
 
+	var dailyAssayCost *float64
+	if m.assayConfig != nil {
+		now := time.Now().UTC()
+		dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		cost, err := m.db.AssayCostUSDSince(dayStart)
+		if err != nil {
+			log.Printf("[bellows] Failed to query daily Assay cost: %v", err)
+		} else {
+			dailyAssayCost = &cost
+		}
+	}
+
 	for i := range prs {
 		if ctx.Err() != nil {
 			return
 		}
-		m.checkPR(ctx, &prs[i])
+		m.checkPR(ctx, &prs[i], dailyAssayCost)
 	}
 }
 
 // checkPR polls a single PR and emits events for any state changes.
-func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
+// dailyAssayCost is the precomputed global Assay cost for the current day,
+// queried once per checkAll cycle to avoid redundant per-PR queries. A nil
+// value means the query failed and the Assay gate should be skipped.
+func (m *Monitor) checkPR(ctx context.Context, pr *state.PR, dailyAssayCost *float64) {
 	m.pathsMu.RLock()
 	anvilPath, ok := m.anvilPaths[pr.Anvil]
 	m.pathsMu.RUnlock()
@@ -541,7 +556,7 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 			delete(m.lastStatuses, key)
 			m.mu.Unlock()
 			// Re-enter checkPR so the nil-snapshot seeding path runs.
-			m.checkPR(ctx, pr)
+			m.checkPR(ctx, pr, dailyAssayCost)
 			return
 		}
 	}
@@ -790,7 +805,7 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR) {
 	// all gating conditions hold (see shouldEmitReviewNeeded). Placed here so a
 	// PR's head is offered for AI review once CI has settled but before/while it
 	// awaits merge. No-op unless an Assay config accessor is registered.
-	m.maybeEmitReviewNeeded(ctx, pr, status, newSnap, ciInProgress)
+	m.maybeEmitReviewNeeded(ctx, pr, status, newSnap, ciInProgress, dailyAssayCost)
 
 	// Detect transition to fully ready-to-merge state (CI passing +
 	// no conflicts, unresolved threads, or pending reviews).
@@ -1142,7 +1157,7 @@ func shouldEmitReviewNeeded(in reviewGateInputs) bool {
 // maybeEmitReviewNeeded evaluates the Assay trigger gate for a managed, open PR
 // and emits EventPRReviewNeeded when all conditions hold. It is a no-op when no
 // Assay config accessor has been registered (the feature is disabled).
-func (m *Monitor) maybeEmitReviewNeeded(ctx context.Context, pr *state.PR, status *vcs.PRStatus, newSnap *prSnapshot, ciInProgress bool) {
+func (m *Monitor) maybeEmitReviewNeeded(ctx context.Context, pr *state.PR, status *vcs.PRStatus, newSnap *prSnapshot, ciInProgress bool, dailyAssayCost *float64) {
 	if m.assayConfig == nil {
 		return
 	}
@@ -1156,13 +1171,10 @@ func (m *Monitor) maybeEmitReviewNeeded(ctx context.Context, pr *state.PR, statu
 		log.Printf("[bellows] Failed to query last Assay run for PR #%d (%s): %v", pr.Number, pr.Anvil, err)
 		return
 	}
-	now := time.Now().UTC()
-	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	dailyCost, err := m.db.AssayCostUSDSince(dayStart)
-	if err != nil {
-		log.Printf("[bellows] Failed to query daily Assay cost: %v", err)
+	if dailyAssayCost == nil {
 		return
 	}
+	now := time.Now().UTC()
 
 	managed := !(strings.HasPrefix(pr.BeadID, "ext-") && !pr.BellowsManaged)
 	in := reviewGateInputs{
@@ -1180,7 +1192,7 @@ func (m *Monitor) maybeEmitReviewNeeded(ctx context.Context, pr *state.PR, statu
 		lastAssayRun:    lastRun,
 		now:             now,
 		debounceSeconds: cfg.DebounceSeconds,
-		dailyCostUSD:    dailyCost,
+		dailyCostUSD:    *dailyAssayCost,
 		dailyCostLimit:  cfg.DailyCostLimitUSD,
 	}
 	if !shouldEmitReviewNeeded(in) {

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -332,6 +332,8 @@ func openTempDB(t *testing.T) (*state.DB, func()) {
 	}
 }
 
+func float64Ptr(v float64) *float64 { return &v }
+
 // TestCheckAll_BellowsManagedPRsGetWorkerRow is a regression test for the
 // Workers-panel visibility fix: bellows-managed PRs must appear in state.DB
 // as workers after checkAll runs.
@@ -1694,7 +1696,7 @@ func TestMaybeEmitReviewNeeded_EmitsWhenUnreviewed(t *testing.T) {
 
 	status := &vcs.PRStatus{State: "OPEN", HeadRefName: "forge/forge-abc", HeadSHA: "abc1234", URL: "https://example/pr/101"}
 	snap := &prSnapshot{CIPassing: true}
-	m.maybeEmitReviewNeeded(context.Background(), pr, status, snap, false)
+	m.maybeEmitReviewNeeded(context.Background(), pr, status, snap, false, float64Ptr(0))
 
 	require.Len(t, got, 1)
 	assert.Equal(t, EventPRReviewNeeded, got[0].EventType)
@@ -1742,7 +1744,7 @@ func TestMaybeEmitReviewNeeded_SuppressedWhenHeadAlreadyReviewed(t *testing.T) {
 
 	status := &vcs.PRStatus{State: "OPEN", HeadRefName: "forge/forge-xyz", HeadSHA: "abc1234"}
 	snap := &prSnapshot{CIPassing: true}
-	m.maybeEmitReviewNeeded(context.Background(), pr, status, snap, false)
+	m.maybeEmitReviewNeeded(context.Background(), pr, status, snap, false, float64Ptr(0))
 
 	assert.Empty(t, got, "gate must not emit when the current head has already been reviewed")
 }
@@ -1761,6 +1763,6 @@ func TestMaybeEmitReviewNeeded_NoConfigIsNoop(t *testing.T) {
 	m.OnEvent(func(_ context.Context, ev PREvent) { got = append(got, ev) })
 
 	status := &vcs.PRStatus{State: "OPEN", HeadSHA: "abc1234"}
-	m.maybeEmitReviewNeeded(context.Background(), pr, status, &prSnapshot{CIPassing: true}, false)
+	m.maybeEmitReviewNeeded(context.Background(), pr, status, &prSnapshot{CIPassing: true}, false, float64Ptr(0))
 	assert.Empty(t, got)
 }

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -1600,3 +1600,167 @@ func TestSweepOrphanedMonitoringWorkers_IgnoresNonBellowsWorkers(t *testing.T) {
 	require.Len(t, w, 1)
 	assert.Equal(t, state.WorkerRunning, w[0].Status, "non-bellows workers must not be affected by the sweep")
 }
+
+// TestShouldEmitReviewNeeded verifies the Assay trigger gate's pure decision
+// function. The base inputs satisfy every condition (so the gate fires); each
+// case mutates exactly one signal to confirm it suppresses the trigger,
+// mirroring the CI/review still-failing gate-test patterns above.
+func TestShouldEmitReviewNeeded(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	base := func() reviewGateInputs {
+		return reviewGateInputs{
+			enabled:         true,
+			managed:         true,
+			open:            true,
+			draft:           false,
+			skipDrafts:      true,
+			headSHA:         "abc1234deadbeef",
+			lastReviewedSHA: "old999",
+			ciInProgress:    false,
+			ciPassing:       true,
+			ciFixCount:      0,
+			maxCIFix:        5,
+			lastAssayRun:    time.Time{},
+			now:             now,
+			debounceSeconds: 300,
+			dailyCostUSD:    0,
+			dailyCostLimit:  10,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*reviewGateInputs)
+		want   bool
+	}{
+		{"all conditions hold", func(in *reviewGateInputs) {}, true},
+		{"disabled", func(in *reviewGateInputs) { in.enabled = false }, false},
+		{"unmanaged", func(in *reviewGateInputs) { in.managed = false }, false},
+		{"not open", func(in *reviewGateInputs) { in.open = false }, false},
+		{"draft with skip_drafts", func(in *reviewGateInputs) { in.draft = true }, false},
+		{"draft without skip_drafts", func(in *reviewGateInputs) { in.draft = true; in.skipDrafts = false }, true},
+		{"head already reviewed", func(in *reviewGateInputs) { in.lastReviewedSHA = in.headSHA }, false},
+		{"empty head SHA", func(in *reviewGateInputs) { in.headSHA = "" }, false},
+		{"CI in progress", func(in *reviewGateInputs) { in.ciInProgress = true }, false},
+		{"CI not passing and under max fix attempts", func(in *reviewGateInputs) { in.ciPassing = false; in.ciFixCount = 2 }, false},
+		{"CI not passing but at max fix attempts", func(in *reviewGateInputs) { in.ciPassing = false; in.ciFixCount = 5 }, true},
+		{"within debounce window", func(in *reviewGateInputs) { in.lastAssayRun = now.Add(-100 * time.Second) }, false},
+		{"outside debounce window", func(in *reviewGateInputs) { in.lastAssayRun = now.Add(-400 * time.Second) }, true},
+		{"within default debounce window", func(in *reviewGateInputs) { in.debounceSeconds = 0; in.lastAssayRun = now.Add(-100 * time.Second) }, false},
+		{"outside default debounce window", func(in *reviewGateInputs) { in.debounceSeconds = 0; in.lastAssayRun = now.Add(-400 * time.Second) }, true},
+		{"daily cost at limit", func(in *reviewGateInputs) { in.dailyCostUSD = 10; in.dailyCostLimit = 10 }, false},
+		{"daily cost over limit", func(in *reviewGateInputs) { in.dailyCostUSD = 15; in.dailyCostLimit = 10 }, false},
+		{"daily cost with no limit", func(in *reviewGateInputs) { in.dailyCostUSD = 99; in.dailyCostLimit = 0 }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base()
+			tt.mutate(&in)
+			assert.Equal(t, tt.want, shouldEmitReviewNeeded(in))
+		})
+	}
+}
+
+// TestMaybeEmitReviewNeeded_EmitsWhenUnreviewed exercises the gate end-to-end
+// against a real state DB: a managed, open, CI-passing PR whose head has never
+// been reviewed should emit EventPRReviewNeeded with the head SHA populated.
+func TestMaybeEmitReviewNeeded_EmitsWhenUnreviewed(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    101,
+		Anvil:     "my-anvil",
+		BeadID:    "forge-abc",
+		Branch:    "forge/forge-abc",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil, nil)
+	m.SetAssayConfig(func(anvil string) AssayGateConfig {
+		return AssayGateConfig{Enabled: true, SkipDrafts: true, DebounceSeconds: 300, DailyCostLimitUSD: 10}
+	})
+
+	var got []PREvent
+	var mu sync.Mutex
+	m.OnEvent(func(_ context.Context, ev PREvent) {
+		mu.Lock()
+		got = append(got, ev)
+		mu.Unlock()
+	})
+
+	status := &vcs.PRStatus{State: "OPEN", HeadRefName: "forge/forge-abc", HeadSHA: "abc1234", URL: "https://example/pr/101"}
+	snap := &prSnapshot{CIPassing: true}
+	m.maybeEmitReviewNeeded(context.Background(), pr, status, snap, false)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, EventPRReviewNeeded, got[0].EventType)
+	assert.Equal(t, "abc1234", got[0].HeadSHA)
+	assert.Equal(t, 101, got[0].PRNumber)
+}
+
+// TestMaybeEmitReviewNeeded_SuppressedWhenHeadAlreadyReviewed verifies the gate
+// does not re-fire once an Assay run has recorded the current head SHA.
+func TestMaybeEmitReviewNeeded_SuppressedWhenHeadAlreadyReviewed(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    202,
+		Anvil:     "my-anvil",
+		BeadID:    "forge-xyz",
+		Branch:    "forge/forge-xyz",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	// Record a run against the current head, well outside the debounce window,
+	// so only the head-SHA match (not debounce) suppresses the trigger.
+	require.NoError(t, db.RecordAssayRun(&state.AssayRun{
+		Anvil:     "my-anvil",
+		PRNumber:  202,
+		HeadSHA:   "abc1234",
+		StartedAt: time.Now().Add(-1 * time.Hour),
+	}))
+
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil, nil)
+	m.SetAssayConfig(func(anvil string) AssayGateConfig {
+		return AssayGateConfig{Enabled: true, SkipDrafts: true, DebounceSeconds: 300, DailyCostLimitUSD: 10}
+	})
+
+	var got []PREvent
+	var mu sync.Mutex
+	m.OnEvent(func(_ context.Context, ev PREvent) {
+		mu.Lock()
+		got = append(got, ev)
+		mu.Unlock()
+	})
+
+	status := &vcs.PRStatus{State: "OPEN", HeadRefName: "forge/forge-xyz", HeadSHA: "abc1234"}
+	snap := &prSnapshot{CIPassing: true}
+	m.maybeEmitReviewNeeded(context.Background(), pr, status, snap, false)
+
+	assert.Empty(t, got, "gate must not emit when the current head has already been reviewed")
+}
+
+// TestMaybeEmitReviewNeeded_NoConfigIsNoop verifies the gate is inert when no
+// Assay config accessor is registered (feature disabled).
+func TestMaybeEmitReviewNeeded_NoConfigIsNoop(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{Number: 303, Anvil: "my-anvil", BeadID: "forge-q", Branch: "b", Status: state.PROpen, CreatedAt: time.Now()}
+	require.NoError(t, db.InsertPR(pr))
+
+	m := New(db, nil, time.Minute, map[string]string{"my-anvil": "/fake"}, nil, nil, nil, nil)
+	var got []PREvent
+	m.OnEvent(func(_ context.Context, ev PREvent) { got = append(got, ev) })
+
+	status := &vcs.PRStatus{State: "OPEN", HeadSHA: "abc1234"}
+	m.maybeEmitReviewNeeded(context.Background(), pr, status, &prSnapshot{CIPassing: true}, false)
+	assert.Empty(t, got)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -94,6 +94,7 @@ type bellowsMonitorIface interface {
 	OnEvent(h bellows.Handler)
 	SetAutoMergeHandler(h func(ctx context.Context, anvil string, pr state.PR))
 	SetSmelterEnabled(f func() bool)
+	SetAssayConfig(f func(anvil string) bellows.AssayGateConfig)
 	UpdateAnvilPaths(paths map[string]string)
 	Refresh()
 	Run(ctx context.Context) error
@@ -984,6 +985,18 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.bellowsMonitor.SetSmelterEnabled(func() bool {
 		return d.cfg.Load().Settings.IsSmelterEnabled()
 	})
+	// Provide the Assay trigger gate with the resolved per-anvil Assay config so
+	// hot-reloaded changes take effect without a restart. Returning the config
+	// each call (rather than capturing it once) keeps the gate live-configured.
+	d.bellowsMonitor.SetAssayConfig(func(anvil string) bellows.AssayGateConfig {
+		ra := d.cfg.Load().ResolvedAssay(anvil)
+		return bellows.AssayGateConfig{
+			Enabled:           ra.IsEnabled(),
+			SkipDrafts:        ra.IsSkipDrafts(),
+			DebounceSeconds:   ra.GetDebounceSeconds(),
+			DailyCostLimitUSD: ra.GetDailyCostLimitUSD(),
+		}
+	})
 	d.bellowsMonitor.OnEvent(d.lifecycleMgr.HandleEvent)
 	d.bellowsMonitor.OnEvent(d.handleBellowsNotifications)
 	d.bellowsMonitor.OnEvent(d.handleBeadCloseOnMerge)
@@ -1537,6 +1550,61 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 			// have IsConflicting=true and the seeding guard would preserve
 			// that value, preventing the still-conflicting branch from
 			// re-emitting EventPRConflicting after the status is reset.
+			if d.bellowsMonitor != nil {
+				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
+			}
+
+		case lifecycle.ActionAssayReview:
+			d.logger.Info("spawning Assay review worker", "pr", req.PRNumber, "bead", req.BeadID, "head", req.HeadSHA)
+			// Insert the worker row FIRST. Per the bead 05/15 lesson, the
+			// assay-run "counter" (RecordAssayRun) must only advance after the
+			// worker row is successfully inserted — otherwise a failed insert
+			// would still mark the head as reviewed and suppress future runs.
+			if err := d.db.InsertWorker(&state.Worker{
+				ID:           workerID,
+				BeadID:       req.BeadID,
+				Anvil:        req.Anvil,
+				Branch:       req.Branch,
+				Status:       state.WorkerRunning,
+				Phase:        "assay",
+				Title:        d.db.BeadTitle(req.BeadID, req.Anvil),
+				PRNumber:     req.PRNumber,
+				StartedAt:    time.Now(),
+				StaleTimeout: workerTimeout / 2,
+			}); err != nil {
+				d.logger.Error("failed to insert Assay worker row; skipping run", "pr", req.PRNumber, "bead", req.BeadID, "error", err)
+				// Do not record a run: reset the snapshot so the next poll can
+				// re-emit EventPRReviewNeeded and retry the dispatch.
+				if d.bellowsMonitor != nil {
+					d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
+				}
+				break
+			}
+
+			// TODO(assay sub-task 3): invoke assay.Review(workerCtx, ...) here to
+			// triage the diff, post findings, and report the real cost/findings.
+			// Until that lands, record a no-op run so LastReviewedSHA advances to
+			// the current head and the trigger gate debounces instead of
+			// re-firing every poll.
+			started := time.Now()
+			run := &state.AssayRun{
+				Anvil:         req.Anvil,
+				PRNumber:      req.PRNumber,
+				HeadSHA:       req.HeadSHA,
+				StartedAt:     started,
+				SkippedReason: "assay reviewer not yet wired",
+			}
+			finished := time.Now()
+			run.FinishedAt = &finished
+			run.DurationMs = finished.Sub(started).Milliseconds()
+			if err := d.db.RecordAssayRun(run); err != nil {
+				d.logger.Error("failed to record Assay run", "pr", req.PRNumber, "bead", req.BeadID, "error", err)
+				_ = d.db.UpdateWorkerStatus(workerID, state.WorkerFailed)
+			} else {
+				_ = d.db.UpdateWorkerStatus(workerID, state.WorkerDone)
+			}
+			// Reset the snapshot so subsequent head pushes are re-detected by
+			// the gate on the next poll.
 			if d.bellowsMonitor != nil {
 				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
 			}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -45,12 +45,13 @@ func (s *PRState) NeedsFix() bool {
 type Action int
 
 const (
-	ActionNone      Action = iota
-	ActionFixCI            // Spawn CI fix worker
-	ActionFixReview        // Spawn review fix worker
-	ActionCloseBead        // Close bead after merge
-	ActionCleanup          // Clean up worktree/branch after close
-	ActionRebase           // Rebase branch on top of main to resolve conflict
+	ActionNone        Action = iota
+	ActionFixCI              // Spawn CI fix worker
+	ActionFixReview          // Spawn review fix worker
+	ActionCloseBead          // Close bead after merge
+	ActionCleanup            // Clean up worktree/branch after close
+	ActionRebase             // Rebase branch on top of main to resolve conflict
+	ActionAssayReview        // Run an Assay AI review pass over the PR's current head
 )
 
 // ActionRequest is dispatched to the action handler.
@@ -62,6 +63,7 @@ type ActionRequest struct {
 	Branch     string
 	BaseBranch string // Target branch for the PR (empty = main)
 	IsManual   bool   // true when triggered by a user IPC action (not auto-detected by Bellows)
+	HeadSHA    string // PR head commit OID, set for ActionAssayReview so the run is recorded against the reviewed head
 }
 
 // ActionHandler processes lifecycle actions. Implementations should be async-safe.
@@ -328,6 +330,14 @@ func (m *Manager) HandleEvent(ctx context.Context, event bellows.PREvent) {
 		st.Closed = true
 		action = ActionCleanup
 		m.logger.Info("PR closed without merge, cleanup", "pr", event.PRNumber, "anvil", event.Anvil)
+
+	case bellows.EventPRReviewNeeded:
+		// The Bellows Assay trigger gate (head-SHA comparison, debounce window,
+		// and daily cost cap) is the sole rate limiter, so no per-PR counter is
+		// tracked here. Per the bead 05/15 lesson, the assay-run "counter" is
+		// recorded by the daemon only after the worker row is inserted.
+		action = ActionAssayReview
+		m.logger.Info("PR review needed, dispatching Assay review", "pr", event.PRNumber, "anvil", event.Anvil)
 	}
 
 	// Capture all values needed after the lock is released.
@@ -343,6 +353,7 @@ func (m *Manager) HandleEvent(ctx context.Context, event bellows.PREvent) {
 		Anvil:      event.Anvil,
 		Branch:     st.Branch,
 		BaseBranch: st.BaseBranch,
+		HeadSHA:    event.HeadSHA,
 	}
 	m.mu.Unlock()
 

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -308,6 +308,40 @@ func TestEventPRConflicting_Dispatch(t *testing.T) {
 	}
 }
 
+// TestEventPRReviewNeeded_Dispatch verifies that a review-needed event
+// dispatches ActionAssayReview and propagates the head SHA. The Bellows gate is
+// the rate limiter, so each event dispatches unconditionally here.
+func TestEventPRReviewNeeded_Dispatch(t *testing.T) {
+	db := newTestDB(t)
+
+	var dispatched []ActionRequest
+	handler := func(_ context.Context, req ActionRequest) {
+		dispatched = append(dispatched, req)
+	}
+
+	m := New(db, testLogger(), handler)
+	ev := makeEvent(77, bellows.EventPRReviewNeeded)
+	ev.HeadSHA = "abc1234"
+	m.HandleEvent(context.Background(), ev)
+
+	if len(dispatched) != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", len(dispatched))
+	}
+	if dispatched[0].Action != ActionAssayReview {
+		t.Errorf("expected ActionAssayReview, got %v", dispatched[0].Action)
+	}
+	if dispatched[0].HeadSHA != "abc1234" {
+		t.Errorf("expected head SHA propagated, got %q", dispatched[0].HeadSHA)
+	}
+
+	// A second review-needed event dispatches again — no per-PR cap in the
+	// lifecycle manager (the Bellows gate gates re-firing).
+	m.HandleEvent(context.Background(), ev)
+	if len(dispatched) != 2 {
+		t.Errorf("expected 2 dispatches, got %d", len(dispatched))
+	}
+}
+
 // TestEventPRConflicting_ExhaustRebase verifies rebase attempts are capped.
 func TestEventPRConflicting_ExhaustRebase(t *testing.T) {
 	db := newTestDB(t)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -547,7 +547,7 @@ const (
 // Note: depupdate is retained here only for backward compatibility with
 // historical DB rows; there is no active depupdate worker flow anymore.
 // Update this constant when new background or synthetic phases are added.
-const backgroundPhases = "'bellows', 'quench', 'cifix', 'burnish', 'reviewfix', 'rebase', 'crucible', 'schematic', 'warden_rerun', 'approve_as_is', 'force_smith', 'smelter', 'depupdate'"
+const backgroundPhases = "'bellows', 'quench', 'cifix', 'burnish', 'reviewfix', 'rebase', 'assay', 'crucible', 'schematic', 'warden_rerun', 'approve_as_is', 'force_smith', 'smelter', 'depupdate'"
 
 // Worker represents a Smith worker entry.
 type Worker struct {
@@ -663,7 +663,7 @@ func (db *DB) ActiveWorkers() ([]Worker, error) {
 // All phases listed in backgroundPhases are excluded from the global check
 // because they only produce log output when external state changes (e.g. PR
 // events) and can be legitimately silent for long stretches. However,
-// lifecycle workers (quench/burnish/rebase) that were registered with a
+// lifecycle workers (quench/burnish/rebase/assay) that were registered with a
 // per-worker StaleTimeout are additionally checked using that shorter
 // threshold — these phases appear in backgroundPhases and are therefore
 // absent from the first result set, so there is no risk of duplicates.
@@ -775,7 +775,7 @@ func (db *DB) MarkWorkerStalled(id string) error {
 
 // ActiveDispatchWorkers returns active workers that are running primary dispatch
 // pipeline phases (smith, temper, warden). Bellows (PR monitoring) and lifecycle
-// workers (quench, burnish, rebase) are excluded so they don't consume dispatch capacity slots.
+// workers (quench, burnish, rebase, assay) are excluded so they don't consume dispatch capacity slots.
 // Stalled workers are included so they continue to count against capacity and
 // prevent the daemon from over-subscribing while stalled processes are still running.
 func (db *DB) ActiveDispatchWorkers() ([]Worker, error) {
@@ -786,7 +786,7 @@ func (db *DB) ActiveDispatchWorkers() ([]Worker, error) {
 }
 
 // ActiveDispatchWorkersByAnvil returns active dispatch workers for a given anvil,
-// excluding bellows and lifecycle workers (quench, burnish, rebase).
+// excluding bellows and lifecycle workers (quench, burnish, rebase, assay).
 // Stalled workers are included so they continue to count against per-anvil capacity.
 func (db *DB) ActiveDispatchWorkersByAnvil(anvil string) ([]Worker, error) {
 	return db.queryWorkers(`SELECT id, bead_id, anvil, branch, pid, status, phase, title, pr_number, started_at, completed_at, log_path

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -713,7 +713,7 @@ func (db *DB) StalledWorkers(staleThreshold time.Duration) ([]Worker, error) {
 		SELECT id, bead_id, anvil, branch, pid, status, phase, title, pr_number, started_at, log_path, stale_timeout
 		FROM workers
 		WHERE status IN ('pending', 'running', 'reviewing', 'monitoring')
-		  AND phase IN ('quench', 'cifix', 'burnish', 'reviewfix', 'rebase')
+		  AND phase IN ('quench', 'cifix', 'burnish', 'reviewfix', 'rebase', 'assay')
 		  AND stale_timeout > 0
 		ORDER BY started_at`)
 	if err != nil {

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1579,6 +1579,7 @@ const (
 	EventBeadTagged           EventType = "bead_tagged"
 	EventBeadClosed           EventType = "bead_closed"
 	EventPRReadyToMerge       EventType = "pr_ready_to_merge"
+	EventPRReviewNeeded       EventType = "pr_review_needed"
 	EventPRMergeRequested     EventType = "pr_merge_requested"
 	EventPRMergeFailed        EventType = "pr_merge_failed"
 	EventPRAutoMerged         EventType = "pr_auto_merged"
@@ -3821,4 +3822,40 @@ func (db *DB) RecordAssayRun(r *AssayRun) error {
 	id, _ := res.LastInsertId()
 	r.ID = int(id)
 	return nil
+}
+
+// LastAssayRunAt returns the started_at timestamp of the most recent assay_runs
+// row for the given anvil and PR number. Returns the zero time (no error) when
+// no run exists. Used by the Bellows Assay trigger gate to debounce repeat runs.
+func (db *DB) LastAssayRunAt(anvil string, prNumber int) (time.Time, error) {
+	var startedAt string
+	err := db.conn.QueryRow(
+		`SELECT started_at FROM assay_runs
+		 WHERE anvil = ? AND pr_number = ?
+		 ORDER BY id DESC LIMIT 1`,
+		anvil, prNumber,
+	).Scan(&startedAt)
+	if err == sql.ErrNoRows {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parseTime(startedAt), nil
+}
+
+// AssayCostUSDSince returns the total cost_usd of all assay_runs started at or
+// after the given time. The cutoff is formatted with dbTimeLayout, whose
+// lexicographic ordering matches chronological ordering, so a TEXT comparison
+// is valid. Used by the Bellows Assay trigger gate to enforce a daily cost cap.
+func (db *DB) AssayCostUSDSince(since time.Time) (float64, error) {
+	var total float64
+	err := db.conn.QueryRow(
+		`SELECT COALESCE(SUM(cost_usd), 0) FROM assay_runs WHERE started_at >= ?`,
+		since.UTC().Format(dbTimeLayout),
+	).Scan(&total)
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
 }

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -1299,19 +1299,37 @@ func TestDB_StalledWorkers_LifecycleWithPerWorkerTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Assay worker with StaleTimeout — should be detected as stale
+	if err := db.InsertWorker(&Worker{
+		ID: "w-assay-with-timeout", BeadID: "BD-4", Anvil: "anvil-1",
+		Status: WorkerRunning, Phase: "assay",
+		StartedAt:    time.Now().Add(-25 * time.Minute),
+		LogPath:      makeStaleLog("assay-with-timeout.log"),
+		StaleTimeout: 10 * time.Minute,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	stalled, err := db.StalledWorkers(5 * time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(stalled) != 1 {
+	if len(stalled) != 2 {
 		ids := make([]string, len(stalled))
 		for i, w := range stalled {
 			ids[i] = w.ID
 		}
-		t.Fatalf("expected 1 stalled worker, got %d: %v", len(stalled), ids)
+		t.Fatalf("expected 2 stalled workers, got %d: %v", len(stalled), ids)
 	}
-	if stalled[0].ID != "w-quench-with-timeout" {
-		t.Errorf("expected w-quench-with-timeout, got %s", stalled[0].ID)
+	stalledIDs := map[string]bool{}
+	for _, w := range stalled {
+		stalledIDs[w.ID] = true
+	}
+	if !stalledIDs["w-quench-with-timeout"] {
+		t.Errorf("expected w-quench-with-timeout in stalled set")
+	}
+	if !stalledIDs["w-assay-with-timeout"] {
+		t.Errorf("expected w-assay-with-timeout in stalled set")
 	}
 }
 

--- a/internal/vcs/github/github.go
+++ b/internal/vcs/github/github.go
@@ -192,7 +192,7 @@ func (p *Provider) MergePR(ctx context.Context, worktreePath string, prNumber in
 func (p *Provider) CheckStatus(ctx context.Context, worktreePath string, prNumber int) (*vcs.PRStatus, error) {
 	args := []string{
 		"pr", "view", fmt.Sprintf("%d", prNumber),
-		"--json", "state,statusCheckRollup,reviews,reviewRequests,mergeable,headRefName,url,title",
+		"--json", "state,statusCheckRollup,reviews,reviewRequests,mergeable,headRefName,headRefOid,isDraft,url,title",
 	}
 
 	cmd := executil.HideWindow(exec.CommandContext(ctx, "gh", args...))

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -373,8 +373,15 @@ type PRStatus struct {
 	Mergeable         string
 	UnresolvedThreads int
 	HeadRefName       string
-	URL               string
-	Title             string
+	// HeadSHA is the commit OID at the head of the PR branch. Used by the
+	// Assay review trigger to detect whether the current head has been
+	// reviewed yet (compared against the last reviewed SHA).
+	HeadSHA string `json:"headRefOid"`
+	// IsDraft is true when the PR is a draft. Draft PRs are skipped by the
+	// Assay trigger when skip_drafts is enabled.
+	IsDraft bool `json:"isDraft"`
+	URL     string
+	Title   string
 }
 
 // IsMerged returns true if the PR has been merged.


### PR DESCRIPTION
## Changes

- **Assay review trigger gate** - Bellows now emits a `pr_review_needed` event and dispatches an Assay review action when a managed, open, non-draft PR's head differs from the last reviewed commit, CI has settled, the per-(anvil, PR) debounce window has elapsed, and the daily Assay cost cap is not exceeded. (Forge-wxxv)

## Original Issue (task): Bellows trigger gate, lifecycle action & daemon dispatch wiring

Orchestration glue. In `internal/bellows/bellows.go` add `EventPRReviewNeeded` and, immediately before ready-to-merge detection, a gate emitting it only when ALL hold: PR managed (existing ext-*/bellows_managed guards), open, not draft, `pr.HeadSHA != lastReviewedSHA(pr)` (new helper querying `pr_findings`), `!ciInProgress && (newSnap.CIPassing || pr.CIFixCount >= maxCIFixAttempts)`, no Assay run within `assay.debounce_seconds` (default 300) for (anvil,pr_number), and daily cost below `assay.daily_cost_limit_usd`. Add gate tests in `bellows_test.go` mirroring existing CI/review still-failing patterns. In `internal/lifecycle/lifecycle.go` add `ActionAssayReview` constant dispatched like `ActionRebase`, incrementing the counter AFTER successful worker insertion (bead 05/15 lesson). Wire dispatch in `internal/daemon/daemon.go`. Depends on sub-task 1 for `LastReviewedSHA` and config; provides the trigger that invokes sub-task 3's `assay.Review`.

---
Bead: Forge-wxxv | Branch: forge/Forge-wxxv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->