### PR TITLE
IPC + CLI + doctor: assay_rerun command, forge assay run, claude availability check (Forge-rem1)

### DIFF
--- a/changelog.d/Forge-rem1.md
+++ b/changelog.d/Forge-rem1.md
@@ -1,0 +1,3 @@
+category: Added
+- **Assay re-review command** - New `assay_rerun {anvil, pr}` IPC command and `forge assay run --pr N --anvil A` CLI subcommand trigger a fresh Assay AI review over a PR's current head, bypassing the Bellows head-SHA debounce. The web "Re-run" button routes through the same command. (Forge-rem1)
+- **Per-pass Assay doctor check** - `forge doctor` now verifies the `claude` (or configured provider) binary is available for every Assay review pass, reported per-pass. (Forge-rem1)

--- a/cmd/forge/assay.go
+++ b/cmd/forge/assay.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Robin831/Forge/internal/ipc"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	assayRunCmd.Flags().Int("pr", 0, "PR id (state.db primary key) to re-review")
+	assayRunCmd.Flags().StringP("anvil", "a", "", "Anvil the PR belongs to")
+	_ = assayRunCmd.MarkFlagRequired("pr")
+	_ = assayRunCmd.MarkFlagRequired("anvil")
+	assayCmd.AddCommand(assayRunCmd)
+	rootCmd.AddCommand(assayCmd)
+}
+
+var assayCmd = &cobra.Command{
+	Use:     "assay",
+	Short:   "Inspect and trigger Assay AI PR reviews",
+	GroupID: "work",
+}
+
+var assayRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Re-run Assay review over a PR's current head",
+	Long: `Trigger a fresh Assay AI review pass over a PR's current head.
+
+The rerun bypasses the Bellows trigger gate's head-SHA debounce, so it forces a
+review even when the current head has already been reviewed. This is the same
+action the web UI's "Re-run" button invokes via the daemon.`,
+	Example: "  forge assay run --pr 12 --anvil heimdall",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prID, _ := cmd.Flags().GetInt("pr")
+		anvil, _ := cmd.Flags().GetString("anvil")
+
+		client, err := ipc.NewClient()
+		if err != nil {
+			return fmt.Errorf("connecting to daemon: %w (is 'forge up' running?)", err)
+		}
+		defer client.Close()
+
+		payload, _ := json.Marshal(ipc.AssayRerunPayload{
+			Anvil: anvil,
+			PR:    prID,
+		})
+
+		resp, err := client.Send(ipc.Command{
+			Type:    "assay_rerun",
+			Payload: payload,
+		})
+		if err != nil {
+			return fmt.Errorf("sending command: %w", err)
+		}
+
+		if resp.Type == "error" {
+			var msg map[string]string
+			var errMsg string
+			if err := json.Unmarshal(resp.Payload, &msg); err == nil && msg["message"] != "" {
+				errMsg = msg["message"]
+			} else if len(resp.Payload) > 0 {
+				errMsg = string(resp.Payload)
+			} else {
+				errMsg = "unknown error from daemon"
+			}
+			return fmt.Errorf("daemon error: %s", errMsg)
+		}
+
+		var result map[string]string
+		if err := json.Unmarshal(resp.Payload, &result); err != nil {
+			return fmt.Errorf("failed to unmarshal daemon response: %w", err)
+		}
+		if result["message"] != "" {
+			fmt.Println(result["message"])
+		} else {
+			fmt.Printf("Assay re-review started for PR id %d\n", prID)
+		}
+		return nil
+	},
+}

