### PR TITLE
Posting layer — gh comments, thread resolution & hash markers (Forge-g197)

### DIFF
--- a/changelog.d/Forge-g197.md
+++ b/changelog.d/Forge-g197.md
@@ -1,0 +1,2 @@
+category: Added
+- **Assay PR posting layer** - When Assay runs outside shadow mode it now posts a top-level summary review with a severity table, opens one inline review comment per finding (anchored to the head SHA and tagged with a stable `assay-hash` marker), and auto-resolves a finding's review thread after two consecutive reviews fail to re-detect it. (Forge-g197)

--- a/internal/assay/post.go
+++ b/internal/assay/post.go
@@ -1,0 +1,387 @@
+package assay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/Robin831/Forge/internal/executil"
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// hashMarkerPrefix opens every inline comment body. The hex hash that follows
+// is the finding's stable identity (independent of head SHA), so a finding maps
+// to the same marker across re-reviews. The marker is what the consecutive-miss
+// resolver matches review threads against.
+const hashMarkerPrefix = "assay-hash:"
+
+// resolveMissThreshold is the number of consecutive reviews a previously-posted
+// finding must go undetected before its review thread is auto-resolved.
+const resolveMissThreshold = 2
+
+// ghExec runs a gh CLI invocation in dir and returns its stdout. It is the seam
+// the posting layer uses to reach the gh CLI; tests replace it with a stub so
+// no real process is spawned. The default implementation shells out to gh.
+type ghExec func(ctx context.Context, dir string, args ...string) ([]byte, error)
+
+// ThreadResolver locates and resolves review threads on a PR. It is satisfied
+// by *github.Provider (see ThreadIDByBodyHeader / ResolveThread); the posting
+// layer depends on the interface, not the concrete provider, so it stays
+// testable and free of an import cycle.
+type ThreadResolver interface {
+	// ThreadIDByBodyHeader returns the platform thread ID whose top comment
+	// body contains header, or "" when none matches.
+	ThreadIDByBodyHeader(ctx context.Context, worktreePath string, prNumber int, header string) (string, error)
+	// ResolveThread marks the identified review thread as resolved.
+	ResolveThread(ctx context.Context, worktreePath string, threadID string) error
+}
+
+// PostRequest carries everything the posting layer needs to publish a review.
+type PostRequest struct {
+	// Anvil is the repository (anvil) name; keys the persisted rows.
+	Anvil string
+	// PRNumber is the pull request to comment on.
+	PRNumber int
+	// HeadSHA is the commit the inline comments are anchored to (commit_id).
+	HeadSHA string
+	// WorktreePath is the directory gh commands run in (the PR worktree). gh
+	// resolves the {owner}/{repo} API placeholders from this checkout.
+	WorktreePath string
+	// SummaryLine is the one-line verdict shown above the severity table in the
+	// top-level review comment. When empty (and there are no findings) the
+	// summary review is skipped.
+	SummaryLine string
+	// Findings is the aggregated set to post (already deduped/suppressed/capped
+	// by Review).
+	Findings []Finding
+}
+
+// PostResult summarizes a posting run.
+type PostResult struct {
+	// SummaryPosted reports whether the top-level review comment was posted.
+	SummaryPosted bool
+	// Posted is the number of inline comments successfully posted.
+	Posted int
+	// Failed is the number of inline comments whose gh call failed (left with
+	// posted=0 so they retry on the next head).
+	Failed int
+	// Resolved is the number of stale findings whose threads were resolved
+	// after crossing the consecutive-miss threshold.
+	Resolved int
+}
+
+// Poster publishes Assay findings to a GitHub PR: a top-level summary review,
+// one inline comment per finding, and auto-resolution of threads for findings
+// that have disappeared across consecutive reviews. Build one with NewPoster.
+//
+// The zero value is not usable; gh and logf are populated by NewPoster. db and
+// resolver may be nil — a nil db skips all persistence (so nothing is recorded
+// or auto-resolved), a nil resolver skips thread resolution only.
+type Poster struct {
+	gh       ghExec
+	db       *state.DB
+	resolver ThreadResolver
+	logf     func(format string, args ...any)
+}
+
+// NewPoster builds a Poster wired to the real gh CLI. db persists posting state
+// (gh_comment_id / gh_thread_id / consecutive_misses); resolver performs thread
+// lookup and resolution. Either may be nil.
+func NewPoster(db *state.DB, resolver ThreadResolver) *Poster {
+	return &Poster{
+		gh:       defaultGhExec,
+		db:       db,
+		resolver: resolver,
+		logf:     log.Printf,
+	}
+}
+
+// Post publishes req's findings to the PR. When cfg.ShadowMode is true it is a
+// no-op (the engine must not produce public side effects in shadow mode) and
+// returns a zero result.
+//
+// Posting never aborts on a single gh failure: each inline comment is attempted
+// independently, failures are logged, and the corresponding finding keeps
+// posted=0 so it is retried on the next head SHA. The only returned error is a
+// fatal one that prevents the whole run (currently none — Post always returns a
+// result and nil unless a future fatal path is added).
+func (p *Poster) Post(ctx context.Context, cfg Config, req PostRequest) (*PostResult, error) {
+	res := &PostResult{}
+	if cfg.ShadowMode {
+		return res, nil
+	}
+
+	// 1. Top-level summary review.
+	if req.SummaryLine != "" || len(req.Findings) > 0 {
+		body := buildSummaryBody(req.SummaryLine, req.Findings)
+		if _, err := p.gh(ctx, req.WorktreePath,
+			"pr", "review", strconv.Itoa(req.PRNumber), "--comment", "--body", body,
+		); err != nil {
+			p.logf("assay: posting summary review for PR #%d: %v", req.PRNumber, err)
+		} else {
+			res.SummaryPosted = true
+		}
+	}
+
+	// Findings already posted (and still open) on this PR. Used to avoid
+	// double-posting and to detect consecutive misses.
+	var postedHashes map[string]bool
+	var openPosted []state.Finding
+	if p.db != nil {
+		var err error
+		openPosted, err = p.db.OpenPostedFindings(req.Anvil, req.PRNumber)
+		if err != nil {
+			p.logf("assay: loading posted findings for PR #%d: %v", req.PRNumber, err)
+		}
+		postedHashes = make(map[string]bool, len(openPosted))
+		for _, f := range openPosted {
+			postedHashes[f.FindingHash] = true
+		}
+	}
+
+	// 2. Inline comments — one per finding.
+	current := make(map[string]bool, len(req.Findings))
+	for _, f := range req.Findings {
+		current[f.Hash] = true
+
+		if postedHashes[f.Hash] {
+			// Already posted on a prior head; it is re-detected, so clear any
+			// accumulated misses and skip re-posting.
+			if p.db != nil {
+				if err := p.db.ResetConsecutiveMiss(f.Hash); err != nil {
+					p.logf("assay: resetting misses for %s: %v", f.Hash, err)
+				}
+			}
+			continue
+		}
+
+		commentID, err := p.postInline(ctx, req, f)
+		if err != nil {
+			// Leave posted=0 so this finding retries on the next SHA.
+			p.logf("assay: posting inline comment for %s (%s): %v", f.File, f.Hash, err)
+			res.Failed++
+			continue
+		}
+		res.Posted++
+		if p.db != nil {
+			if err := p.db.MarkFindingPosted(f.Hash, commentID); err != nil {
+				p.logf("assay: marking %s posted: %v", f.Hash, err)
+			}
+		}
+	}
+
+	// 3. Consecutive-miss thread resolution. A finding posted earlier but not
+	// re-detected this round is a miss; on the threshold we resolve its thread.
+	res.Resolved = p.resolveMisses(ctx, req, openPosted, current)
+
+	return res, nil
+}
+
+// postInline posts a single inline review comment for f and returns the new
+// GitHub comment ID. The body opens with the hash marker; line anchoring uses
+// start_line/line for a multi-line anchor and line alone otherwise.
+func (p *Poster) postInline(ctx context.Context, req PostRequest, f Finding) (int64, error) {
+	start, end, ok := parseLineSpec(f.Anchor)
+	if !ok {
+		return 0, fmt.Errorf("anchor %q has no parseable line", f.Anchor)
+	}
+
+	endpoint := fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", req.PRNumber)
+	args := []string{
+		"api", "--method", "POST", endpoint,
+		"-f", "body=" + buildInlineBody(f),
+		"-f", "commit_id=" + req.HeadSHA,
+		"-f", "path=" + f.File,
+	}
+	if start > 0 && start < end {
+		// Multi-line range comment.
+		args = append(args,
+			"-F", "start_line="+strconv.Itoa(start),
+			"-f", "start_side=RIGHT",
+			"-F", "line="+strconv.Itoa(end),
+			"-f", "side=RIGHT",
+		)
+	} else {
+		args = append(args,
+			"-F", "line="+strconv.Itoa(end),
+			"-f", "side=RIGHT",
+		)
+	}
+
+	out, err := p.gh(ctx, req.WorktreePath, args...)
+	if err != nil {
+		return 0, err
+	}
+	var resp struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return 0, fmt.Errorf("parsing comment response: %w", err)
+	}
+	return resp.ID, nil
+}
+
+// resolveMisses bumps the consecutive-miss counter for every previously-posted
+// finding absent from current, and resolves the thread for any that reaches the
+// threshold. Returns the number of threads resolved.
+func (p *Poster) resolveMisses(ctx context.Context, req PostRequest, openPosted []state.Finding, current map[string]bool) int {
+	if p.db == nil {
+		return 0
+	}
+	resolved := 0
+	for _, f := range openPosted {
+		if current[f.FindingHash] {
+			continue // re-detected — handled in the inline loop
+		}
+		if err := p.db.IncrementConsecutiveMiss(f.FindingHash); err != nil {
+			p.logf("assay: incrementing misses for %s: %v", f.FindingHash, err)
+			continue
+		}
+		if f.ConsecutiveMisses+1 < resolveMissThreshold {
+			continue
+		}
+		if p.resolveThread(ctx, req, f) {
+			resolved++
+		}
+	}
+	return resolved
+}
+
+// resolveThread locates the review thread for f by its hash marker, persists
+// the matched thread ID, resolves it, and marks the finding resolved. It
+// returns true only when the thread was resolved.
+func (p *Poster) resolveThread(ctx context.Context, req PostRequest, f state.Finding) bool {
+	if p.resolver == nil {
+		return false
+	}
+	threadID := f.GHThreadID
+	if threadID == "" {
+		header := markerFor(f.FindingHash)
+		id, err := p.resolver.ThreadIDByBodyHeader(ctx, req.WorktreePath, req.PRNumber, header)
+		if err != nil {
+			p.logf("assay: looking up thread for %s: %v", f.FindingHash, err)
+			return false
+		}
+		if id == "" {
+			return false // thread not found yet; try again next round
+		}
+		threadID = id
+		if err := p.db.SetFindingThreadID(f.FindingHash, threadID); err != nil {
+			p.logf("assay: persisting thread id for %s: %v", f.FindingHash, err)
+		}
+	}
+	if err := p.resolver.ResolveThread(ctx, req.WorktreePath, threadID); err != nil {
+		p.logf("assay: resolving thread %s for %s: %v", threadID, f.FindingHash, err)
+		return false
+	}
+	if err := p.db.MarkResolved(f.FindingHash); err != nil {
+		p.logf("assay: marking %s resolved: %v", f.FindingHash, err)
+	}
+	return true
+}
+
+// buildSummaryBody renders the top-level review body: the summary line followed
+// by a markdown severity table aggregated from the findings. Severities are
+// rendered in a fixed order (Important, Nit, PreExisting); zero-count rows are
+// omitted.
+func buildSummaryBody(summaryLine string, findings []Finding) string {
+	counts := map[Severity]int{}
+	for _, f := range findings {
+		counts[f.Severity]++
+	}
+
+	var b strings.Builder
+	if summaryLine != "" {
+		b.WriteString(summaryLine)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("| Severity | Count |\n")
+	b.WriteString("| --- | --- |\n")
+	for _, sev := range []Severity{SeverityImportant, SeverityNit, SeverityPreExisting} {
+		if n := counts[sev]; n > 0 {
+			fmt.Fprintf(&b, "| %s | %d |\n", sev, n)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// buildInlineBody renders a single inline comment body. It OPENS with the hash
+// marker (an HTML comment, invisible in rendered markdown) so re-reviews can
+// match the thread, followed by the severity-tagged title, the body, and any
+// evidence as a fenced block.
+func buildInlineBody(f Finding) string {
+	var b strings.Builder
+	b.WriteString(markerFor(f.Hash))
+	b.WriteByte('\n')
+	if f.Severity != "" {
+		fmt.Fprintf(&b, "**[%s] %s**\n\n", f.Severity, f.Title)
+	} else {
+		fmt.Fprintf(&b, "**%s**\n\n", f.Title)
+	}
+	if f.Body != "" {
+		b.WriteString(f.Body)
+		b.WriteByte('\n')
+	}
+	if f.Evidence != "" {
+		b.WriteString("\n```\n")
+		b.WriteString(f.Evidence)
+		b.WriteString("\n```\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// markerFor returns the hash marker line for a finding hash, e.g.
+// "<!-- assay-hash: deadbeef -->".
+func markerFor(hash string) string {
+	return fmt.Sprintf("<!-- %s %s -->", hashMarkerPrefix, hash)
+}
+
+// parseLineSpec extracts the line anchor from a finding anchor of the form
+// "path:line" or "path:start-end". It returns (start, end, true) for a range,
+// (line, line, true) for a single line, and ok=false when no trailing line
+// number is present. The path may itself contain colons; only the final
+// colon-delimited segment is interpreted as the line spec.
+func parseLineSpec(anchor string) (start, end int, ok bool) {
+	idx := strings.LastIndex(anchor, ":")
+	if idx < 0 {
+		return 0, 0, false
+	}
+	spec := strings.TrimSpace(anchor[idx+1:])
+	if spec == "" {
+		return 0, 0, false
+	}
+	if dash := strings.Index(spec, "-"); dash >= 0 {
+		s, errS := strconv.Atoi(strings.TrimSpace(spec[:dash]))
+		e, errE := strconv.Atoi(strings.TrimSpace(spec[dash+1:]))
+		if errS != nil || errE != nil {
+			return 0, 0, false
+		}
+		if e < s {
+			s, e = e, s
+		}
+		return s, e, true
+	}
+	n, err := strconv.Atoi(spec)
+	if err != nil {
+		return 0, 0, false
+	}
+	return n, n, true
+}
+
+// defaultGhExec is the production ghExec: it shells out to the gh CLI in dir.
+func defaultGhExec(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "gh", args...))
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh %s: %w\nstderr: %s", strings.Join(args, " "), err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/assay/post_test.go
+++ b/internal/assay/post_test.go
@@ -1,0 +1,463 @@
+package assay
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/state"
+)
+
+// --- gh exec stub ---------------------------------------------------------
+
+// recordedCall captures one ghExec invocation.
+type recordedCall struct {
+	args []string
+}
+
+// stubGh is a deterministic ghExec. It records every call and returns either a
+// scripted stdout or an error. failPaths makes inline POSTs for a given file
+// path fail (to exercise per-comment continue-on-failure).
+type stubGh struct {
+	mu        sync.Mutex
+	calls     []recordedCall
+	nextID    int64
+	failPaths map[string]bool
+}
+
+func newStubGh() *stubGh {
+	return &stubGh{nextID: 1000, failPaths: map[string]bool{}}
+}
+
+func (s *stubGh) exec(_ context.Context, _ string, args ...string) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, recordedCall{args: args})
+
+	// Inline comment POST? Find the path field to decide success/failure.
+	isInline := false
+	path := ""
+	for _, a := range args {
+		if strings.HasPrefix(a, "path=") {
+			path = strings.TrimPrefix(a, "path=")
+		}
+		if strings.Contains(a, "/pulls/") && strings.HasSuffix(a, "/comments") {
+			isInline = true
+		}
+	}
+	if isInline {
+		if s.failPaths[path] {
+			return nil, fmt.Errorf("simulated gh failure for %s", path)
+		}
+		s.nextID++
+		return []byte(fmt.Sprintf(`{"id": %d}`, s.nextID)), nil
+	}
+	return []byte(`{}`), nil
+}
+
+func (s *stubGh) inlineCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, c := range s.calls {
+		for _, a := range c.args {
+			if strings.Contains(a, "/pulls/") && strings.HasSuffix(a, "/comments") {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func (s *stubGh) summaryPosted() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.calls {
+		if len(c.args) >= 2 && c.args[0] == "pr" && c.args[1] == "review" {
+			return true
+		}
+	}
+	return false
+}
+
+// --- thread resolver stub -------------------------------------------------
+
+type stubResolver struct {
+	threadID    string // returned by ThreadIDByBodyHeader
+	lookupCalls int
+	resolved    []string
+	lookedFor   []string
+}
+
+func (r *stubResolver) ThreadIDByBodyHeader(_ context.Context, _ string, _ int, header string) (string, error) {
+	r.lookupCalls++
+	r.lookedFor = append(r.lookedFor, header)
+	return r.threadID, nil
+}
+
+func (r *stubResolver) ResolveThread(_ context.Context, _ string, threadID string) error {
+	r.resolved = append(r.resolved, threadID)
+	return nil
+}
+
+// --- helpers --------------------------------------------------------------
+
+func newTestDB(t *testing.T) *state.DB {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "assay-post-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	db, err := state.Open(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func readFindingRow(t *testing.T, db *state.DB, hash string) (posted bool, commentID int64, misses int, resolved bool) {
+	t.Helper()
+	var p, m int
+	var resolvedAt *string
+	err := db.Conn().QueryRow(
+		`SELECT posted, gh_comment_id, consecutive_misses, resolved_at
+		   FROM pr_findings WHERE finding_hash = ?`, hash,
+	).Scan(&p, &commentID, &m, &resolvedAt)
+	if err != nil {
+		t.Fatalf("reading finding %s: %v", hash, err)
+	}
+	return p == 1, commentID, m, resolvedAt != nil
+}
+
+func newPoster(db *state.DB, gh ghExec, resolver ThreadResolver) *Poster {
+	return &Poster{gh: gh, db: db, resolver: resolver, logf: func(string, ...any) {}}
+}
+
+// --- buildSummaryBody -----------------------------------------------------
+
+func TestBuildSummaryBody(t *testing.T) {
+	findings := []Finding{
+		{Severity: SeverityImportant},
+		{Severity: SeverityImportant},
+		{Severity: SeverityNit},
+		{Severity: SeverityPreExisting},
+	}
+	got := buildSummaryBody("2 important, 1 nit, 1 pre-existing.", findings)
+
+	if !strings.HasPrefix(got, "2 important, 1 nit, 1 pre-existing.") {
+		t.Errorf("summary body should start with the summary line, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"| Severity | Count |",
+		"| Important | 2 |",
+		"| Nit | 1 |",
+		"| PreExisting | 1 |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary body missing %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildSummaryBodyOmitsZeroRows(t *testing.T) {
+	got := buildSummaryBody("", []Finding{{Severity: SeverityNit}})
+	if strings.Contains(got, "Important") || strings.Contains(got, "PreExisting") {
+		t.Errorf("zero-count severities should be omitted, got:\n%s", got)
+	}
+	if !strings.Contains(got, "| Nit | 1 |") {
+		t.Errorf("expected the Nit row, got:\n%s", got)
+	}
+}
+
+// --- buildInlineBody / marker --------------------------------------------
+
+func TestBuildInlineBodyOpensWithMarker(t *testing.T) {
+	f := Finding{
+		Hash:     "deadbeef",
+		Severity: SeverityImportant,
+		Title:    "nil deref",
+		Body:     "x may be nil here.",
+		Evidence: "x.Foo()",
+	}
+	got := buildInlineBody(f)
+
+	wantMarker := "<!-- assay-hash: deadbeef -->"
+	if !strings.HasPrefix(got, wantMarker) {
+		t.Errorf("inline body must OPEN with the hash marker %q, got:\n%s", wantMarker, got)
+	}
+	if !strings.Contains(got, "**[Important] nil deref**") {
+		t.Errorf("inline body missing severity-tagged title, got:\n%s", got)
+	}
+	if !strings.Contains(got, "x may be nil here.") || !strings.Contains(got, "x.Foo()") {
+		t.Errorf("inline body missing body/evidence, got:\n%s", got)
+	}
+}
+
+func TestMarkerForDeterministic(t *testing.T) {
+	if markerFor("abc123") != markerFor("abc123") {
+		t.Fatal("markerFor must be deterministic for the same hash")
+	}
+	if markerFor("abc123") == markerFor("def456") {
+		t.Fatal("markerFor must differ for different hashes")
+	}
+}
+
+// --- parseLineSpec --------------------------------------------------------
+
+func TestParseLineSpec(t *testing.T) {
+	cases := []struct {
+		anchor             string
+		wantStart, wantEnd int
+		wantOK             bool
+	}{
+		{"main.go:42", 42, 42, true},
+		{"pkg/file.go:10-20", 10, 20, true},
+		{"pkg/file.go:20-10", 10, 20, true}, // normalized
+		{"main.go", 0, 0, false},
+		{"main.go:", 0, 0, false},
+		{"main.go:abc", 0, 0, false},
+	}
+	for _, c := range cases {
+		s, e, ok := parseLineSpec(c.anchor)
+		if ok != c.wantOK || s != c.wantStart || e != c.wantEnd {
+			t.Errorf("parseLineSpec(%q) = (%d,%d,%v), want (%d,%d,%v)",
+				c.anchor, s, e, ok, c.wantStart, c.wantEnd, c.wantOK)
+		}
+	}
+}
+
+// --- Post: payload construction (single vs multi-line) --------------------
+
+func TestPostInlinePayloadLineSpec(t *testing.T) {
+	gh := newStubGh()
+	p := newPoster(nil, gh.exec, nil)
+	req := PostRequest{PRNumber: 7, HeadSHA: "sha7", WorktreePath: "/wt"}
+
+	if _, err := p.postInline(context.Background(), req, Finding{File: "a.go", Anchor: "a.go:5", Hash: "h1"}); err != nil {
+		t.Fatalf("single-line postInline: %v", err)
+	}
+	if _, err := p.postInline(context.Background(), req, Finding{File: "b.go", Anchor: "b.go:5-9", Hash: "h2"}); err != nil {
+		t.Fatalf("multi-line postInline: %v", err)
+	}
+
+	single := gh.calls[0].args
+	if !hasArg(single, "line=5") || hasArg(single, "start_line=5") {
+		t.Errorf("single-line call should carry line=5 and no start_line, got %v", single)
+	}
+	if !hasArg(single, "commit_id=sha7") || !hasArg(single, "path=a.go") {
+		t.Errorf("single-line call missing commit_id/path, got %v", single)
+	}
+
+	multi := gh.calls[1].args
+	if !hasArg(multi, "start_line=5") || !hasArg(multi, "line=9") {
+		t.Errorf("multi-line call should carry start_line=5 and line=9, got %v", multi)
+	}
+}
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Post: shadow mode short-circuit -------------------------------------
+
+func TestPostShadowModeNoOp(t *testing.T) {
+	gh := newStubGh()
+	p := newPoster(nil, gh.exec, nil)
+	cfg := Config{ShadowMode: true}
+	req := PostRequest{
+		PRNumber:    1,
+		SummaryLine: "should not post",
+		Findings:    []Finding{{File: "a.go", Anchor: "a.go:1", Hash: "h1"}},
+	}
+	res, err := p.Post(context.Background(), cfg, req)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("shadow mode must not call gh, got %d calls", len(gh.calls))
+	}
+	if res.SummaryPosted || res.Posted != 0 {
+		t.Errorf("shadow mode result should be zero, got %+v", res)
+	}
+}
+
+// --- Post: per-comment continue-on-failure -------------------------------
+
+func TestPostContinuesOnFailure(t *testing.T) {
+	db := newTestDB(t)
+	gh := newStubGh()
+	gh.failPaths["bad.go"] = true
+	p := newPoster(db, gh.exec, nil)
+
+	findings := []Finding{
+		{File: "good.go", Anchor: "good.go:1", Hash: "ok1", Severity: SeverityImportant, Title: "a"},
+		{File: "bad.go", Anchor: "bad.go:2", Hash: "fail1", Severity: SeverityImportant, Title: "b"},
+		{File: "good2.go", Anchor: "good2.go:3", Hash: "ok2", Severity: SeverityNit, Title: "c"},
+	}
+	// Persist rows (as Review would) so posted state is observable.
+	for _, f := range findings {
+		mustInsert(t, db, "anvil", 5, f)
+	}
+
+	cfg := Config{ShadowMode: false}
+	req := PostRequest{Anvil: "anvil", PRNumber: 5, HeadSHA: "sha5", Findings: findings, SummaryLine: "s"}
+	res, err := p.Post(context.Background(), cfg, req)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+
+	if res.Posted != 2 || res.Failed != 1 {
+		t.Errorf("expected 2 posted / 1 failed, got %+v", res)
+	}
+	if gh.inlineCalls() != 3 {
+		t.Errorf("all 3 inline comments should be attempted, got %d", gh.inlineCalls())
+	}
+	if !gh.summaryPosted() {
+		t.Error("summary review should have been posted")
+	}
+
+	// Failed finding stays posted=0 for retry; successful ones get an ID.
+	if posted, _, _, _ := readFindingRow(t, db, "fail1"); posted {
+		t.Error("failed finding should remain posted=0")
+	}
+	if posted, id, _, _ := readFindingRow(t, db, "ok1"); !posted || id == 0 {
+		t.Errorf("ok1 should be posted with a comment id, got posted=%v id=%d", posted, id)
+	}
+}
+
+// --- Post: consecutive-miss resolution ------------------------------------
+
+func TestPostResolvesOnSecondMiss(t *testing.T) {
+	db := newTestDB(t)
+	gh := newStubGh()
+	resolver := &stubResolver{threadID: "THREAD_1"}
+	p := newPoster(db, gh.exec, resolver)
+
+	// A finding posted on an earlier head, currently at 1 miss.
+	mustInsert(t, db, "anvil", 9, Finding{
+		File: "gone.go", Anchor: "gone.go:1", Hash: "stale", Severity: SeverityImportant, Title: "x",
+	})
+	mustMarkPosted(t, db, "stale", 111)
+	if err := db.IncrementConsecutiveMiss("stale"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{ShadowMode: false}
+	// Review found nothing this round → the stale finding is missed again (2nd).
+	req := PostRequest{Anvil: "anvil", PRNumber: 9, HeadSHA: "sha9", Findings: nil}
+	res, err := p.Post(context.Background(), cfg, req)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+
+	if res.Resolved != 1 {
+		t.Errorf("expected 1 resolution at the 2nd miss, got %d", res.Resolved)
+	}
+	if len(resolver.resolved) != 1 || resolver.resolved[0] != "THREAD_1" {
+		t.Errorf("ResolveThread should have been called with THREAD_1, got %v", resolver.resolved)
+	}
+	if _, _, misses, resolved := readFindingRow(t, db, "stale"); !resolved || misses != 2 {
+		t.Errorf("stale finding should be resolved with misses=2, got misses=%d resolved=%v", misses, resolved)
+	}
+	// The lookup header must be the finding's hash marker.
+	if len(resolver.lookedFor) != 1 || resolver.lookedFor[0] != markerFor("stale") {
+		t.Errorf("thread lookup header should be the hash marker, got %v", resolver.lookedFor)
+	}
+}
+
+func TestPostDoesNotResolveOnFirstMiss(t *testing.T) {
+	db := newTestDB(t)
+	gh := newStubGh()
+	resolver := &stubResolver{threadID: "THREAD_1"}
+	p := newPoster(db, gh.exec, resolver)
+
+	mustInsert(t, db, "anvil", 3, Finding{
+		File: "gone.go", Anchor: "gone.go:1", Hash: "fresh", Severity: SeverityImportant, Title: "x",
+	})
+	mustMarkPosted(t, db, "fresh", 222) // misses reset to 0
+
+	cfg := Config{ShadowMode: false}
+	req := PostRequest{Anvil: "anvil", PRNumber: 3, HeadSHA: "sha3", Findings: nil}
+	res, err := p.Post(context.Background(), cfg, req)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+
+	if res.Resolved != 0 {
+		t.Errorf("first miss should not resolve, got Resolved=%d", res.Resolved)
+	}
+	if len(resolver.resolved) != 0 {
+		t.Errorf("ResolveThread should not be called on first miss, got %v", resolver.resolved)
+	}
+	if _, _, misses, resolved := readFindingRow(t, db, "fresh"); resolved || misses != 1 {
+		t.Errorf("expected misses=1 and unresolved, got misses=%d resolved=%v", misses, resolved)
+	}
+}
+
+func TestPostResetsMissesOnRedetection(t *testing.T) {
+	db := newTestDB(t)
+	gh := newStubGh()
+	p := newPoster(db, gh.exec, nil)
+
+	f := Finding{File: "x.go", Anchor: "x.go:1", Hash: "redetect", Severity: SeverityNit, Title: "x"}
+	mustInsert(t, db, "anvil", 4, f)
+	mustMarkPosted(t, db, "redetect", 333)
+	if err := db.IncrementConsecutiveMiss("redetect"); err != nil { // now at 1
+		t.Fatal(err)
+	}
+
+	cfg := Config{ShadowMode: false}
+	// Re-detected this round → misses reset, not re-posted.
+	req := PostRequest{Anvil: "anvil", PRNumber: 4, HeadSHA: "sha4", Findings: []Finding{f}}
+	res, err := p.Post(context.Background(), cfg, req)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if res.Posted != 0 {
+		t.Errorf("already-posted finding should not be re-posted, got Posted=%d", res.Posted)
+	}
+	if gh.inlineCalls() != 0 {
+		t.Errorf("no inline POST expected for an already-posted finding, got %d", gh.inlineCalls())
+	}
+	if _, _, misses, _ := readFindingRow(t, db, "redetect"); misses != 0 {
+		t.Errorf("misses should reset to 0 on re-detection, got %d", misses)
+	}
+}
+
+// --- shared insert helpers ------------------------------------------------
+
+func mustInsert(t *testing.T, db *state.DB, anvil string, pr int, f Finding) {
+	t.Helper()
+	if err := db.InsertFinding(state.Finding{
+		Anvil:       anvil,
+		PRNumber:    pr,
+		HeadSHA:     "sha0",
+		FindingHash: f.Hash,
+		File:        f.File,
+		Anchor:      f.Anchor,
+		Severity:    string(f.Severity),
+		Category:    f.Category,
+		Title:       f.Title,
+		Body:        f.Body,
+	}); err != nil {
+		t.Fatalf("InsertFinding %s: %v", f.Hash, err)
+	}
+}
+
+func mustMarkPosted(t *testing.T, db *state.DB, hash string, id int64) {
+	t.Helper()
+	if err := db.MarkFindingPosted(hash, id); err != nil {
+		t.Fatalf("MarkFindingPosted %s: %v", hash, err)
+	}
+}

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -3788,13 +3788,17 @@ func (db *DB) MarkResolved(findingHash string) error {
 }
 
 // MarkFindingPosted records that a finding was successfully posted as a GitHub
-// review comment: it sets posted=1, stores the returned comment ID, and resets
-// the consecutive-miss counter (the finding has just been confirmed present on
-// the current head). Used by the Assay posting layer after a successful
-// inline-comment POST.
+// review comment: it sets posted=1, stores the returned comment ID, resets
+// the consecutive-miss counter, clears resolved_at (so a previously resolved
+// finding reappears in OpenPostedFindings), and clears the stale gh_thread_id
+// (the new comment lives on a fresh thread). Used by the Assay posting layer
+// after a successful inline-comment POST.
 func (db *DB) MarkFindingPosted(findingHash string, ghCommentID int64) error {
 	_, err := db.conn.Exec(
-		`UPDATE pr_findings SET posted = 1, gh_comment_id = ?, consecutive_misses = 0 WHERE finding_hash = ?`,
+		`UPDATE pr_findings
+		    SET posted = 1, gh_comment_id = ?, consecutive_misses = 0,
+		        resolved_at = NULL, gh_thread_id = ''
+		  WHERE finding_hash = ?`,
 		ghCommentID, findingHash,
 	)
 	return err

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1022,23 +1022,23 @@ func nonTerminalPRStatusSQL() string {
 
 // PR represents a pull request entry.
 type PR struct {
-	ID                   int
-	Number               int
-	Anvil                string
-	BeadID               string
-	Branch               string
-	BaseBranch           string // Target branch for the PR (empty = repo default base branch)
-	Status               PRStatus
-	CreatedAt            time.Time
-	LastChecked          *time.Time
-	CIFixCount           int
-	ReviewFixCount       int
-	RebaseCount          int
-	CIPassing            bool
-	IsConflicting        bool
-	HasUnresolvedThreads bool
-	HasPendingReviews    bool
-	HasApproval          bool
+	ID                      int
+	Number                  int
+	Anvil                   string
+	BeadID                  string
+	Branch                  string
+	BaseBranch              string // Target branch for the PR (empty = repo default base branch)
+	Status                  PRStatus
+	CreatedAt               time.Time
+	LastChecked             *time.Time
+	CIFixCount              int
+	ReviewFixCount          int
+	RebaseCount             int
+	CIPassing               bool
+	IsConflicting           bool
+	HasUnresolvedThreads    bool
+	HasPendingReviews       bool
+	HasApproval             bool
 	Title                   string
 	BellowsManaged          bool // true = bellows runs lifecycle workers (quench, burnish, rebase)
 	BellowsManuallyAssigned bool // true = a user explicitly assigned bellows via IPC; reconcile must not clobber
@@ -1513,17 +1513,17 @@ func (db *DB) DismissExhaustedPR(id int) error {
 type EventType string
 
 const (
-	EventDaemonStarted        EventType = "daemon_started"
-	EventDaemonStopped        EventType = "daemon_stopped"
-	EventConfigReload         EventType = "config_reload"
+	EventDaemonStarted EventType = "daemon_started"
+	EventDaemonStopped EventType = "daemon_stopped"
+	EventConfigReload  EventType = "config_reload"
 	EventOrphanCleanup EventType = "orphan_cleanup"
 	// EventPoll is retained as a constant for historical rows already in the
 	// events table (and so referring code does not need to be churned), but it
 	// is no longer written by the daemon: successful polls are tracked only in
 	// the in-memory map on Daemon (see Daemon.lastPollMap). Failed polls
 	// continue to be persisted as EventPollError so they remain visible.
-	EventPoll      EventType = "poll"
-	EventPollError EventType = "poll_error"
+	EventPoll                 EventType = "poll"
+	EventPollError            EventType = "poll_error"
 	EventBeadClaimed          EventType = "bead_claimed"
 	EventSmithStarted         EventType = "smith_started"
 	EventSmithDone            EventType = "smith_done"
@@ -1572,42 +1572,42 @@ const (
 	// check finds origin/forge/<bead-id> with commits not reachable from the
 	// base ref and no PR — a prior worker pushed but never opened a PR.
 	EventDispatchBlockedStrandedBranch EventType = "dispatch_blocked_stranded_branch"
-	EventRateLimited          EventType = "rate_limited"
-	EventCostLimitHit         EventType = "cost_limit_hit"
-	EventSchematicSubBead     EventType = "schematic_sub_bead"
-	EventWorkerStalled        EventType = "worker_stalled"
-	EventBeadTagged           EventType = "bead_tagged"
-	EventBeadClosed           EventType = "bead_closed"
-	EventPRReadyToMerge       EventType = "pr_ready_to_merge"
-	EventPRReviewNeeded       EventType = "pr_review_needed"
-	EventPRMergeRequested     EventType = "pr_merge_requested"
-	EventPRMergeFailed        EventType = "pr_merge_failed"
-	EventPRAutoMerged         EventType = "pr_auto_merged"
-	EventError                EventType = "error"
-	EventBeadRecovered        EventType = "bead_recovered"
-	EventBeadStopped          EventType = "bead_stopped"
-	EventDepcheckStarted      EventType = "depcheck_started"
-	EventDepcheckPassed       EventType = "depcheck_passed"
-	EventDepcheckFound        EventType = "depcheck_found"
-	EventDepcheckFailed       EventType = "depcheck_failed"
-	EventDepcheckBeadCreated  EventType = "depcheck_bead_created"
-	EventDepcheckDedup        EventType = "depcheck_dedup"
-	EventVulnScanStarted      EventType = "vuln_scan_started"
-	EventVulnScanDone         EventType = "vuln_scan_done"
-	EventVulnScanFailed       EventType = "vuln_scan_failed"
-	EventVulnScanCycleDone    EventType = "vuln_scan_cycle_done"
-	EventVulnBeadCreated      EventType = "vuln_bead_created"
-	EventWardenRerun          EventType = "warden_rerun"
-	EventApproveAsIs          EventType = "approve_as_is"
-	EventForceSmith           EventType = "force_smith"
-	EventAutoLearnError       EventType = "auto_learn_error"
-	EventAutoLearnSkipped     EventType = "auto_learn_skipped"
-	EventAutoLearnRules       EventType = "auto_learn_rules"
-	EventWardenRuleLearned    EventType = "warden_rule_learned"
-	EventBeadAutoClosed       EventType = "bead_auto_closed"
-	EventNoChangesNeeded      EventType = "no_changes_needed"
-	EventPRCreationFailed     EventType = "pr_creation_failed"
-	EventPRAlreadyExists      EventType = "pr_already_exists"
+	EventRateLimited                   EventType = "rate_limited"
+	EventCostLimitHit                  EventType = "cost_limit_hit"
+	EventSchematicSubBead              EventType = "schematic_sub_bead"
+	EventWorkerStalled                 EventType = "worker_stalled"
+	EventBeadTagged                    EventType = "bead_tagged"
+	EventBeadClosed                    EventType = "bead_closed"
+	EventPRReadyToMerge                EventType = "pr_ready_to_merge"
+	EventPRReviewNeeded                EventType = "pr_review_needed"
+	EventPRMergeRequested              EventType = "pr_merge_requested"
+	EventPRMergeFailed                 EventType = "pr_merge_failed"
+	EventPRAutoMerged                  EventType = "pr_auto_merged"
+	EventError                         EventType = "error"
+	EventBeadRecovered                 EventType = "bead_recovered"
+	EventBeadStopped                   EventType = "bead_stopped"
+	EventDepcheckStarted               EventType = "depcheck_started"
+	EventDepcheckPassed                EventType = "depcheck_passed"
+	EventDepcheckFound                 EventType = "depcheck_found"
+	EventDepcheckFailed                EventType = "depcheck_failed"
+	EventDepcheckBeadCreated           EventType = "depcheck_bead_created"
+	EventDepcheckDedup                 EventType = "depcheck_dedup"
+	EventVulnScanStarted               EventType = "vuln_scan_started"
+	EventVulnScanDone                  EventType = "vuln_scan_done"
+	EventVulnScanFailed                EventType = "vuln_scan_failed"
+	EventVulnScanCycleDone             EventType = "vuln_scan_cycle_done"
+	EventVulnBeadCreated               EventType = "vuln_bead_created"
+	EventWardenRerun                   EventType = "warden_rerun"
+	EventApproveAsIs                   EventType = "approve_as_is"
+	EventForceSmith                    EventType = "force_smith"
+	EventAutoLearnError                EventType = "auto_learn_error"
+	EventAutoLearnSkipped              EventType = "auto_learn_skipped"
+	EventAutoLearnRules                EventType = "auto_learn_rules"
+	EventWardenRuleLearned             EventType = "warden_rule_learned"
+	EventBeadAutoClosed                EventType = "bead_auto_closed"
+	EventNoChangesNeeded               EventType = "no_changes_needed"
+	EventPRCreationFailed              EventType = "pr_creation_failed"
+	EventPRAlreadyExists               EventType = "pr_already_exists"
 
 	// Crucible events — parent bead orchestration with children on feature branches.
 	EventCrucibleStarted         EventType = "crucible_started"
@@ -1627,23 +1627,23 @@ const (
 	EventTestBeadCreated    EventType = "test_bead_created"
 
 	// Smelter events — batch warden rule flushing.
-	EventSmelterStarted    EventType = "smelter_started"
-	EventSmelterFlushed    EventType = "smelter_flushed"
-	EventSmelterFailed     EventType = "smelter_failed"
-	EventSmelterCycleDone  EventType = "smelter_cycle_done"
+	EventSmelterStarted   EventType = "smelter_started"
+	EventSmelterFlushed   EventType = "smelter_flushed"
+	EventSmelterFailed    EventType = "smelter_failed"
+	EventSmelterCycleDone EventType = "smelter_cycle_done"
 
 	// Wicket events — GitHub issue triage monitor.
-	EventWicketScanDone         EventType = "wicket_scan_done"
-	EventWicketIssueTriage      EventType = "wicket_issue_triage"
-	EventWicketBeadCreated      EventType = "wicket_bead_created"
-	EventWicketClarification    EventType = "wicket_clarification"
-	EventWicketRejected         EventType = "wicket_rejected"
-	EventWicketFlaggedHuman     EventType = "wicket_flagged_human"
-	EventWicketError            EventType = "wicket_error"
-	EventWicketDispatchConfirm  EventType = "wicket_dispatch_confirm"
-	EventWicketPRLinked         EventType = "wicket_pr_linked"
-	EventWicketIssueClosed      EventType = "wicket_issue_closed"
-	EventWicketIssueStaleClose  EventType = "wicket_issue_stale_close"
+	EventWicketScanDone        EventType = "wicket_scan_done"
+	EventWicketIssueTriage     EventType = "wicket_issue_triage"
+	EventWicketBeadCreated     EventType = "wicket_bead_created"
+	EventWicketClarification   EventType = "wicket_clarification"
+	EventWicketRejected        EventType = "wicket_rejected"
+	EventWicketFlaggedHuman    EventType = "wicket_flagged_human"
+	EventWicketError           EventType = "wicket_error"
+	EventWicketDispatchConfirm EventType = "wicket_dispatch_confirm"
+	EventWicketPRLinked        EventType = "wicket_pr_linked"
+	EventWicketIssueClosed     EventType = "wicket_issue_closed"
+	EventWicketIssueStaleClose EventType = "wicket_issue_stale_close"
 
 	// Pipeline hook events.
 	EventHookFailed EventType = "hook_failed"
@@ -1998,17 +1998,17 @@ func (db *DB) LastPollAllAnvils() ([]AnvilPollStatus, error) {
 
 // RetryRecord tracks retry state for a bead.
 type RetryRecord struct {
-	BeadID                string
-	Anvil                 string
-	RetryCount            int
-	NextRetry             *time.Time
-	NeedsHuman            bool
-	ClarificationNeeded   bool
-	DispatchFailures      int
-	RecoveryFailures      int
-	FirstRecoveryFailure  *time.Time
-	LastError             string
-	UpdatedAt             time.Time
+	BeadID               string
+	Anvil                string
+	RetryCount           int
+	NextRetry            *time.Time
+	NeedsHuman           bool
+	ClarificationNeeded  bool
+	DispatchFailures     int
+	RecoveryFailures     int
+	FirstRecoveryFailure *time.Time
+	LastError            string
+	UpdatedAt            time.Time
 }
 
 // GetRetry returns the retry record for a bead, or nil if none exists.
@@ -3231,12 +3231,12 @@ func (db *DB) DeletePendingRules(ids []int) error {
 // WicketIssue is the database representation of a GitHub issue that has been
 // seen (and optionally triaged) by the Wicket monitor.
 type WicketIssue struct {
-	ID           int
-	Repo         string
-	IssueNumber  int
-	Title        string
-	Body         string
-	Author       string
+	ID          int
+	Repo        string
+	IssueNumber int
+	Title       string
+	Body        string
+	Author      string
 	// State is the lifecycle state of this record: "pending", "bead_created",
 	// "ask_clarify", "needs_human", "rejected", "dispatched", "stale", "merged", "closed".
 	State        string
@@ -3785,6 +3785,74 @@ func (db *DB) MarkResolved(findingHash string) error {
 		time.Now().UTC().Format(dbTimeLayout), findingHash,
 	)
 	return err
+}
+
+// MarkFindingPosted records that a finding was successfully posted as a GitHub
+// review comment: it sets posted=1, stores the returned comment ID, and resets
+// the consecutive-miss counter (the finding has just been confirmed present on
+// the current head). Used by the Assay posting layer after a successful
+// inline-comment POST.
+func (db *DB) MarkFindingPosted(findingHash string, ghCommentID int64) error {
+	_, err := db.conn.Exec(
+		`UPDATE pr_findings SET posted = 1, gh_comment_id = ?, consecutive_misses = 0 WHERE finding_hash = ?`,
+		ghCommentID, findingHash,
+	)
+	return err
+}
+
+// ResetConsecutiveMiss clears the consecutive_misses counter for a finding that
+// was re-detected on a fresh review (so an intermittent disappearance does not
+// accumulate toward auto-resolution).
+func (db *DB) ResetConsecutiveMiss(findingHash string) error {
+	_, err := db.conn.Exec(
+		`UPDATE pr_findings SET consecutive_misses = 0 WHERE finding_hash = ?`,
+		findingHash,
+	)
+	return err
+}
+
+// SetFindingThreadID stores the GitHub review thread node ID matched to a
+// finding, so a subsequent resolution can target the thread directly.
+func (db *DB) SetFindingThreadID(findingHash, threadID string) error {
+	_, err := db.conn.Exec(
+		`UPDATE pr_findings SET gh_thread_id = ? WHERE finding_hash = ?`,
+		threadID, findingHash,
+	)
+	return err
+}
+
+// OpenPostedFindings returns the findings on the given anvil/PR that have been
+// posted (posted=1) and not yet resolved (resolved_at IS NULL). The Assay
+// posting layer uses these to detect findings that disappeared on a later
+// review — accumulating consecutive misses until their threads are
+// auto-resolved.
+func (db *DB) OpenPostedFindings(anvil string, prNumber int) ([]Finding, error) {
+	rows, err := db.conn.Query(
+		`SELECT head_sha, finding_hash, file, anchor, severity, category, title,
+		        body, evidence, source_pass, gh_comment_id, gh_thread_id,
+		        consecutive_misses
+		   FROM pr_findings
+		  WHERE anvil = ? AND pr_number = ? AND posted = 1 AND resolved_at IS NULL`,
+		anvil, prNumber,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Finding
+	for rows.Next() {
+		f := Finding{Anvil: anvil, PRNumber: prNumber, Posted: true}
+		if err := rows.Scan(
+			&f.HeadSHA, &f.FindingHash, &f.File, &f.Anchor, &f.Severity,
+			&f.Category, &f.Title, &f.Body, &f.Evidence, &f.SourcePass,
+			&f.GHCommentID, &f.GHThreadID, &f.ConsecutiveMisses,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
 }
 
 // PostedFindingHashes returns the set of finding_hash values that have already

--- a/internal/vcs/github/github.go
+++ b/internal/vcs/github/github.go
@@ -789,6 +789,110 @@ func (p *Provider) ResolveThread(ctx context.Context, worktreePath string, threa
 	return nil
 }
 
+// ThreadIDByBodyHeader returns the GraphQL node ID of the first review thread on
+// the PR whose top comment body contains the given header marker (for example
+// an "<!-- assay-hash: … -->" line). It returns "" (no error) when no thread
+// matches. Assay uses this to locate the thread it previously opened for a
+// finding so the thread can be resolved once the finding is gone.
+func (p *Provider) ThreadIDByBodyHeader(ctx context.Context, worktreePath string, prNumber int, header string) (string, error) {
+	if strings.TrimSpace(header) == "" {
+		return "", nil
+	}
+
+	owner, repo, err := p.GetRepoOwnerAndName(ctx, worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("getting repo owner and name: %w", err)
+	}
+
+	query := `
+	query($owner:String!, $repo:String!, $pr:Int!, $cursor:String) {
+		repository(owner:$owner, name:$repo) {
+			pullRequest(number:$pr) {
+				reviewThreads(first:100, after:$cursor) {
+					pageInfo { hasNextPage endCursor }
+					nodes {
+						id
+						comments(first:1) {
+							nodes { body }
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	type gqlPage struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+						Nodes []struct {
+							ID       string `json:"id"`
+							Comments struct {
+								Nodes []struct {
+									Body string `json:"body"`
+								} `json:"nodes"`
+							} `json:"comments"`
+						} `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+
+	cursor := ""
+	for {
+		args := []string{
+			"api", "graphql",
+			"-f", "query=" + query,
+			"-f", "owner=" + owner,
+			"-f", "repo=" + repo,
+			"-F", fmt.Sprintf("pr=%d", prNumber),
+		}
+		if cursor != "" {
+			args = append(args, "-f", "cursor="+cursor)
+		} else {
+			args = append(args, "-F", "cursor=null")
+		}
+
+		cmd := executil.HideWindow(exec.CommandContext(ctx, "gh", args...))
+		cmd.Dir = worktreePath
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("gh api graphql (threads): %w\nstderr: %s", err, stderr.String())
+		}
+
+		var page gqlPage
+		if err := json.Unmarshal(stdout.Bytes(), &page); err != nil {
+			return "", fmt.Errorf("parsing graphql response: %w", err)
+		}
+
+		for _, thread := range page.Data.Repository.PullRequest.ReviewThreads.Nodes {
+			if len(thread.Comments.Nodes) == 0 {
+				continue
+			}
+			if strings.Contains(thread.Comments.Nodes[0].Body, header) {
+				return thread.ID, nil
+			}
+		}
+
+		if !page.Data.Repository.PullRequest.ReviewThreads.PageInfo.HasNextPage {
+			break
+		}
+		cursor = page.Data.Repository.PullRequest.ReviewThreads.PageInfo.EndCursor
+	}
+
+	return "", nil
+}
+
 // ParseRepoURL parses a git remote URL into owner and repository name.
 func ParseRepoURL(url string) (owner, repo string, err error) {
 	url = strings.TrimSuffix(url, ".git")


### PR DESCRIPTION
## Changes

- **Assay PR posting layer** - When Assay runs outside shadow mode it now posts a top-level summary review with a severity table, opens one inline review comment per finding (anchored to the head SHA and tagged with a stable `assay-hash` marker), and auto-resolves a finding's review thread after two consecutive reviews fail to re-detect it. (Forge-g197)

## Original Issue (task): Posting layer — gh comments, thread resolution & hash markers

Create `internal/assay/post.go`. When shadow_mode=false: (1) post top-level summary review via `gh pr review <n> --comment --body <summary>` with summary_line and a markdown severity table; (2) post inline comments via `gh api repos/:owner/:repo/pulls/:n/comments` with commit_id=HeadSHA, path, line (or start_line/line for multi-line), body opening with `<!-- assay-hash: <hex> -->`; (3) on 2 consecutive misses, query review threads via `gh api graphql`, match by body header, persist gh_thread_id, and call existing `vcs.Provider.ResolveThread(ctx, worktreePath, threadID)` at `internal/vcs/github/github.go:765` — add a small thread-ID-by-body-header helper there if absent. (4) gh failures per-comment: log and continue, leaving posted=0 row for retry on next SHA. Depends on sub-task 3 (Findings) and sub-task 1 (persistence of gh_comment_id/gh_thread_id/consecutive_misses).

---
Bead: Forge-g197 | Branch: forge/Forge-g197
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->