### PR TITLE
Web backend: findings endpoint + SSE update channel (Forge-3zsv)

### DIFF
--- a/changelog.d/Forge-3zsv.md
+++ b/changelog.d/Forge-3zsv.md
@@ -1,0 +1,2 @@
+category: Added
+- **PR findings API & live SSE channel** - Added `GET /api/prs/{id}/findings`, returning a PR's Assay findings (id, pr, anvil, status, severity, message, timestamp) plus the latest review-run status, and a `GET /api/prs/{id}/findings/stream` Server-Sent Events channel that re-emits the snapshot whenever findings or rerun status change so the PR detail panel updates live. (Forge-3zsv)

--- a/internal/web/prs.go
+++ b/internal/web/prs.go
@@ -224,6 +224,216 @@ func (s *Server) recentlyMergedPRs(window time.Duration) ([]prItemJSON, error) {
 	return out, nil
 }
 
+// findingJSON is the wire shape for one Assay finding on a PR. The first
+// seven fields (id, pr, anvil, status, severity, message, timestamp) form the
+// stable contract the typed frontend client mirrors; the remaining fields are
+// optional context the PR detail panel renders when present.
+type findingJSON struct {
+	ID        int    `json:"id"`
+	PR        int    `json:"pr"`
+	Anvil     string `json:"anvil"`
+	Status    string `json:"status"`
+	Severity  string `json:"severity"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp,omitempty"`
+	HeadSHA   string `json:"head_sha,omitempty"`
+	File      string `json:"file,omitempty"`
+	Anchor    string `json:"anchor,omitempty"`
+	Category  string `json:"category,omitempty"`
+	Body      string `json:"body,omitempty"`
+}
+
+// assayRunJSON summarises the most recent Assay review pass over a PR so the
+// detail panel can show "rerun" progress (running → complete/error/skipped).
+type assayRunJSON struct {
+	Status        string  `json:"status"`
+	HeadSHA       string  `json:"head_sha,omitempty"`
+	StartedAt     string  `json:"started_at,omitempty"`
+	FinishedAt    string  `json:"finished_at,omitempty"`
+	DurationMs    int64   `json:"duration_ms,omitempty"`
+	CostUSD       float64 `json:"cost_usd,omitempty"`
+	FindingsCount int     `json:"findings_count"`
+	PostedCount   int     `json:"posted_count"`
+	ShadowMode    bool    `json:"shadow_mode,omitempty"`
+	SkippedReason string  `json:"skipped_reason,omitempty"`
+	Error         string  `json:"error,omitempty"`
+}
+
+// prFindingsResponse is the JSON body returned by GET /api/prs/{id}/findings
+// and emitted on the findings SSE channel. `run` is null until Assay has
+// recorded at least one review pass for the PR; `findings` is always an array.
+type prFindingsResponse struct {
+	PR       int           `json:"pr"`
+	Anvil    string        `json:"anvil"`
+	Run      *assayRunJSON `json:"run"`
+	Findings []findingJSON `json:"findings"`
+}
+
+// handlePRFindings returns the Assay findings (and latest run status) for the
+// PR identified by the {id} path parameter. The PR row is resolved from
+// state.db so the anvil/number key the pr_findings table is queried with.
+func (s *Server) handlePRFindings(w http.ResponseWriter, r *http.Request) {
+	ctx, ok := s.requirePR(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.collectPRFindings(ctx.pr.Anvil, ctx.pr.Number)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load findings: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// collectPRFindings reads the findings and most-recent Assay run for one PR.
+// It queries state.db directly (like recentlyMergedPRs) so the change stays
+// confined to the web package. Findings are ordered Important → PreExisting →
+// Nit, then by insertion order, so the most actionable items sort first.
+func (s *Server) collectPRFindings(anvil string, prNumber int) (prFindingsResponse, error) {
+	resp := prFindingsResponse{
+		PR:       prNumber,
+		Anvil:    anvil,
+		Findings: []findingJSON{},
+	}
+	conn := s.db.Conn()
+	if conn == nil {
+		return resp, nil
+	}
+
+	rows, err := conn.Query(`SELECT id, pr_number, anvil, head_sha, file, anchor,
+		severity, category, title, body, posted, resolved_at, created_at
+		FROM pr_findings
+		WHERE anvil = ? AND pr_number = ?
+		ORDER BY
+			CASE severity WHEN 'Important' THEN 0 WHEN 'Nit' THEN 2 ELSE 1 END,
+			id`, anvil, prNumber)
+	if err != nil {
+		return resp, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			id, pr                                        int
+			av, headSHA, file, anchor, severity, category string
+			title, body, createdAt                        string
+			posted                                        int
+			resolvedAt                                    sql.NullString
+		)
+		if err := rows.Scan(&id, &pr, &av, &headSHA, &file, &anchor, &severity,
+			&category, &title, &body, &posted, &resolvedAt, &createdAt); err != nil {
+			s.logger.Warn("pr finding row scan failed", "error", err)
+			continue
+		}
+		item := findingJSON{
+			ID:       id,
+			PR:       pr,
+			Anvil:    av,
+			Status:   findingStatus(posted != 0, resolvedAt.Valid),
+			Severity: severity,
+			Message:  title,
+			HeadSHA:  headSHA,
+			File:     file,
+			Anchor:   anchor,
+			Category: category,
+			Body:     body,
+		}
+		if t := parseAnyTime(createdAt); !t.IsZero() {
+			item.Timestamp = t.UTC().Format(time.RFC3339Nano)
+		}
+		resp.Findings = append(resp.Findings, item)
+	}
+	if err := rows.Err(); err != nil {
+		return resp, err
+	}
+
+	run, err := s.latestAssayRun(anvil, prNumber)
+	if err != nil {
+		return resp, err
+	}
+	resp.Run = run
+	return resp, nil
+}
+
+// latestAssayRun returns the most recent assay_runs row for the anvil/PR as a
+// wire object, or (nil, nil) when no run has been recorded yet.
+func (s *Server) latestAssayRun(anvil string, prNumber int) (*assayRunJSON, error) {
+	conn := s.db.Conn()
+	if conn == nil {
+		return nil, nil
+	}
+	var (
+		headSHA, skipped, errMsg           string
+		startedAt                          string
+		finishedAt                         sql.NullString
+		durationMs                         int64
+		costUSD                            float64
+		findingsCount, postedCount, shadow int
+	)
+	err := conn.QueryRow(`SELECT head_sha, started_at, finished_at, duration_ms,
+		cost_usd, findings_count, posted_count, shadow_mode, skipped_reason, error
+		FROM assay_runs
+		WHERE anvil = ? AND pr_number = ?
+		ORDER BY id DESC LIMIT 1`, anvil, prNumber).Scan(
+		&headSHA, &startedAt, &finishedAt, &durationMs, &costUSD,
+		&findingsCount, &postedCount, &shadow, &skipped, &errMsg)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	run := &assayRunJSON{
+		Status:        runStatus(finishedAt.Valid, errMsg, skipped),
+		HeadSHA:       headSHA,
+		DurationMs:    durationMs,
+		CostUSD:       costUSD,
+		FindingsCount: findingsCount,
+		PostedCount:   postedCount,
+		ShadowMode:    shadow != 0,
+		SkippedReason: skipped,
+		Error:         errMsg,
+	}
+	if t := parseAnyTime(startedAt); !t.IsZero() {
+		run.StartedAt = t.UTC().Format(time.RFC3339Nano)
+	}
+	if finishedAt.Valid {
+		if t := parseAnyTime(finishedAt.String); !t.IsZero() {
+			run.FinishedAt = t.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	return run, nil
+}
+
+// findingStatus maps a finding's posted/resolved flags to a status label the
+// frontend can badge: resolved (thread closed) → posted (live comment) → open
+// (detected, not yet posted).
+func findingStatus(posted, resolved bool) string {
+	switch {
+	case resolved:
+		return "resolved"
+	case posted:
+		return "posted"
+	default:
+		return "open"
+	}
+}
+
+// runStatus maps an assay_runs row to a coarse lifecycle label: running (not
+// finished) → error → skipped → complete.
+func runStatus(finished bool, errMsg, skipped string) string {
+	switch {
+	case !finished:
+		return "running"
+	case errMsg != "":
+		return "error"
+	case skipped != "":
+		return "skipped"
+	default:
+		return "complete"
+	}
+}
+
 // parseAnyTime parses a timestamp using the layouts the state package
 // produces (canonical fixed-width with nanos, then RFC3339Nano / RFC3339).
 // Returns the zero time when none of them parse.

--- a/internal/web/prs.go
+++ b/internal/web/prs.go
@@ -244,7 +244,7 @@ type findingJSON struct {
 }
 
 // assayRunJSON summarises the most recent Assay review pass over a PR so the
-// detail panel can show "rerun" progress (running → complete/error/skipped).
+// detail panel can show "rerun" progress (running → error → skipped → complete).
 type assayRunJSON struct {
 	Status        string  `json:"status"`
 	HeadSHA       string  `json:"head_sha,omitempty"`
@@ -305,7 +305,7 @@ func (s *Server) collectPRFindings(anvil string, prNumber int) (prFindingsRespon
 		FROM pr_findings
 		WHERE anvil = ? AND pr_number = ?
 		ORDER BY
-			CASE severity WHEN 'Important' THEN 0 WHEN 'Nit' THEN 2 ELSE 1 END,
+			CASE severity WHEN 'Important' THEN 0 WHEN 'PreExisting' THEN 1 WHEN 'Nit' THEN 2 ELSE 3 END,
 			id`, anvil, prNumber)
 	if err != nil {
 		return resp, err

--- a/internal/web/prs_test.go
+++ b/internal/web/prs_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,6 +125,137 @@ func TestPRsAll_SectionAssignment(t *testing.T) {
 	}
 	if got := resp.RecentlyMerged[0]; got.Number != 3 || got.Status != string(state.PRMerged) {
 		t.Errorf("recently_merged[0] unexpected: %+v", got)
+	}
+}
+
+func TestPRFindings_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, httptest.NewRequest("GET", "/api/prs/1/findings", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d", rec.Code)
+	}
+}
+
+func TestPRFindings_NotFound(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	req := httptest.NewRequest("GET", "/api/prs/999/findings", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown PR, got %d", rec.Code)
+	}
+}
+
+func TestPRFindings_EmptyShape(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	pr := &state.PR{
+		Number: 8, Anvil: "anvil-a", BeadID: "Forge-bbbb",
+		Branch: "b", Status: state.PROpen, CreatedAt: time.Now().UTC(),
+	}
+	if err := srv.db.InsertPR(pr); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	cookie := loginAndGetCookie(t, srv)
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/prs/%d/findings", pr.ID), nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// findings must serialise as [] (not null) so the SPA can index it; run is
+	// null until Assay records a pass.
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if string(body["findings"]) == "null" {
+		t.Errorf("findings should be [] not null")
+	}
+	if string(body["run"]) != "null" {
+		t.Errorf("run should be null when no run recorded, got %s", body["run"])
+	}
+}
+
+func TestPRFindings_ReturnsFindingsAndRun(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+
+	pr := &state.PR{
+		Number: 7, Anvil: "anvil-a", BeadID: "Forge-aaaa",
+		Branch: "feature/x", Status: state.PROpen, Title: "Change",
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := srv.db.InsertPR(pr); err != nil {
+		t.Fatalf("insert PR: %v", err)
+	}
+
+	// One Important finding (open) and one Nit finding (posted).
+	if err := srv.db.InsertFinding(state.Finding{
+		Anvil: "anvil-a", PRNumber: 7, HeadSHA: "deadbeef", FindingHash: "h1",
+		File: "a.go", Anchor: "a.go:1", Severity: "Important", Category: "logic",
+		Title: "Bug here", Body: "details",
+	}); err != nil {
+		t.Fatalf("insert finding 1: %v", err)
+	}
+	if err := srv.db.InsertFinding(state.Finding{
+		Anvil: "anvil-a", PRNumber: 7, HeadSHA: "deadbeef", FindingHash: "h2",
+		File: "b.go", Anchor: "b.go:2", Severity: "Nit", Category: "style",
+		Title: "Style nit", Body: "x", Posted: true,
+	}); err != nil {
+		t.Fatalf("insert finding 2: %v", err)
+	}
+
+	finished := time.Now().UTC()
+	if err := srv.db.RecordAssayRun(&state.AssayRun{
+		Anvil: "anvil-a", PRNumber: 7, HeadSHA: "deadbeef",
+		StartedAt: finished.Add(-time.Minute), FinishedAt: &finished,
+		FindingsCount: 2, PostedCount: 1, CostUSD: 0.5,
+	}); err != nil {
+		t.Fatalf("record run: %v", err)
+	}
+
+	cookie := loginAndGetCookie(t, srv)
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/prs/%d/findings", pr.ID), nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp prFindingsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.PR != 7 || resp.Anvil != "anvil-a" {
+		t.Errorf("unexpected pr/anvil: %+v", resp)
+	}
+	if len(resp.Findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d (%+v)", len(resp.Findings), resp.Findings)
+	}
+	// Important sorts before Nit.
+	if resp.Findings[0].Severity != "Important" {
+		t.Errorf("expected Important first, got %q", resp.Findings[0].Severity)
+	}
+	if resp.Findings[0].Status != "open" {
+		t.Errorf("expected open status, got %q", resp.Findings[0].Status)
+	}
+	if resp.Findings[0].Message != "Bug here" {
+		t.Errorf("expected message from title, got %q", resp.Findings[0].Message)
+	}
+	if resp.Findings[1].Status != "posted" {
+		t.Errorf("expected posted status, got %q", resp.Findings[1].Status)
+	}
+	if resp.Run == nil || resp.Run.Status != "complete" {
+		t.Errorf("expected complete run, got %+v", resp.Run)
+	}
+	if resp.Run != nil && resp.Run.HeadSHA != "deadbeef" {
+		t.Errorf("expected run head_sha deadbeef, got %q", resp.Run.HeadSHA)
 	}
 }
 

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -57,6 +57,11 @@ func (s *Server) routes() http.Handler {
 		r.Get("/history/workers", s.handleHistoryWorkers)
 		r.Get("/costs", s.handleCosts)
 		r.Get("/prs/all", s.handlePRs)
+		// Assay findings for one PR, plus a live SSE channel that re-emits the
+		// findings/run snapshot whenever it changes so the PR detail panel
+		// updates without a manual refresh.
+		r.Get("/prs/{id}/findings", s.handlePRFindings)
+		r.Get("/prs/{id}/findings/stream", s.handlePRFindingsStream)
 		r.Get("/bead/{bead_id}", s.handleBeadDetail)
 		r.Get("/bead/{bead_id}/deps", s.handleBeadDeps)
 

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -121,6 +121,75 @@ func (s *Server) handleActivityStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handlePRFindingsStream serves GET /api/prs/{id}/findings/stream as Server-Sent
+// Events. It resolves the PR from state.db, emits the current findings/run
+// snapshot immediately, then polls every 2s and re-emits only when the snapshot
+// changes (findings set or latest run status). Each update is delivered as a
+// named `findings` event whose data payload is a prFindingsResponse — the same
+// shape GET /api/prs/{id}/findings returns — so the frontend can apply it
+// directly. A 30s keep-alive comment keeps the connection warm behind proxies.
+func (s *Server) handlePRFindingsStream(w http.ResponseWriter, r *http.Request) {
+	ctx, ok := s.requirePR(w, r)
+	if !ok {
+		return
+	}
+	anvil := ctx.pr.Anvil
+	prNumber := ctx.pr.Number
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	fmt.Fprint(w, "retry: 3000\n\n")
+	flusher.Flush()
+
+	// lastFingerprint is the JSON of the last snapshot we emitted. Comparing
+	// the marshalled payload lets us suppress no-op ticks (no new findings, no
+	// run-status change) so the client only re-renders on real updates.
+	var lastFingerprint string
+	emit := func() {
+		resp, err := s.collectPRFindings(anvil, prNumber)
+		if err != nil {
+			s.logger.Warn("pr findings stream collect failed", "anvil", anvil, "pr", prNumber, "error", err)
+			return
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return
+		}
+		if string(data) == lastFingerprint {
+			return
+		}
+		lastFingerprint = string(data)
+		fmt.Fprintf(w, "event: findings\ndata: %s\n\n", data)
+		flusher.Flush()
+	}
+	emit()
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	keepalive := time.NewTicker(30 * time.Second)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepalive.C:
+			fmt.Fprint(w, ": keepalive\n\n")
+			flusher.Flush()
+		case <-ticker.C:
+			emit()
+		}
+	}
+}
+
 func toActivityEvent(e state.Event) activityEvent {
 	return activityEvent{
 		ID:        e.ID,

--- a/internal/web/sse_test.go
+++ b/internal/web/sse_test.go
@@ -122,6 +122,59 @@ func TestActivityStream_InitialEvents(t *testing.T) {
 	}
 }
 
+func TestPRFindingsStream_InitialSnapshot(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+
+	pr := &state.PR{
+		Number: 11, Anvil: "anvil-a", BeadID: "Forge-cccc",
+		Branch: "x", Status: state.PROpen, CreatedAt: time.Now().UTC(),
+	}
+	if err := srv.db.InsertPR(pr); err != nil {
+		t.Fatalf("insert PR: %v", err)
+	}
+	if err := srv.db.InsertFinding(state.Finding{
+		Anvil: "anvil-a", PRNumber: 11, FindingHash: "fh1",
+		Severity: "Important", Title: "Important finding",
+	}); err != nil {
+		t.Fatalf("insert finding: %v", err)
+	}
+
+	resp, cancel := authedSSEClient(t, srv, fmt.Sprintf("/api/prs/%d/findings/stream", pr.ID), "")
+	defer cancel()
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Content-Type: got %q want text/event-stream", got)
+	}
+
+	got := readSSEData(t, resp.Body, 1, 5*time.Second)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 snapshot event, got %d (%v)", len(got), got)
+	}
+	var snap prFindingsResponse
+	if err := json.Unmarshal([]byte(got[0]), &snap); err != nil {
+		t.Fatalf("unmarshal snapshot: %v", err)
+	}
+	if snap.PR != 11 || snap.Anvil != "anvil-a" {
+		t.Errorf("unexpected snapshot pr/anvil: %+v", snap)
+	}
+	if len(snap.Findings) != 1 || snap.Findings[0].Message != "Important finding" {
+		t.Errorf("unexpected snapshot findings: %+v", snap.Findings)
+	}
+}
+
+func TestPRFindingsStream_NotFound(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	req := httptest.NewRequest("GET", "/api/prs/12345/findings/stream", nil)
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown PR, got %d", rec.Code)
+	}
+}
+
 func TestActivityStream_LastEventIDSkipsReplay(t *testing.T) {
 	srv := newServerWithDefaults(t, nil)
 


### PR DESCRIPTION
## Changes

- **PR findings API & live SSE channel** - Added `GET /api/prs/{id}/findings`, returning a PR's Assay findings (id, pr, anvil, status, severity, message, timestamp) plus the latest review-run status, and a `GET /api/prs/{id}/findings/stream` Server-Sent Events channel that re-emits the snapshot whenever findings or rerun status change so the PR detail panel updates live. (Forge-3zsv)

## Original Issue (task): Web backend: findings endpoint + SSE update channel

Modify internal/web/router.go, internal/web/prs.go, and internal/web/sse.go. Add a findings GET endpoint (e.g. GET /api/prs/{id}/findings or /api/findings?pr=N) in prs.go that returns Assay findings for a PR, wired into the router in router.go. Add an SSE update channel in sse.go that broadcasts findings/rerun status updates to connected clients so the PR detail panel updates live. Define the findings JSON response shape (id, pr, anvil, status, severity, message, timestamp) so the typed frontend client can mirror it. Depends on sub-tasks 3/4 for the underlying findings data store. This sub-task provides the HTTP/SSE surface the frontend sub-task consumes.

---
Bead: Forge-3zsv | Branch: forge/Forge-3zsv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->