--- a/cmd/forge/doctor.go
+++ b/cmd/forge/doctor.go
@@ -397,7 +397,11 @@ func checkOpenAIAuth(name string) checkResult {
 // binary means that pass cannot run, so it is reported as a failure.
 func checkAssayPasses() []checkResult {
 	if cfg == nil {
-		return nil
+		return []checkResult{{
+			Name:   "Assay passes",
+			Status: "warn",
+			Detail: "no config loaded — assay pass checks skipped",
+		}}
 	}
 	if !cfg.Assay.IsEnabled() {
 		return []checkResult{{

--- a/cmd/forge/doctor.go
+++ b/cmd/forge/doctor.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/Robin831/Forge/internal/assay"
 	"github.com/Robin831/Forge/internal/autostart"
 	"github.com/Robin831/Forge/internal/changelog"
 	"github.com/Robin831/Forge/internal/daemon"
@@ -75,6 +76,9 @@ var doctorCmd = &cobra.Command{
 
 		// 4. Check claude installed
 		checks = append(checks, checkBinary("claude", "Claude CLI"))
+
+		// 4a. Check claude (or configured provider) availability per Assay pass
+		checks = append(checks, checkAssayPasses()...)
 
 		// 5. Check provider chain CLIs and auth
 		checks = append(checks, checkProviderChain()...)
@@ -384,6 +388,52 @@ func checkOpenAIAuth(name string) checkResult {
 		Status: "warn",
 		Detail: "OPENAI_API_KEY is not set — OpenAI provider requires authentication",
 	}
+}
+
+// checkAssayPasses verifies the CLI binary backing each Assay review pass is
+// available in PATH, reported per-pass. Assay runs a cheap triage scoping pass
+// plus five deep finding passes; each resolves to a provider (the Claude CLI by
+// default, or whatever triage_provider/review_provider configure). A missing
+// binary means that pass cannot run, so it is reported as a failure.
+func checkAssayPasses() []checkResult {
+	if cfg == nil {
+		return nil
+	}
+	if !cfg.Assay.IsEnabled() {
+		return []checkResult{{
+			Name:   "Assay passes",
+			Status: "ok",
+			Detail: "assay disabled — set assay.enabled to review PRs",
+		}}
+	}
+
+	engineCfg := assay.FromAssayConfig(cfg.Assay)
+	var results []checkResult
+	for _, pp := range assay.PassProviders(engineCfg) {
+		name := "Assay pass (" + pp.Pass + ")"
+		bin := pp.Provider.Cmd()
+		path, err := execLookPath(bin)
+		if err != nil {
+			results = append(results, checkResult{
+				Name:   name,
+				Status: "fail",
+				Detail: fmt.Sprintf("%s not found in PATH (provider %s)", bin, pp.Provider.Label()),
+			})
+			continue
+		}
+		// Probe the binary's version for richer detail; fall back to the
+		// resolved path when the probe fails (binary present is enough to pass).
+		detail := fmt.Sprintf("%s (%s)", path, pp.Provider.Label())
+		if out, verr := execRunCommand(path, "--version"); verr == nil {
+			detail = fmt.Sprintf("%s (%s)", strings.TrimSpace(string(out)), pp.Provider.Label())
+		}
+		results = append(results, checkResult{
+			Name:   name,
+			Status: "ok",
+			Detail: detail,
+		})
+	}
+	return results
 }
 
 func checkBinary(name, description string) checkResult {

--- a/cmd/forge/doctor_test.go
+++ b/cmd/forge/doctor_test.go
@@ -556,3 +556,95 @@ func TestCheckProviderChain_NilConfig(t *testing.T) {
 		t.Errorf("expected warn when cfg is nil, got %q", results[0].Status)
 	}
 }
+
+// --- Assay pass doctor check tests ---
+
+func TestCheckAssayPasses_NilConfig(t *testing.T) {
+	origCfg := cfg
+	cfg = nil
+	defer func() { cfg = origCfg }()
+
+	results := checkAssayPasses()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result when cfg is nil, got %d", len(results))
+	}
+	if results[0].Status != "warn" {
+		t.Errorf("expected warn when cfg is nil, got %q", results[0].Status)
+	}
+}
+
+func TestCheckAssayPasses_Disabled(t *testing.T) {
+	origCfg := cfg
+	cfg = &config.Config{}
+	defer func() { cfg = origCfg }()
+
+	results := checkAssayPasses()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result when assay disabled, got %d", len(results))
+	}
+	if results[0].Status != "ok" {
+		t.Errorf("expected ok when assay disabled, got %q", results[0].Status)
+	}
+	if !strings.Contains(results[0].Detail, "disabled") {
+		t.Errorf("expected detail to mention disabled, got %q", results[0].Detail)
+	}
+}
+
+func TestCheckAssayPasses_EnabledBinaryFound(t *testing.T) {
+	enabled := true
+	origCfg := cfg
+	cfg = &config.Config{
+		Assay: config.AssayConfig{Enabled: &enabled},
+	}
+	defer func() { cfg = origCfg }()
+
+	mockExec(t,
+		func(file string) (string, error) {
+			return "/usr/local/bin/" + file, nil
+		},
+		func(name string, args ...string) ([]byte, error) {
+			return []byte("claude 1.2.3"), nil
+		},
+	)
+
+	results := checkAssayPasses()
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for enabled assay")
+	}
+	for _, r := range results {
+		if r.Status != "ok" {
+			t.Errorf("expected ok for %q, got %q: %s", r.Name, r.Status, r.Detail)
+		}
+		if !strings.Contains(r.Name, "Assay pass") {
+			t.Errorf("expected name to contain 'Assay pass', got %q", r.Name)
+		}
+	}
+}
+
+func TestCheckAssayPasses_EnabledBinaryMissing(t *testing.T) {
+	enabled := true
+	origCfg := cfg
+	cfg = &config.Config{
+		Assay: config.AssayConfig{Enabled: &enabled},
+	}
+	defer func() { cfg = origCfg }()
+
+	mockExec(t,
+		func(file string) (string, error) {
+			return "", errors.New("not found")
+		},
+		func(name string, args ...string) ([]byte, error) {
+			return nil, errors.New("not found")
+		},
+	)
+
+	results := checkAssayPasses()
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for enabled assay")
+	}
+	for _, r := range results {
+		if r.Status != "fail" {
+			t.Errorf("expected fail for %q when binary missing, got %q: %s", r.Name, r.Status, r.Detail)
+		}
+	}
+}

--- a/internal/assay/passes.go
+++ b/internal/assay/passes.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/Robin831/Forge/internal/provider"
 	"github.com/Robin831/Forge/internal/smith"
 )
 
