### PR TITLE
Cap concurrent lifecycle (burnish/quench/rebase) workers — unbounded, crashed the server (Forge-3m06)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ settings:
   max_ci_fix_attempts: 5       # CI fix cycles per PR (default 5)
   max_review_fix_attempts: 5   # Review fix cycles per PR (default 5)
   max_rebase_attempts: 3       # Conflict rebase attempts per PR (default 3)
+  max_lifecycle_workers: 2     # Concurrent quench/burnish/rebase/assay fix workers (default 2)
   daily_cost_limit: 50.00      # USD per day; 0 = no limit
   copilot_daily_request_limit: 300  # 300 for Pro, 1500 for Pro+; 0 = no limit
   bellows_interval: 2m         # PR monitor poll interval

--- a/changelog.d/Forge-3m06.md
+++ b/changelog.d/Forge-3m06.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Cap concurrent lifecycle fix workers** - Bellows fix workers (quench/cifix, burnish/reviewfix, rebase, assay) are now bounded by a global `max_lifecycle_workers` concurrency cap (default 2) instead of fanning out unbounded. Each fix worker spawns its own Claude session and was deliberately excluded from `max_total_smiths`, so a burst of stuck PRs could previously spawn one Claude session per PR and OOM-crash the host. Actions over the cap are deferred and retried on the next Bellows poll. (Forge-3m06)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ settings:
   max_ci_fix_attempts: 5
   max_review_fix_attempts: 5
   max_rebase_attempts: 3
+  max_lifecycle_workers: 2          # Concurrent quench/burnish/rebase/assay fix workers
   merge_strategy: squash
   daily_cost_limit: 50.00
   copilot_daily_request_limit: 300  # 300 for Pro, 1500 for Pro+
@@ -479,6 +480,7 @@ anvils:
 | `max_ci_fix_attempts` | int | `5` | `1` | Maximum CI fix cycles per PR before marking as exhausted. |
 | `max_review_fix_attempts` | int | `5` | `1` | Maximum review fix cycles per PR before marking as exhausted. |
 | `max_rebase_attempts` | int | `3` | `1` | Maximum conflict rebase attempts per PR before marking as exhausted. |
+| `max_lifecycle_workers` | int | `2` | `0` (use default) | Global cap on concurrent lifecycle/bellows fix workers (quench/cifix, burnish/reviewfix, rebase, assay) across all PRs and anvils. Each fix worker spawns its own Claude session and is **not** counted against `max_total_smiths`, so this independent ceiling prevents a burst of stuck PRs from fanning out unbounded Claude sessions and OOM-crashing the host. `0` or unset falls back to the default of `2`. |
 | `merge_strategy` | string | `"squash"` | | How PRs are merged from Hearth TUI. Valid: `squash`, `merge`, `rebase`. |
 | `stale_interval` | duration | `5m` | `30s` or `0` | How long a worker's log can go without modification before marking as stalled. `0` disables stale detection. |
 | `go_race_detection` | bool | `false` | | Enable the `-race` flag for Go tests in Temper globally. Per-anvil `go_race_detection` overrides this. |
@@ -729,6 +731,7 @@ Environment variables with the `FORGE_` prefix override YAML values. Nested keys
 | `FORGE_SETTINGS_MAX_CI_FIX_ATTEMPTS` | `settings.max_ci_fix_attempts` |
 | `FORGE_SETTINGS_MAX_REVIEW_FIX_ATTEMPTS` | `settings.max_review_fix_attempts` |
 | `FORGE_SETTINGS_MAX_REBASE_ATTEMPTS` | `settings.max_rebase_attempts` |
+| `FORGE_SETTINGS_MAX_LIFECYCLE_WORKERS` | `settings.max_lifecycle_workers` |
 | `FORGE_SETTINGS_MERGE_STRATEGY` | `settings.merge_strategy` |
 | `FORGE_SETTINGS_STALE_INTERVAL` | `settings.stale_interval` |
 | `FORGE_SETTINGS_DEPCHECK_INTERVAL` | `settings.depcheck_interval` |
@@ -770,6 +773,7 @@ The config is validated at load time. Errors are reported as a list:
 - `max_ci_fix_attempts` must be >= 1
 - `max_review_fix_attempts` must be >= 1
 - `max_rebase_attempts` must be >= 1
+- `max_lifecycle_workers` must not be negative (omit or set to 0 to use the default)
 - `poll_interval` must be >= 10s
 - `smith_timeout` must be >= 1m
 - `bellows_interval` must be >= 30s
