### PR TITLE
Hearth 2.0: show PR number + GitHub link in pipeline view (Forge-s4sv)

### DIFF
--- a/changelog.d/Forge-s4sv.md
+++ b/changelog.d/Forge-s4sv.md
@@ -1,0 +1,2 @@
+category: Added
+- **PR number column in Hearth queue** - The Hearth queue/pipeline view now shows each bead's PR number as a clickable GitHub hyperlink (OSC 8) between the bead ID and the anvil, falling back to blank for beads without a PR. (Forge-s4sv)

--- a/cmd/forge/hearth.go
+++ b/cmd/forge/hearth.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"sort"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -15,7 +17,30 @@ import (
 	"github.com/Robin831/Forge/internal/hearth"
 	"github.com/Robin831/Forge/internal/ipc"
 	"github.com/Robin831/Forge/internal/state"
+	"github.com/Robin831/Forge/internal/vcs/github"
 )
+
+// anvilRepoBaseURL derives an anvil's GitHub repository base URL
+// (e.g. "https://github.com/owner/repo") from its git remote "origin".
+// It returns an empty string when the path is blank, the remote is unreadable,
+// or the URL cannot be parsed as a GitHub repo — callers then fall back to
+// rendering PR numbers as plain text without a hyperlink.
+func anvilRepoBaseURL(anvilPath string) string {
+	if anvilPath == "" {
+		return ""
+	}
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = anvilPath
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	owner, repo, err := github.ParseRepoURL(strings.TrimSpace(string(out)))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("https://github.com/%s/%s", owner, repo)
+}
 
 func init() {
 	rootCmd.AddCommand(hearthCmd)
@@ -46,10 +71,14 @@ var hearthCmd = &cobra.Command{
 
 		anvilNames := make([]string, 0, len(cfg.Anvils))
 		autoMergeAnvils := make(map[string]bool)
+		anvilRepoURLs := make(map[string]string)
 		for name, a := range cfg.Anvils {
 			anvilNames = append(anvilNames, name)
 			if a.AutoMerge {
 				autoMergeAnvils[name] = true
+			}
+			if url := anvilRepoBaseURL(a.Path); url != "" {
+				anvilRepoURLs[name] = url
 			}
 		}
 		sort.Strings(anvilNames)
@@ -67,6 +96,7 @@ var hearthCmd = &cobra.Command{
 			// Hearth reflects changes after restart.
 			AutoMergeAnvils: func() map[string]bool { return autoMergeAnvils },
 			WicketEnabled:   cfg.Settings.WicketEnabled,
+			AnvilRepoURLs:   anvilRepoURLs,
 		}
 
 		model := hearth.NewModel(ds)

--- a/internal/hearth/data.go
+++ b/internal/hearth/data.go
@@ -97,6 +97,26 @@ type DataSource struct {
 	// WicketEnabled controls whether the Wicket panel is shown in the TUI.
 	// Set to true when wicket_enabled is true in the loaded config.
 	WicketEnabled bool
+	// AnvilRepoURLs maps an anvil name to its GitHub repository base URL
+	// (e.g. "https://github.com/owner/repo"), derived once at startup from the
+	// anvil's git remote. The Queue panel uses it to build clickable PR links.
+	// An anvil missing from the map (or a blank value) renders PR numbers as
+	// plain text without a hyperlink.
+	AnvilRepoURLs map[string]string
+}
+
+// prURLForBead builds the GitHub PR URL for a bead's PR from the anvil's
+// repository base URL. Returns an empty string when the base URL is unknown
+// or the PR number is not positive, so callers fall back to plain text.
+func prURLForBead(anvilRepoURLs map[string]string, anvil string, prNumber int) string {
+	if prNumber <= 0 {
+		return ""
+	}
+	base := anvilRepoURLs[anvil]
+	if base == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/pull/%d", strings.TrimRight(base, "/"), prNumber)
 }
 
 // Tick returns a Bubbletea command that sends a TickMsg after the interval.
@@ -109,15 +129,31 @@ func Tick() tea.Cmd {
 // FetchQueue reads the daemon's cached queue from the state DB.
 // The daemon writes queue data on each poll cycle, so the Hearth TUI
 // always reflects the daemon's view without running its own bd ready calls.
-func FetchQueue(db *state.DB) tea.Cmd {
+// Each queued bead is enriched with its open PR number and a clickable GitHub
+// URL by joining the prs table on (anvil, bead ID).
+func FetchQueue(ds *DataSource) tea.Cmd {
 	return func() tea.Msg {
-		cached, err := db.QueueCache()
+		cached, err := ds.DB.QueueCache()
 		if err != nil {
 			return QueueErrorMsg{Err: err}
 		}
 
+		// Build a lookup of (anvil, bead ID) → PR number from open PRs so each
+		// queued bead can show its PR. Keyed by anvil+\x00+beadID to avoid
+		// collisions between anvils that reuse bead IDs.
+		prByBead := make(map[string]int)
+		if prs, prErr := ds.DB.OpenPRs(); prErr == nil {
+			for _, p := range prs {
+				if p.BeadID == "" || p.Number == 0 {
+					continue
+				}
+				prByBead[p.Anvil+"\x00"+p.BeadID] = p.Number
+			}
+		}
+
 		var items []QueueItem
 		for _, c := range cached {
+			prNumber := prByBead[c.Anvil+"\x00"+c.BeadID]
 			items = append(items, QueueItem{
 				BeadID:      c.BeadID,
 				Title:       c.Title,
@@ -127,6 +163,8 @@ func FetchQueue(db *state.DB) tea.Cmd {
 				Status:      c.Status,
 				Section:     string(c.Section),
 				Assignee:    c.Assignee,
+				PRNumber:    prNumber,
+				PRURL:       prURLForBead(ds.AnvilRepoURLs, c.Anvil, prNumber),
 			})
 		}
 
@@ -1158,7 +1196,7 @@ func FetchWicketSummary(db *state.DB) tea.Cmd {
 // controlled by healthTickDivisor in the TickMsg handler.
 func FetchAll(ds *DataSource, logCache *LogTailerCache) tea.Cmd {
 	return tea.Batch(
-		FetchQueue(ds.DB),
+		FetchQueue(ds),
 		FetchNeedsAttention(ds),
 		FetchReadyToMerge(*ds),
 		FetchWorkers(ds.DB, logCache),

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -4750,8 +4750,8 @@ func renderQueuePRCell(prNumber int, prURL string) string {
 	if w := lipgloss.Width(label); w < prColumnWidth {
 		label += strings.Repeat(" ", prColumnWidth-w)
 	}
-	styled := lipgloss.NewStyle().Foreground(colorInfo).Render(label)
-	return renderOSC8Link(prURL, styled)
+	linked := renderOSC8Link(prURL, label)
+	return lipgloss.NewStyle().Foreground(colorInfo).Render(linked)
 }
 
 // eventTypeStyle returns a styled event type.

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -70,6 +70,11 @@ type QueueItem struct {
 	Status      string
 	Section     string // "ready", "unlabeled", "in_progress"
 	Assignee    string
+	// PRNumber is the GitHub PR number for this bead, or 0 when no PR exists yet.
+	PRNumber int
+	// PRURL is the full https://github.com/<owner>/<repo>/pull/<n> link for the
+	// bead's PR, or empty when no PR exists or the anvil's repo URL is unknown.
+	PRURL string
 }
 
 // queueNavItem represents a navigable item in the grouped queue panel.
@@ -3388,16 +3393,21 @@ func (m *Model) renderQueue(width, height int) string {
 				lastSection = item.Section
 			}
 
-			// Main bead line.
+			// Main bead line: priority + bead ID, then the PR column, then the
+			// anvil suffix on the right. The PR cell is rendered outside the
+			// selection highlight because it may carry an OSC 8 hyperlink escape
+			// that must not be wrapped by lipgloss styling.
 			priority := priorityStyle(item.Priority)
 			anvilSuffix := ""
 			if !m.queueGrouped {
 				anvilSuffix = " " + dimStyle.Render(item.Anvil)
 			}
-			mainLine := fmt.Sprintf("%s%s %s%s", indent, priority, item.BeadID, anvilSuffix)
+			beadPart := fmt.Sprintf("%s%s %s", indent, priority, item.BeadID)
 			if ni == m.queueVP.cursor {
-				mainLine = selectedStyle.Render(mainLine)
+				beadPart = selectedStyle.Render(beadPart)
 			}
+			prCell := renderQueuePRCell(item.PRNumber, item.PRURL)
+			mainLine := beadPart + "  " + prCell + anvilSuffix
 			rows = append(rows, displayRow{text: mainLine, navIdx: ni})
 
 			// Title line.
@@ -4689,6 +4699,59 @@ func phaseTag(phase string) string {
 	default:
 		return lipgloss.NewStyle().Foreground(colorMuted).Render("[idle]")
 	}
+}
+
+// renderOSC8Link wraps text in an OSC 8 terminal hyperlink escape sequence,
+// making the text clickable in supporting terminals (e.g. Windows Terminal,
+// iTerm2). When url is empty the text is returned unchanged.
+//
+// To avoid terminal escape injection, the OSC 8 sequence is only emitted when
+// both url and text contain no ASCII control characters (e.g. ESC, BEL).
+func renderOSC8Link(url, text string) string {
+	if url == "" {
+		return text
+	}
+	if !isSafeForOSC8(url) || !isSafeForOSC8(text) {
+		return text
+	}
+	return "\x1b]8;;" + url + "\x1b\\" + text + "\x1b]8;;\x1b\\"
+}
+
+// isSafeForOSC8 reports whether s can be safely embedded into an OSC 8
+// hyperlink sequence. It rejects ASCII control characters (0x00-0x1F, 0x7F),
+// including ESC and BEL, which could otherwise be used for terminal escape
+// injection.
+func isSafeForOSC8(s string) bool {
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b < 0x20 || b == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+// prColumnWidth is the fixed display width reserved for the queue PR column
+// (e.g. "PR #1234"). It keeps the bead and PR columns aligned across rows
+// whether or not a given bead has a PR yet.
+const prColumnWidth = 8
+
+// renderQueuePRCell returns the styled, fixed-width PR cell for a queue row.
+// When the bead has a PR it shows "PR #N" as a clickable OSC 8 hyperlink (when
+// a URL is known); otherwise it returns blank padding of the same width so the
+// surrounding columns stay aligned. The visible text is padded to
+// prColumnWidth before the hyperlink escape is applied, so the OSC 8 control
+// bytes do not count toward the column width.
+func renderQueuePRCell(prNumber int, prURL string) string {
+	if prNumber <= 0 {
+		return strings.Repeat(" ", prColumnWidth)
+	}
+	label := fmt.Sprintf("PR #%d", prNumber)
+	if w := lipgloss.Width(label); w < prColumnWidth {
+		label += strings.Repeat(" ", prColumnWidth-w)
+	}
+	styled := lipgloss.NewStyle().Foreground(colorInfo).Render(label)
+	return renderOSC8Link(prURL, styled)
 }
 
 // eventTypeStyle returns a styled event type.

--- a/internal/hearth/queue_pr_test.go
+++ b/internal/hearth/queue_pr_test.go
@@ -1,0 +1,137 @@
+package hearth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPRURLForBead(t *testing.T) {
+	urls := map[string]string{
+		"forge":     "https://github.com/Robin831/Forge",
+		"withslash": "https://github.com/owner/repo/",
+	}
+
+	tests := []struct {
+		name     string
+		anvil    string
+		prNumber int
+		want     string
+	}{
+		{"valid", "forge", 42, "https://github.com/Robin831/Forge/pull/42"},
+		{"trailing slash trimmed", "withslash", 7, "https://github.com/owner/repo/pull/7"},
+		{"no PR number", "forge", 0, ""},
+		{"negative PR number", "forge", -1, ""},
+		{"unknown anvil", "missing", 5, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prURLForBead(urls, tt.anvil, tt.prNumber)
+			if got != tt.want {
+				t.Errorf("prURLForBead(%q, %d) = %q; want %q", tt.anvil, tt.prNumber, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderOSC8Link(t *testing.T) {
+	out := renderOSC8Link("https://example.com/pull/1", "PR #1")
+	if !strings.Contains(out, "\x1b]8;;https://example.com/pull/1\x1b\\") {
+		t.Errorf("expected OSC 8 open sequence with URL, got %q", out)
+	}
+	if !strings.Contains(out, "PR #1") {
+		t.Errorf("expected link text in output, got %q", out)
+	}
+	if !strings.HasSuffix(out, "\x1b]8;;\x1b\\") {
+		t.Errorf("expected OSC 8 close sequence, got %q", out)
+	}
+}
+
+func TestRenderOSC8LinkEmptyURL(t *testing.T) {
+	out := renderOSC8Link("", "plain")
+	if out != "plain" {
+		t.Errorf("expected plain text for empty URL, got %q", out)
+	}
+}
+
+func TestRenderOSC8LinkRejectsControlChars(t *testing.T) {
+	// A URL with an embedded ESC must not produce an OSC 8 sequence.
+	out := renderOSC8Link("https://example.com/\x1bevil", "PR #1")
+	if strings.Contains(out, "\x1b]8;;") {
+		t.Errorf("expected no OSC 8 sequence for unsafe URL, got %q", out)
+	}
+	if out != "PR #1" {
+		t.Errorf("expected fallback to plain text, got %q", out)
+	}
+}
+
+func TestRenderQueuePRCellWithPR(t *testing.T) {
+	cell := renderQueuePRCell(123, "https://github.com/owner/repo/pull/123")
+	if !strings.Contains(cell, "PR #123") {
+		t.Errorf("expected 'PR #123' in cell, got %q", cell)
+	}
+	if !strings.Contains(cell, "\x1b]8;;https://github.com/owner/repo/pull/123\x1b\\") {
+		t.Errorf("expected OSC 8 hyperlink to the PR URL, got %q", cell)
+	}
+}
+
+func TestRenderQueuePRCellNoPR(t *testing.T) {
+	cell := renderQueuePRCell(0, "")
+	if strings.Contains(cell, "PR #") {
+		t.Errorf("expected blank cell when no PR, got %q", cell)
+	}
+	if len(cell) != prColumnWidth {
+		t.Errorf("expected blank cell width %d, got %d (%q)", prColumnWidth, len(cell), cell)
+	}
+}
+
+func TestRenderQueuePRCellNoURLFallsBackToPlainText(t *testing.T) {
+	// When the anvil repo URL is unknown the PR number is still shown, but as
+	// plain text without an OSC 8 hyperlink.
+	cell := renderQueuePRCell(9, "")
+	if !strings.Contains(cell, "PR #9") {
+		t.Errorf("expected 'PR #9' in cell, got %q", cell)
+	}
+	if strings.Contains(cell, "\x1b]8;;") {
+		t.Errorf("expected no OSC 8 sequence without URL, got %q", cell)
+	}
+}
+
+func TestRenderQueueShowsPRNumber(t *testing.T) {
+	m := NewModel(nil)
+	m.focused = PanelQueue
+	m.width = 80
+	m.height = 24
+	m.queue = []QueueItem{
+		{BeadID: "bd-1", Anvil: "forge", Section: "ready", PRNumber: 55, PRURL: "https://github.com/owner/repo/pull/55"},
+	}
+	m.queueVP = scrollViewport{cursor: 0}
+	m.rebuildQueueNav()
+
+	out := m.renderQueue(80, 24)
+	if !strings.Contains(out, "PR #55") {
+		t.Errorf("expected rendered queue to contain 'PR #55', got:\n%s", out)
+	}
+	if !strings.Contains(out, "\x1b]8;;https://github.com/owner/repo/pull/55\x1b\\") {
+		t.Errorf("expected rendered queue to contain OSC 8 hyperlink, got:\n%s", out)
+	}
+}
+
+func TestRenderQueueNoPRNoHyperlink(t *testing.T) {
+	m := NewModel(nil)
+	m.focused = PanelQueue
+	m.width = 80
+	m.height = 24
+	m.queue = []QueueItem{
+		{BeadID: "bd-2", Anvil: "forge", Section: "ready"},
+	}
+	m.queueVP = scrollViewport{cursor: 0}
+	m.rebuildQueueNav()
+
+	out := m.renderQueue(80, 24)
+	if strings.Contains(out, "\x1b]8;;") {
+		t.Errorf("expected no OSC 8 hyperlink for bead without PR, got:\n%s", out)
+	}
+	if !strings.Contains(out, "bd-2") {
+		t.Errorf("expected bead ID in output, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Changes

- **PR number column in Hearth queue** - The Hearth queue/pipeline view now shows each bead's PR number as a clickable GitHub hyperlink (OSC 8) between the bead ID and the anvil, falling back to blank for beads without a PR. (Forge-s4sv)

## Original Issue (feature): Hearth 2.0: show PR number + GitHub link in pipeline view

In the Hearth 2.0 pipeline/queue view, add a column showing each bead's PR number and a clickable link to the GitHub PR. Place it between the bead name and the colorful status tag on the right.

---
Bead: Forge-s4sv | Branch: forge/Forge-s4sv
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->