@@ -50,6 +51,30 @@ var deepPasses = []passDef{
 	{Name: "conventions", Tier: tierReview, promptFile: "conventions"},
 	{Name: "tests-missing", Tier: tierReview, promptFile: "tests_missing"},
 	{Name: "repo-specific", Tier: tierReview, promptFile: "repo_specific"},
+}
+
+// PassProvider names a single Assay pass and the resolved provider that runs
+// it. doctor uses this to verify each pass's CLI binary (typically `claude`)
+// is available before a review is attempted.
+type PassProvider struct {
+	// Pass is the pass identifier ("triage", "logic", "security", …).
+	Pass string
+	// Provider is the resolved provider (Kind/Cmd/Model) for the pass, derived
+	// from the Config's per-tier provider/model hints.
+	Provider provider.Provider
+}
+
+// PassProviders returns the resolved provider for every Assay pass — the cheap
+// triage scoping pass plus the five deep finding passes — given a Config. The
+// concrete provider for each pass comes entirely from the Config's tier hints
+// (never a hard-coded model); an empty hint resolves to the Claude provider.
+func PassProviders(c Config) []PassProvider {
+	out := make([]PassProvider, 0, 1+len(deepPasses))
+	out = append(out, PassProvider{Pass: passTriage.Name, Provider: c.providerFor(passTriage.Tier)})
+	for _, p := range deepPasses {
+		out = append(out, PassProvider{Pass: p.Name, Provider: c.providerFor(p.Tier)})
+	}
+	return out
 }
 
 // PassOutput is the raw result of a single model invocation.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4497,6 +4497,68 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		data, _ := json.Marshal(map[string]string{"message": "warden re-review started"})
 		return ipc.Response{Type: "ok", Payload: data}
 
