### PR TITLE
Tests for stranded-branch auto-recovery and registration (Forge-8wed)

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -4185,6 +4185,28 @@ func TestPreDispatchRemoteBranchCheck(t *testing.T) {
 		if r != nil && r.NeedsHuman {
 			t.Errorf("bead must NOT be marked needs_human when a PR already exists; bellows takes over")
 		}
+
+		// The existing PR must be left untouched: no auto-open is attempted and
+		// no recovery is performed. The branch is handed straight to bellows.
+		require.Equal(t, int32(0), mockVCS.createPRCalls.Load(),
+			"CreatePR must NOT be called when a PR already exists for the stranded branch")
+
+		// The pre-existing PR is registered (so bellows owns it) under the real
+		// bead ID derived from the forge/<bead> branch — never a synthetic ext-* id.
+		pr, err := db.GetPRByNumber(bead.Anvil, 77)
+		require.NoError(t, err)
+		require.NotNil(t, pr, "the already-open PR should be registered for bellows")
+		assert.Equal(t, bead.ID, pr.BeadID,
+			"registered PR must carry the real bead ID, not a synthetic ext-* placeholder")
+
+		// No recovery event must fire — recovery only applies when there is no PR.
+		events, err := db.RecentEvents(20)
+		require.NoError(t, err)
+		for _, ev := range events {
+			if ev.Type == state.EventDispatchRecoveredStrandedBranch && ev.BeadID == bead.ID {
+				t.Errorf("EventDispatchRecoveredStrandedBranch must NOT be logged when a PR already exists")
+			}
+		}
 	})
 
 	// pushStrandedWithFragment creates a stranded forge branch carrying a
@@ -4241,6 +4263,17 @@ func TestPreDispatchRemoteBranchCheck(t *testing.T) {
 		pr, err := db.GetPRByNumber(bead.Anvil, 91)
 		require.NoError(t, err)
 		require.NotNil(t, pr, "auto-opened PR should be registered in state.db")
+		// Registration must use the real bead ID derived from the forge/<bead>
+		// branch — not a synthetic ext-<number> placeholder — so merge-close
+		// (handleBeadCloseOnMerge) can key off it and close the bead on merge.
+		assert.Equal(t, bead.ID, pr.BeadID,
+			"recovered PR must be registered under the real bead ID, not ext-<number>")
+		assert.Equal(t, branch, pr.Branch,
+			"recovered PR must record the forge/<bead> branch it was opened from")
+		// "forge-managed": a recovery PR registered under a real bead ID must be
+		// bellows-managed so bellows drives it through CI/review/merge.
+		assert.True(t, pr.BellowsManaged,
+			"auto-recovered PR must be bellows-managed (forge owns its lifecycle)")
 
 		events, err := db.RecentEvents(20)
 		require.NoError(t, err)


### PR DESCRIPTION
## Reviewer's approval notes

Test-only additive assertions for stranded-branch recovery; all referenced symbols exist, tests pass, assertions correctly encode the bead's acceptance criteria

## Original Issue (task): Tests for stranded-branch auto-recovery and registration

Add tests covering the acceptance criteria in internal/daemon (table-driven where the existing stranded-branch tests live). Cases: (1) stranded forge/<bead> branch with changelog fragment and no PR -> PR auto-opened, marked forge-managed, registered with correct bead_id, needs_human NOT set, dispatch_recovered_stranded_branch event emitted; (2) stranded branch WITHOUT changelog fragment -> still escalates to needs_human; (3) stranded branch that already has a PR -> unchanged (defer to bellows); (4) CreatePR failure during auto-open -> falls back to needs_human escalation; (5) forge-pattern PR adopted by bellows registers with bead_id derived from branch (not ext-<number>) and bellows_managed=1 when marker present. Mirror the existing EventDispatchBlockedStrandedBranch test patterns. Depends on sub-tasks 1 and 2 being implemented.

---
Bead: Forge-8wed | Branch: forge/Forge-8wed
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->