@@ -793,6 +797,7 @@ The daemon watches `forge.yaml` via fsnotify. When the file changes, **only a su
 - `poll_interval` is re-read and the new value takes effect on the next cycle
 - `smith_timeout` is re-read and used for newly started smiths
 - `max_total_smiths` is re-read and applied to subsequent scheduling decisions
+- `max_lifecycle_workers` is re-read and applied to subsequent lifecycle fix-worker dispatches
 - `claude_flags` are re-read and used for newly started smiths
 - `smith_providers` and `stage_providers` are re-read and used for newly dispatched beads
 - `copilot_combined_smith_warden` toggles combined Smith+Warden mode at runtime

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -315,6 +315,15 @@ type SettingsConfig struct {
 	// MaxRebaseAttempts is the maximum number of conflict rebase attempts per
 	// PR before the PR is considered exhausted. Default: 3.
 	MaxRebaseAttempts int `mapstructure:"max_rebase_attempts" yaml:"max_rebase_attempts"`
+	// MaxLifecycleWorkers caps how many lifecycle/bellows fix workers
+	// (quench/cifix, burnish/reviewfix, rebase, assay) may run concurrently
+	// across all PRs and anvils. Each fix worker spawns its own Claude session
+	// of comparable length to a Smith, and they are deliberately excluded from
+	// the max_total_smiths dispatch cap (see state.ActiveDispatchWorkers), so
+	// without their own ceiling a burst of stuck PRs can fan out unbounded
+	// Claude sessions and OOM the host (Forge-3m06). A value <= 0 falls back to
+	// DefaultMaxLifecycleWorkers. Default: 2.
+	MaxLifecycleWorkers int `mapstructure:"max_lifecycle_workers" yaml:"max_lifecycle_workers"`
 	// MergeStrategy controls how PRs are merged from the Hearth TUI.
 	// Valid values: "squash" (default), "merge", "rebase".
 	MergeStrategy string `mapstructure:"merge_strategy" yaml:"merge_strategy,omitempty"`
@@ -477,6 +486,13 @@ type SettingsConfig struct {
 	// per-turn budget without recompiling.
 	ForgeChat ForgeChatSettings `mapstructure:"forgechat" yaml:"forgechat,omitempty"`
 }
+
+// DefaultMaxLifecycleWorkers is the fallback concurrency cap for lifecycle/bellows
+// fix workers (quench/burnish/rebase/assay) when settings.max_lifecycle_workers is
+// unset or <= 0. Kept deliberately small because each lifecycle worker spawns its
+// own Claude session and they are not counted against the max_total_smiths dispatch
+// cap; an unbounded fan-out previously OOM-crashed the host (Forge-3m06).
+const DefaultMaxLifecycleWorkers = 2
 
 // MaxForgeChatTurnTimeout is the hard upper bound for settings.forgechat.turn_timeout.
 // Values above this are clamped on load and a warning is logged. Picked so that
@@ -642,6 +658,7 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		MaxCIFixAttempts          int      `yaml:"max_ci_fix_attempts"`
 		MaxReviewFixAttempts      int      `yaml:"max_review_fix_attempts"`
 		MaxRebaseAttempts         int      `yaml:"max_rebase_attempts"`
+		MaxLifecycleWorkers       int      `yaml:"max_lifecycle_workers"`
 		BurnishVerifyTimeout      string   `yaml:"burnish_verify_timeout,omitempty"`
 		MergeStrategy             string   `yaml:"merge_strategy,omitempty"`
 		StaleInterval             string   `yaml:"stale_interval"`
@@ -704,6 +721,7 @@ func (s SettingsConfig) MarshalYAML() (interface{}, error) {
 		MaxCIFixAttempts:          s.MaxCIFixAttempts,
 		MaxReviewFixAttempts:      s.MaxReviewFixAttempts,
 		MaxRebaseAttempts:         s.MaxRebaseAttempts,
+		MaxLifecycleWorkers:       s.MaxLifecycleWorkers,
 		BurnishVerifyTimeout:      func() string {
 			if s.BurnishVerifyTimeout > 0 {
 				return durationString(s.BurnishVerifyTimeout)
@@ -1113,6 +1131,7 @@ func Defaults() Config {
 			MaxCIFixAttempts:     5,
 			MaxReviewFixAttempts: 5,
 			MaxRebaseAttempts:    3,
+			MaxLifecycleWorkers:  DefaultMaxLifecycleWorkers,
 			BurnishVerifyTimeout: 5 * time.Minute,
 			StaleInterval:        5 * time.Minute,
 			DepcheckInterval:     168 * time.Hour, // weekly
@@ -1193,6 +1212,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetDefault("settings.max_ci_fix_attempts", 5)
 	v.SetDefault("settings.max_review_fix_attempts", 5)
 	v.SetDefault("settings.max_rebase_attempts", 3)
+	v.SetDefault("settings.max_lifecycle_workers", DefaultMaxLifecycleWorkers)
 	v.SetDefault("settings.burnish_verify_timeout", "5m")
 	v.SetDefault("settings.stale_interval", "5m")
 	v.SetDefault("settings.depcheck_interval", "168h")
@@ -1472,6 +1492,9 @@ func (c *Config) Validate() []string {
 	}
 	if c.Settings.MaxRebaseAttempts < 1 {
 		errs = append(errs, "settings.max_rebase_attempts must be >= 1")
+	}
+	if c.Settings.MaxLifecycleWorkers < 0 {
+		errs = append(errs, "settings.max_lifecycle_workers must not be negative (omit or set to 0 to use the default)")
 	}
 	if c.Settings.BurnishVerifyTimeout < 0 {
 		errs = append(errs, "settings.burnish_verify_timeout must not be negative (omit or set to 0 to use the package default)")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,6 +193,7 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, 5, cfg.Settings.MaxCIFixAttempts)
 	assert.Equal(t, 5, cfg.Settings.MaxReviewFixAttempts)
 	assert.Equal(t, 3, cfg.Settings.MaxRebaseAttempts)
+	assert.Equal(t, DefaultMaxLifecycleWorkers, cfg.Settings.MaxLifecycleWorkers)
 	assert.NotNil(t, cfg.Anvils)
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -140,12 +140,13 @@ type Daemon struct {
 
 	// lifecycleActive counts the lifecycle/bellows fix workers
 	// (quench/burnish/rebase/assay) currently running a Claude session. Gated by
-	// reserveLifecycleSlot against settings.max_lifecycle_workers so a burst of
+	// waitForLifecycleSlot against settings.max_lifecycle_workers so a burst of
 	// stuck PRs cannot fan out unbounded Claude sessions and OOM the host
 	// (Forge-3m06). These workers are deliberately excluded from the
 	// max_total_smiths dispatch cap (see state.ActiveDispatchWorkers), so they
 	// need this independent ceiling.
 	lifecycleActive atomic.Int64
+	lifecycleCond   *sync.Cond
 
 	// PR Monitoring (Bellows)
 	bellowsMonitor  bellowsMonitorIface
@@ -371,6 +372,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 		lastPollMap:           make(map[string]anvilPollSnapshot),
 		queueTimestamps:       make(map[string]queueTimestamp),
 	}
+	d.lifecycleCond = sync.NewCond(&sync.Mutex{})
 	d.notifier.Store(notifier)
 	d.dispatcher.Store(dispatcher)
 	// Wire up the crucible-active check so orphan recovery skips parent beads
@@ -1287,30 +1289,18 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 		// sessions and OOM-crashed the host (Forge-3m06). The light-weight
 		// no-worktree actions (CloseBead/Cleanup) already returned above and are
 		// intentionally not gated.
+		//
+		// We block until a slot becomes available (or ctx is cancelled) so the
+		// originally-dispatched attempt runs and per-PR retry counters reflect
+		// real work, rather than deferring and re-dispatching which can burn
+		// through attempt limits without ever running a fix worker.
 		maxLifecycle := d.cfg.Load().Settings.MaxLifecycleWorkers
-		if !d.reserveLifecycleSlot(maxLifecycle) {
-			d.logger.Warn("lifecycle worker capacity reached, deferring action",
+		if !d.waitForLifecycleSlot(ctx, maxLifecycle) {
+			d.logger.Warn("lifecycle slot wait cancelled",
 				"action", req.Action,
 				"pr", req.PRNumber,
 				"bead", req.BeadID,
-				"active", d.lifecycleActive.Load(),
-				"limit", effectiveMaxLifecycleWorkers(maxLifecycle),
 			)
-			// Reset lifecycle + bellows state so the next Bellows poll re-emits
-			// this event and the action is retried once a slot frees. Mirrors the
-			// worktree-create failure path below; runaway is still bounded by the
-			// per-PR attempt counters (CIFixCount/ReviewFixCnt/RebaseCount).
-			switch req.Action {
-			case lifecycle.ActionRebase:
-				d.lifecycleMgr.NotifyRebaseCompleted(req.Anvil, req.PRNumber)
-			case lifecycle.ActionFixCI:
-				d.lifecycleMgr.NotifyCIFixCompleted(req.Anvil, req.PRNumber)
-			case lifecycle.ActionFixReview:
-				d.lifecycleMgr.NotifyReviewFixCompleted(req.Anvil, req.PRNumber)
-			}
-			if d.bellowsMonitor != nil {
-				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
-			}
 			return
 		}
 		defer d.releaseLifecycleSlot()
@@ -2006,13 +1996,9 @@ func effectiveMaxLifecycleWorkers(limit int) int {
 	return limit
 }
 
-// reserveLifecycleSlot atomically reserves a concurrency slot for a lifecycle fix
-// worker (quench/burnish/rebase/assay). It returns true if a slot was acquired —
-// in which case the caller MUST call releaseLifecycleSlot exactly once when the
-// worker finishes (use defer) — or false if the effective max_lifecycle_workers
-// limit is already reached. The compare-and-swap loop makes the check-and-reserve
-// atomic so concurrent handler goroutines (Bellows-triggered and manual) cannot
-// over-subscribe the cap.
+// reserveLifecycleSlot atomically tries to reserve a concurrency slot for a
+// lifecycle fix worker. Returns true if a slot was acquired (caller MUST call
+// releaseLifecycleSlot exactly once), false if the cap is reached.
 func (d *Daemon) reserveLifecycleSlot(limit int) bool {
 	maxSlots := int64(effectiveMaxLifecycleWorkers(limit))
 	for {
@@ -2026,9 +2012,51 @@ func (d *Daemon) reserveLifecycleSlot(limit int) bool {
 	}
 }
 
-// releaseLifecycleSlot frees a slot previously reserved by reserveLifecycleSlot.
+// waitForLifecycleSlot blocks until a lifecycle concurrency slot is available or
+// ctx is cancelled. Returns true if a slot was acquired (caller MUST call
+// releaseLifecycleSlot), false if the context was cancelled before a slot freed.
+func (d *Daemon) waitForLifecycleSlot(ctx context.Context, limit int) bool {
+	if d.reserveLifecycleSlot(limit) {
+		return true
+	}
+
+	d.logger.Info("waiting for lifecycle slot",
+		"active", d.lifecycleActive.Load(),
+		"limit", effectiveMaxLifecycleWorkers(limit),
+	)
+
+	// Bridge ctx cancellation into the Cond so Wait() unblocks.
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			d.lifecycleCond.Broadcast()
+		case <-done:
+		}
+	}()
+	defer close(done)
+
+	d.lifecycleCond.L.Lock()
+	defer d.lifecycleCond.L.Unlock()
+	for {
+		if ctx.Err() != nil {
+			return false
+		}
+		if d.reserveLifecycleSlot(limit) {
+			return true
+		}
+		d.lifecycleCond.Wait()
+	}
+}
+
+// releaseLifecycleSlot frees a slot previously reserved by
+// reserveLifecycleSlot/waitForLifecycleSlot and wakes any goroutines waiting
+// for a slot.
 func (d *Daemon) releaseLifecycleSlot() {
 	d.lifecycleActive.Add(-1)
+	if d.lifecycleCond != nil {
+		d.lifecycleCond.Broadcast()
+	}
 }
 
 // runStaleDetection periodically checks active workers for stale log files.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -138,6 +138,15 @@ type Daemon struct {
 	worktreeMgr    *worktree.Manager
 	promptBuilder  *prompt.Builder
 
+	// lifecycleActive counts the lifecycle/bellows fix workers
+	// (quench/burnish/rebase/assay) currently running a Claude session. Gated by
+	// reserveLifecycleSlot against settings.max_lifecycle_workers so a burst of
+	// stuck PRs cannot fan out unbounded Claude sessions and OOM the host
+	// (Forge-3m06). These workers are deliberately excluded from the
+	// max_total_smiths dispatch cap (see state.ActiveDispatchWorkers), so they
+	// need this independent ceiling.
+	lifecycleActive atomic.Int64
+
 	// PR Monitoring (Bellows)
 	bellowsMonitor  bellowsMonitorIface
 	lifecycleMgr    *lifecycle.Manager
@@ -1270,6 +1279,42 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 			return
 		}
 
+		// Gate the expensive fix workers (quench/burnish/rebase/assay) behind a
+		// global concurrency cap. Each spawns a Claude session of comparable
+		// length to a Smith, yet they are deliberately excluded from the
+		// max_total_smiths dispatch cap (see state.ActiveDispatchWorkers). Without
+		// their own ceiling a burst of stuck PRs fans out unbounded Claude
+		// sessions and OOM-crashed the host (Forge-3m06). The light-weight
+		// no-worktree actions (CloseBead/Cleanup) already returned above and are
+		// intentionally not gated.
+		maxLifecycle := d.cfg.Load().Settings.MaxLifecycleWorkers
+		if !d.reserveLifecycleSlot(maxLifecycle) {
+			d.logger.Warn("lifecycle worker capacity reached, deferring action",
+				"action", req.Action,
+				"pr", req.PRNumber,
+				"bead", req.BeadID,
+				"active", d.lifecycleActive.Load(),
+				"limit", effectiveMaxLifecycleWorkers(maxLifecycle),
+			)
+			// Reset lifecycle + bellows state so the next Bellows poll re-emits
+			// this event and the action is retried once a slot frees. Mirrors the
+			// worktree-create failure path below; runaway is still bounded by the
+			// per-PR attempt counters (CIFixCount/ReviewFixCnt/RebaseCount).
+			switch req.Action {
+			case lifecycle.ActionRebase:
+				d.lifecycleMgr.NotifyRebaseCompleted(req.Anvil, req.PRNumber)
+			case lifecycle.ActionFixCI:
+				d.lifecycleMgr.NotifyCIFixCompleted(req.Anvil, req.PRNumber)
+			case lifecycle.ActionFixReview:
+				d.lifecycleMgr.NotifyReviewFixCompleted(req.Anvil, req.PRNumber)
+			}
+			if d.bellowsMonitor != nil {
+				d.bellowsMonitor.ResetPRState(req.Anvil, req.PRNumber)
+			}
+			return
+		}
+		defer d.releaseLifecycleSlot()
+
 		// Create/get worktree for the PR branch. Use lockKey (which may be
 		// "pr-{N}" for non-bead PRs) so the path is always non-empty/valid.
 		wt, err := d.worktreeMgr.Create(ctx, anvilCfg.Path, lockKey, req.Branch)
@@ -1949,6 +1994,41 @@ func (d *Daemon) drainPendingAction(ctx context.Context, beadID string) {
 	}
 	d.logger.Info("draining parked lifecycle action", "bead", beadID, "action", req.Action)
 	d.handleLifecycleAction(ctx, req)
+}
+
+// effectiveMaxLifecycleWorkers resolves the configured lifecycle concurrency cap,
+// falling back to config.DefaultMaxLifecycleWorkers when the setting is unset or
+// non-positive.
+func effectiveMaxLifecycleWorkers(limit int) int {
+	if limit <= 0 {
+		return config.DefaultMaxLifecycleWorkers
+	}
+	return limit
+}
+
+// reserveLifecycleSlot atomically reserves a concurrency slot for a lifecycle fix
+// worker (quench/burnish/rebase/assay). It returns true if a slot was acquired —
+// in which case the caller MUST call releaseLifecycleSlot exactly once when the
+// worker finishes (use defer) — or false if the effective max_lifecycle_workers
+// limit is already reached. The compare-and-swap loop makes the check-and-reserve
+// atomic so concurrent handler goroutines (Bellows-triggered and manual) cannot
+// over-subscribe the cap.
+func (d *Daemon) reserveLifecycleSlot(limit int) bool {
+	maxSlots := int64(effectiveMaxLifecycleWorkers(limit))
+	for {
+		cur := d.lifecycleActive.Load()
+		if cur >= maxSlots {
+			return false
+		}
+		if d.lifecycleActive.CompareAndSwap(cur, cur+1) {
+			return true
+		}
+	}
+}
+
+// releaseLifecycleSlot frees a slot previously reserved by reserveLifecycleSlot.
+func (d *Daemon) releaseLifecycleSlot() {
+	d.lifecycleActive.Add(-1)
 }
 
 // runStaleDetection periodically checks active workers for stale log files.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2411,7 +2411,7 @@ func TestReserveLifecycleSlot_Concurrent(t *testing.T) {
 	const limit = 2
 	const goroutines = 16
 
-	d := &Daemon{}
+	d := &Daemon{lifecycleCond: sync.NewCond(&sync.Mutex{})}
 
 	var granted atomic.Int64
 	var wg sync.WaitGroup
@@ -2441,16 +2441,16 @@ func TestReserveLifecycleSlot_Concurrent(t *testing.T) {
 // TestReserveLifecycleSlot_DefaultLimit verifies that a non-positive limit falls
 // back to the package default.
 func TestReserveLifecycleSlot_DefaultLimit(t *testing.T) {
-	d := &Daemon{}
+	d := &Daemon{lifecycleCond: sync.NewCond(&sync.Mutex{})}
 	for i := 0; i < config.DefaultMaxLifecycleWorkers; i++ {
 		assert.True(t, d.reserveLifecycleSlot(0), "reservation %d should succeed under default limit", i)
 	}
 	assert.False(t, d.reserveLifecycleSlot(0), "reservation beyond default limit must fail")
 }
 
-// TestHandleLifecycleAction_RespectsLifecycleCap verifies that a fix action is
-// deferred (no fix worker spawned) when the lifecycle concurrency cap is already
-// saturated, and that the lifecycle counter is left untouched.
+// TestHandleLifecycleAction_RespectsLifecycleCap verifies that a fix action
+// blocks when the lifecycle concurrency cap is saturated, and proceeds once a
+// slot frees — without burning retry counters.
 func TestHandleLifecycleAction_RespectsLifecycleCap(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "forge-lifecycle-cap-*")
 	require.NoError(t, err)
@@ -2469,6 +2469,7 @@ func TestHandleLifecycleAction_RespectsLifecycleCap(t *testing.T) {
 		worktreeMgr:   worktree.NewManager(),
 		promptBuilder: prompt.NewBuilder(),
 		runCtx:        context.Background(),
+		lifecycleCond: sync.NewCond(&sync.Mutex{}),
 	}
 	d.cfg.Store(&config.Config{
 		Settings: config.SettingsConfig{MaxLifecycleWorkers: 1},
@@ -2484,7 +2485,7 @@ func TestHandleLifecycleAction_RespectsLifecycleCap(t *testing.T) {
 	require.True(t, d.reserveLifecycleSlot(1))
 
 	// Emit a CI failure: the lifecycle manager dispatches ActionFixCI, but the
-	// gate must defer it because the only slot is taken.
+	// handler must block waiting for a slot (not defer/reset).
 	lm.HandleEvent(context.Background(), bellows.PREvent{
 		PRNumber:  7,
 		BeadID:    "CAP-1",
@@ -2493,7 +2494,18 @@ func TestHandleLifecycleAction_RespectsLifecycleCap(t *testing.T) {
 		EventType: bellows.EventCIFailed,
 	})
 
-	// Wait for the deferred handler goroutine to finish.
+	// Give the handler goroutine time to park on the Cond wait.
+	time.Sleep(100 * time.Millisecond)
+
+	// The counter must still reflect only the pre-reserved slot — the blocked
+	// handler has not yet acquired a slot.
+	assert.Equal(t, int64(1), d.lifecycleActive.Load(), "blocked action must not change the lifecycle counter")
+
+	// Release the pre-reserved slot to unblock the waiting handler. It will
+	// proceed to acquire a slot and then fail at worktree creation (the anvil
+	// path is a temp dir, not a git repo), releasing the slot and finishing.
+	d.releaseLifecycleSlot()
+
 	done := make(chan struct{})
 	go func() { d.wg.Wait(); close(done) }()
 	select {
@@ -2502,16 +2514,43 @@ func TestHandleLifecycleAction_RespectsLifecycleCap(t *testing.T) {
 		t.Fatal("timeout waiting for handleLifecycleAction to complete")
 	}
 
-	// The counter must still reflect only the pre-reserved slot — the deferred
-	// action neither reserved nor leaked a slot.
-	assert.Equal(t, int64(1), d.lifecycleActive.Load(), "deferred action must not change the lifecycle counter")
+	// After the handler finishes (worktree creation fails), the slot must be
+	// released back, leaving the counter at zero.
+	assert.Equal(t, int64(0), d.lifecycleActive.Load(), "lifecycle counter must return to zero after handler finishes")
+}
 
-	// No fix worker should have been inserted for the deferred PR.
-	workers, err := db.ActiveWorkers()
-	require.NoError(t, err)
-	for _, w := range workers {
-		assert.NotEqual(t, "CAP-1", w.BeadID, "no fix worker should be spawned while at capacity")
+// TestWaitForLifecycleSlot_CancelledContext verifies that waitForLifecycleSlot
+// returns false promptly when the context is cancelled while waiting.
+func TestWaitForLifecycleSlot_CancelledContext(t *testing.T) {
+	d := &Daemon{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		lifecycleCond: sync.NewCond(&sync.Mutex{}),
 	}
+
+	// Saturate the slot.
+	require.True(t, d.reserveLifecycleSlot(1))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- d.waitForLifecycleSlot(ctx, 1)
+	}()
+
+	// Give the goroutine time to park on the Cond wait.
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case got := <-done:
+		assert.False(t, got, "waitForLifecycleSlot must return false on cancelled context")
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForLifecycleSlot did not return after context cancellation")
+	}
+
+	// The counter must still be 1 (only the pre-reserved slot).
+	assert.Equal(t, int64(1), d.lifecycleActive.Load())
 }
 
 // mockVCSProvider implements vcs.Provider for testing.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2395,6 +2395,125 @@ func TestHandleLifecycleAction_CloseBead_Error(t *testing.T) {
 	assert.True(t, st.Merged, "lifecycle state should show PR as merged even when bd close fails")
 }
 
+// TestEffectiveMaxLifecycleWorkers verifies the fallback to the package default
+// when the configured limit is unset or non-positive.
+func TestEffectiveMaxLifecycleWorkers(t *testing.T) {
+	assert.Equal(t, config.DefaultMaxLifecycleWorkers, effectiveMaxLifecycleWorkers(0))
+	assert.Equal(t, config.DefaultMaxLifecycleWorkers, effectiveMaxLifecycleWorkers(-5))
+	assert.Equal(t, 1, effectiveMaxLifecycleWorkers(1))
+	assert.Equal(t, 7, effectiveMaxLifecycleWorkers(7))
+}
+
+// TestReserveLifecycleSlot_Concurrent verifies that no more than the configured
+// limit of lifecycle slots can be reserved concurrently, and that releasing a
+// slot lets a subsequent reservation succeed.
+func TestReserveLifecycleSlot_Concurrent(t *testing.T) {
+	const limit = 2
+	const goroutines = 16
+
+	d := &Daemon{}
+
+	var granted atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if d.reserveLifecycleSlot(limit) {
+				granted.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(limit), granted.Load(), "exactly %d slots should be granted", limit)
+	assert.Equal(t, int64(limit), d.lifecycleActive.Load(), "counter should reflect granted slots")
+
+	// At capacity: further reservations fail.
+	assert.False(t, d.reserveLifecycleSlot(limit), "reservation must fail when at capacity")
+
+	// Releasing one slot frees capacity for exactly one more reservation.
+	d.releaseLifecycleSlot()
+	assert.True(t, d.reserveLifecycleSlot(limit), "reservation must succeed after a slot frees")
+	assert.False(t, d.reserveLifecycleSlot(limit), "reservation must fail again once back at capacity")
+}
+
+// TestReserveLifecycleSlot_DefaultLimit verifies that a non-positive limit falls
+// back to the package default.
+func TestReserveLifecycleSlot_DefaultLimit(t *testing.T) {
+	d := &Daemon{}
+	for i := 0; i < config.DefaultMaxLifecycleWorkers; i++ {
+		assert.True(t, d.reserveLifecycleSlot(0), "reservation %d should succeed under default limit", i)
+	}
+	assert.False(t, d.reserveLifecycleSlot(0), "reservation beyond default limit must fail")
+}
+
+// TestHandleLifecycleAction_RespectsLifecycleCap verifies that a fix action is
+// deferred (no fix worker spawned) when the lifecycle concurrency cap is already
+// saturated, and that the lifecycle counter is left untouched.
+func TestHandleLifecycleAction_RespectsLifecycleCap(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-lifecycle-cap-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "state.db")
+	db, err := state.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	d := &Daemon{
+		db:            db,
+		logger:        logger,
+		worktreeMgr:   worktree.NewManager(),
+		promptBuilder: prompt.NewBuilder(),
+		runCtx:        context.Background(),
+	}
+	d.cfg.Store(&config.Config{
+		Settings: config.SettingsConfig{MaxLifecycleWorkers: 1},
+		Anvils: map[string]config.AnvilConfig{
+			"test-anvil": {Path: tmpDir},
+		},
+	})
+
+	lm := lifecycle.New(db, logger, d.handleLifecycleAction)
+	d.lifecycleMgr = lm
+
+	// Saturate the single lifecycle slot to simulate an in-flight fix worker.
+	require.True(t, d.reserveLifecycleSlot(1))
+
+	// Emit a CI failure: the lifecycle manager dispatches ActionFixCI, but the
+	// gate must defer it because the only slot is taken.
+	lm.HandleEvent(context.Background(), bellows.PREvent{
+		PRNumber:  7,
+		BeadID:    "CAP-1",
+		Anvil:     "test-anvil",
+		Branch:    "forge/CAP-1",
+		EventType: bellows.EventCIFailed,
+	})
+
+	// Wait for the deferred handler goroutine to finish.
+	done := make(chan struct{})
+	go func() { d.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for handleLifecycleAction to complete")
+	}
+
+	// The counter must still reflect only the pre-reserved slot — the deferred
+	// action neither reserved nor leaked a slot.
+	assert.Equal(t, int64(1), d.lifecycleActive.Load(), "deferred action must not change the lifecycle counter")
+
+	// No fix worker should have been inserted for the deferred PR.
+	workers, err := db.ActiveWorkers()
+	require.NoError(t, err)
+	for _, w := range workers {
+		assert.NotEqual(t, "CAP-1", w.BeadID, "no fix worker should be spawned while at capacity")
+	}
+}
+
 // mockVCSProvider implements vcs.Provider for testing.
 type mockVCSProvider struct {
 	mergeCalls atomic.Int32

--- a/internal/hotreload/hotreload.go
+++ b/internal/hotreload/hotreload.go
@@ -12,6 +12,7 @@
 //   - settings.max_ci_fix_attempts (applied immediately to lifecycle manager)
 //   - settings.max_review_fix_attempts (applied immediately to lifecycle manager)
 //   - settings.max_rebase_attempts (applied immediately to lifecycle manager)
+//   - settings.max_lifecycle_workers (gates concurrent lifecycle fix workers; read per-dispatch)
 //   - settings.crucible_poll_interval (change the slow-path Crucible poll cadence)
 //   - settings.copilot_combined_smith_warden (toggle combined mode at runtime)
 //   - settings.copilot_warden_sample_rate (adjust sampling rate at runtime)
@@ -246,6 +247,11 @@ func applyChanges(old, new *config.Config) []string {
 	if old.Settings.MaxRebaseAttempts != new.Settings.MaxRebaseAttempts {
 		changes = append(changes, fmt.Sprintf("max_rebase_attempts: %d → %d",
 			old.Settings.MaxRebaseAttempts, new.Settings.MaxRebaseAttempts))
+	}
+
+	if old.Settings.MaxLifecycleWorkers != new.Settings.MaxLifecycleWorkers {
+		changes = append(changes, fmt.Sprintf("max_lifecycle_workers: %d → %d",
+			old.Settings.MaxLifecycleWorkers, new.Settings.MaxLifecycleWorkers))
 	}
 
 	if old.Settings.CopilotCombinedSmithWarden != new.Settings.CopilotCombinedSmithWarden {


### PR DESCRIPTION
## Changes

- **Cap concurrent lifecycle fix workers** - Bellows fix workers (quench/cifix, burnish/reviewfix, rebase, assay) are now bounded by a global `max_lifecycle_workers` concurrency cap (default 2) instead of fanning out unbounded. Each fix worker spawns its own Claude session and was deliberately excluded from `max_total_smiths`, so a burst of stuck PRs could previously spawn one Claude session per PR and OOM-crash the host. Actions over the cap are deferred and retried on the next Bellows poll. (Forge-3m06)

## Original Issue (bug): Cap concurrent lifecycle (burnish/quench/rebase) workers — unbounded, crashed the server

Lifecycle/bellows fix workers (burnish/reviewfix, quench/cifix, rebase) are not bounded by any concurrency limit. With 4 stuck PRs, 4 burnish workers ran simultaneously — each spawns its own Claude session — and the server OOM/crashed.

Root cause:
- The global dispatch cap 'max_total_smiths' is enforced via worker.CanSpawnGlobal / worker.DispatchTotalActiveCount, which call state.ActiveDispatchWorkers(). That query (internal/state/db.go) excludes 'backgroundPhases' (db.go:550) which INCLUDES 'quench','cifix','burnish','reviewfix','rebase'. So lifecycle workers are intentionally not counted toward dispatch capacity.
- internal/daemon/daemon.go handleLifecycleAction (line ~1209) spawns the fix worker with NO global-capacity check at all. It only takes a per-bead in-flight lock (activeBeads), which stops the SAME bead running twice but does nothing across different PRs.
- Net: lifecycle workers are neither counted nor gated → unbounded fan-out. daemon.go:1303 even notes each 'spawns a Claude session of comparable length' to a smith.

---
Bead: Forge-3m06 | Branch: forge/Forge-3m06
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->