+	case "assay_rerun":
+		var arp ipc.AssayRerunPayload
+		if err := json.Unmarshal(cmd.Payload, &arp); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": "invalid assay_rerun payload: " + err.Error()})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if arp.Anvil == "" || arp.PR == 0 {
+			msg, _ := json.Marshal(map[string]string{"message": "assay_rerun requires anvil and pr"})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		anvilCfg, ok := d.cfg.Load().Anvils[arp.Anvil]
+		if !ok {
+			msg, _ := json.Marshal(map[string]string{"message": "unknown anvil: " + arp.Anvil})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		pr, err := d.db.GetPRByID(arp.PR)
+		if err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("failed to look up PR id %d: %v", arp.PR, err)})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if pr == nil {
+			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("PR id %d not found", arp.PR)})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if pr.Anvil != arp.Anvil {
+			msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("PR id %d belongs to anvil %q, not %q", arp.PR, pr.Anvil, arp.Anvil)})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		_ = d.db.LogEvent(state.EventPRReviewNeeded, fmt.Sprintf("Assay re-review requested for PR #%d (manual)", pr.Number), pr.BeadID, arp.Anvil)
+		d.logger.Info("Assay re-review requested", "pr", pr.Number, "anvil", arp.Anvil, "bead", pr.BeadID)
+
+		d.wg.Add(1)
+		go func() {
+			defer d.wg.Done()
+			// Resolve the current head SHA so the run records against the head
+			// actually reviewed. A manual rerun deliberately bypasses the
+			// Bellows trigger gate's head-SHA debounce, so the stored
+			// LastReviewedSHA may already equal head — dispatching
+			// ActionAssayReview directly forces the pass regardless.
+			headSHA := ""
+			statusCtx, cancel := context.WithTimeout(d.runCtx, 30*time.Second)
+			if st, serr := d.vcsForAnvil(arp.Anvil).CheckStatusLight(statusCtx, anvilCfg.Path, pr.Number); serr == nil && st != nil {
+				headSHA = st.HeadSHA
+			} else if serr != nil {
+				d.logger.Warn("assay rerun: failed to resolve PR head SHA; recording run without it", "pr", pr.Number, "anvil", arp.Anvil, "error", serr)
+			}
+			cancel()
+			d.handleLifecycleAction(d.runCtx, lifecycle.ActionRequest{
+				Action:     lifecycle.ActionAssayReview,
+				PRNumber:   pr.Number,
+				BeadID:     pr.BeadID,
+				Anvil:      arp.Anvil,
+				Branch:     pr.Branch,
+				BaseBranch: pr.BaseBranch,
+				HeadSHA:    headSHA,
+				IsManual:   true,
+			})
+		}()
+
+		data, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("Assay re-review started for PR #%d", pr.Number)})
+		return ipc.Response{Type: "ok", Payload: data}
+
 	case "approve_as_is":
 		var ap ipc.ApproveAsIsPayload
 		if err := json.Unmarshal(cmd.Payload, &ap); err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2957,6 +2957,120 @@ func TestHandleIPC_WardenRerun(t *testing.T) {
 	})
 }
 
+// TestHandleIPC_AssayRerun verifies the assay_rerun IPC handler validates
+// payloads, checks anvil config, looks up the PR from the DB, and verifies
+// anvil ownership.
+func TestHandleIPC_AssayRerun(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "state.db")
+	db, err := state.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	d := &Daemon{
+		db:            db,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		worktreeMgr:   worktree.NewManager(),
+		promptBuilder: prompt.NewBuilder(),
+		runCtx:        context.Background(),
+	}
+	d.cfg.Store(&config.Config{
+		Anvils: map[string]config.AnvilConfig{
+			"test-anvil": {Path: tmpDir},
+		},
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		resp := d.handleIPC(ipc.Command{Type: "assay_rerun", Payload: []byte("invalid")})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "invalid assay_rerun payload")
+	})
+
+	t.Run("missing fields", func(t *testing.T) {
+		payload, _ := json.Marshal(ipc.AssayRerunPayload{Anvil: "test-anvil"})
+		resp := d.handleIPC(ipc.Command{Type: "assay_rerun", Payload: payload})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "requires anvil and pr")
+	})
+
+	t.Run("unknown anvil", func(t *testing.T) {
+		payload, _ := json.Marshal(ipc.AssayRerunPayload{Anvil: "nope", PR: 1})
+		resp := d.handleIPC(ipc.Command{Type: "assay_rerun", Payload: payload})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "unknown anvil")
+	})
+
+	t.Run("missing PR id", func(t *testing.T) {
+		payload, _ := json.Marshal(ipc.AssayRerunPayload{Anvil: "test-anvil", PR: 999})
+		resp := d.handleIPC(ipc.Command{Type: "assay_rerun", Payload: payload})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "not found")
+	})
+
+	t.Run("anvil mismatch", func(t *testing.T) {
+		require.NoError(t, db.InsertPR(&state.PR{
+			Number: 42, Anvil: "other-anvil", BeadID: "BD-MM",
+			Branch: "b", Status: state.PROpen, CreatedAt: time.Now(),
+		}))
+		pr, err := db.GetPRByNumber("other-anvil", 42)
+		require.NoError(t, err)
+
+		payload, _ := json.Marshal(ipc.AssayRerunPayload{Anvil: "test-anvil", PR: pr.ID})
+		resp := d.handleIPC(ipc.Command{Type: "assay_rerun", Payload: payload})
+		assert.Equal(t, "error", resp.Type)
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "belongs to anvil")
+	})
+
+	t.Run("success starts background goroutine", func(t *testing.T) {
+		require.NoError(t, db.InsertPR(&state.PR{
+			Number: 77, Anvil: "test-anvil", BeadID: "BD-ASSAY",
+			Branch: "forge/BD-ASSAY", Status: state.PROpen, CreatedAt: time.Now(),
+		}))
+		pr, err := db.GetPRByNumber("test-anvil", 77)
+		require.NoError(t, err)
+
+		payload, _ := json.Marshal(ipc.AssayRerunPayload{Anvil: "test-anvil", PR: pr.ID})
+		resp := d.handleIPC(ipc.Command{Type: "assay_rerun", Payload: payload})
+		assert.Equal(t, "ok", resp.Type)
+
+		var msg map[string]string
+		_ = json.Unmarshal(resp.Payload, &msg)
+		assert.Contains(t, msg["message"], "Assay re-review started")
+
+		done := make(chan struct{})
+		go func() { d.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for background goroutine")
+		}
+
+		events, err := db.RecentEvents(20)
+		require.NoError(t, err)
+		found := false
+		for _, ev := range events {
+			if ev.Type == state.EventPRReviewNeeded && ev.BeadID == "BD-ASSAY" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "assay_rerun event should be logged")
+	})
+}
+
 // TestHandleIPC_ApproveAsIs verifies the approve_as_is IPC handler validates
 // payloads, checks anvil config, and dispatches a background goroutine.
 func TestHandleIPC_ApproveAsIs(t *testing.T) {

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -31,7 +31,7 @@ import (
 
 // Command is a message sent from a client to the daemon.
 type Command struct {
-	Type    string          `json:"type"`    // "status", "kill_worker", "refresh", "queue", "run_bead", "set_clarification", "clear_clarification"
+	Type    string          `json:"type"`    // "status", "kill_worker", "refresh", "queue", "run_bead", "set_clarification", "clear_clarification", "assay_rerun"
 	Payload json.RawMessage `json:"payload"` // Type-specific data
 	// ReadTimeout is an optional client-side timeout for reading the response.
 	// Zero uses DefaultReadTimeout. Long-running commands that go through bd or
@@ -268,6 +268,18 @@ type PRActionPayload struct {
 type WardenRerunPayload struct {
 	BeadID string `json:"bead_id"`
 	Anvil  string `json:"anvil"`
+}
+
+// AssayRerunPayload is the payload for an "assay_rerun" command.
+// Triggers a fresh Assay AI review pass over a PR's current head, bypassing the
+// Bellows trigger gate's head-SHA debounce. PR is the state.db PR id (matching
+// the {pr} path parameter the web rerun endpoint forwards, and the `pr` field
+// the api.ts client posts); Anvil resolves the worktree/config for the
+// re-review. The field shape mirrors api.ts RerunAssayParams so the web backend
+// can forward the request without translation.
+type AssayRerunPayload struct {
+	Anvil string `json:"anvil"`
+	PR    int    `json:"pr"`
 }
 
 // ApproveAsIsPayload is the payload for an "approve_as_is" command.

--- a/internal/web/pr_actions.go
+++ b/internal/web/pr_actions.go
@@ -178,3 +178,19 @@ func (s *Server) handlePRResetCounters(w http.ResponseWriter, r *http.Request) {
 		PRID:   ctx.prID,
 	})
 }
+
+// handlePRRerunAssay handles POST /api/prs/{id}/rerun-assay — triggers a
+// fresh Assay AI review pass over the PR's current head, bypassing the
+// Bellows trigger gate's head-SHA debounce. The request body must contain
+// {"anvil": "<name>"} to identify the anvil configuration.
+func (s *Server) handlePRRerunAssay(w http.ResponseWriter, r *http.Request) {
+	ctx, ok := s.requirePR(w, r)
+	if !ok {
+		return
+	}
+	s.logActor(r, "assay_rerun", "pr", ctx.pr.Number, "anvil", ctx.pr.Anvil)
+	s.dispatchAction(w, "assay_rerun", ipc.AssayRerunPayload{
+		Anvil: ctx.pr.Anvil,
+		PR:    ctx.prID,
+	})
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -92,6 +92,7 @@ func (s *Server) routes() http.Handler {
 		r.Post("/prs/{id}/fix-comments", s.handlePRFixComments)
 		r.Post("/prs/{id}/fix-conflicts", s.handlePRFixConflicts)
 		r.Post("/prs/{id}/reset-counters", s.handlePRResetCounters)
+		r.Post("/prs/{id}/rerun-assay", s.handlePRRerunAssay)
 
 		// Beads-Forge sessions (Hearth 2.0). Sessions are scoped per
 		// signed-in user. The /turn endpoint drives the AI loop —


### PR DESCRIPTION
## Changes

- **Assay re-review command** - New `assay_rerun {anvil, pr}` IPC command and `forge assay run --pr N --anvil A` CLI subcommand trigger a fresh Assay AI review over a PR's current head, bypassing the Bellows head-SHA debounce. The web "Re-run" button routes through the same command. (Forge-rem1)
- **Per-pass Assay doctor check** - `forge doctor` now verifies the `claude` (or configured provider) binary is available for every Assay review pass, reported per-pass. (Forge-rem1)

## Original Issue (task): IPC + CLI + doctor: assay_rerun command, forge assay run, claude availability check

Add an assay_rerun {anvil, pr} command handler to internal/ipc/ipc.go (register the command, parse anvil+pr args, trigger the rerun path from sub-tasks 3/4). Add optional CLI subcommand `forge assay run --pr N --anvil A` in cmd/forge/main.go that dispatches the same IPC command. Add a `forge doctor` check verifying `claude` binary availability across all passes (exec.LookPath or version probe, reported per-pass). The web-backend rerun endpoint and frontend Re-run button ultimately invoke this IPC command, so keep the command name/payload consistent with the api.ts client.

---
Bead: Forge-rem1 | Branch: forge/Forge-rem1
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->