### PR TITLE
Hearth 2.0: event filter should search the whole event log, not just the loaded ~100 (Forge-1l1s)

### DIFF
--- a/changelog.d/Forge-1l1s.md
+++ b/changelog.d/Forge-1l1s.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Hearth event filter searches the whole log** - The Events panel filter now runs a DB-backed search across the entire event log instead of only the ~100 events loaded in memory, so filtering for an older bead or event id matches correctly. Results are capped at 500 to protect the TUI render. (Forge-1l1s)

--- a/internal/hearth/data.go
+++ b/internal/hearth/data.go
@@ -57,6 +57,12 @@ const healthTickDivisor = 5
 // EventFetchLimit is the maximum number of events retrieved for the Events panel.
 const EventFetchLimit = 100
 
+// EventFilterMatchLimit is the maximum number of events returned when an event
+// filter is active. The filter is applied at the SQL level so the whole event
+// log is searched (not just the most recent EventFetchLimit rows), but the
+// result count is still capped to protect the TUI render.
+const EventFilterMatchLimit = 500
+
 // TickMsg triggers a data refresh cycle.
 type TickMsg time.Time
 
@@ -689,6 +695,37 @@ func FetchEvents(db *state.DB, limit int) tea.Cmd {
 		}
 
 		return UpdateEventsMsg{Items: items}
+	}
+}
+
+// FetchEventsMatching searches the entire event log for events matching the
+// filter and returns them as an UpdateFilteredEventsMsg. The search runs at the
+// SQL level (via RecentEventsMatching) so events older than the EventFetchLimit
+// window are also matched — fixing the case where filtering only ever scanned
+// the most recent ~100 in-memory events. The same poll/poll_error exclusions as
+// FetchEvents apply, and results are capped at EventFilterMatchLimit.
+//
+// The originating filter text is echoed back in the message so the model can
+// discard results from a stale query (the user may have typed further since).
+func FetchEventsMatching(db *state.DB, filter string) tea.Cmd {
+	return func() tea.Msg {
+		events, err := db.RecentEventsMatching(filter, EventFilterMatchLimit,
+			[]state.EventType{state.EventPoll, state.EventPollError})
+		if err != nil {
+			return UpdateFilteredEventsMsg{Filter: filter, Items: nil}
+		}
+
+		items := make([]EventItem, 0, len(events))
+		for _, e := range events {
+			items = append(items, EventItem{
+				Timestamp: e.Timestamp.Format("15:04:05"),
+				Type:      string(e.Type),
+				Message:   e.Message,
+				BeadID:    e.BeadID,
+			})
+		}
+
+		return UpdateFilteredEventsMsg{Filter: filter, Items: items}
 	}
 }
 

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -1569,7 +1569,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		prevKey := m.lastSeenEventKey
 
 		m.events = msg.Items
-		filterCmd := m.applyEventFilter()
+		newKey := ""
+		if len(msg.Items) > 0 {
+			newKey = toastEventKey(msg.Items[0])
+		}
+		var filterCmd tea.Cmd
+		if newKey != prevKey {
+			filterCmd = m.applyEventFilter()
+		}
 		m.eventRevision++
 		// Auto-scroll to bottom if enabled and new events arrived
 		if m.eventAutoScroll && len(msg.Items) > m.prevEventCount {
@@ -1580,8 +1587,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.prevEventCount = len(msg.Items)
 
 		// Update the last-seen key for the next cycle.
-		if len(msg.Items) > 0 {
-			m.lastSeenEventKey = toastEventKey(msg.Items[0])
+		if newKey != "" {
+			m.lastSeenEventKey = newKey
 		}
 
 		// Detect new events and fire toast notifications for notable ones.
@@ -4471,6 +4478,7 @@ func (m *Model) applyEventFilter() tea.Cmd {
 	}
 	// Prefer a DB-backed search so events older than the loaded window match.
 	if m.data != nil && m.data.DB != nil {
+		m.filteredEvents = nil
 		return FetchEventsMatching(m.data.DB, m.eventFilterText)
 	}
 	// Fallback: filter the in-memory slice (display-only mode).

--- a/internal/hearth/hearth.go
+++ b/internal/hearth/hearth.go
@@ -901,18 +901,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.eventFilter.Blur()
 				m.eventFilter.SetValue("")
 				m.eventFilterText = ""
-				m.applyEventFilter()
+				filterCmd := m.applyEventFilter()
 				m.eventScroll = 0
 				m.eventRevision++
-				return m, nil
+				return m, filterCmd
 			case "enter":
 				m.eventFilterActive = false
 				m.eventFilter.Blur()
 				m.eventFilterText = m.eventFilter.Value()
-				m.applyEventFilter()
+				filterCmd := m.applyEventFilter()
 				m.eventScroll = 0
 				m.eventRevision++
-				return m, nil
+				return m, filterCmd
 			default:
 				var cmd tea.Cmd
 				m.eventFilter, cmd = m.eventFilter.Update(msg)
@@ -920,9 +920,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				newText := m.eventFilter.Value()
 				if newText != m.eventFilterText {
 					m.eventFilterText = newText
-					m.applyEventFilter()
+					filterCmd := m.applyEventFilter()
 					m.eventScroll = 0
 					m.eventRevision++
+					return m, tea.Batch(cmd, filterCmd)
 				}
 				return m, cmd
 			}
@@ -1568,7 +1569,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		prevKey := m.lastSeenEventKey
 
 		m.events = msg.Items
-		m.applyEventFilter()
+		filterCmd := m.applyEventFilter()
 		m.eventRevision++
 		// Auto-scroll to bottom if enabled and new events arrived
 		if m.eventAutoScroll && len(msg.Items) > m.prevEventCount {
@@ -1603,8 +1604,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		if filterCmd != nil {
+			toastCmds = append(toastCmds, filterCmd)
+		}
 		if len(toastCmds) > 0 {
 			return m, tea.Batch(toastCmds...)
+		}
+
+	case UpdateFilteredEventsMsg:
+		// Ignore results from a stale query — the filter text may have changed
+		// while this DB search was in flight. Scroll position is left untouched
+		// here so periodic refreshes don't jump the view; the user-facing filter
+		// actions reset the scroll themselves.
+		if msg.Filter == m.eventFilterText {
+			m.filteredEvents = msg.Items
+			m.eventRevision++
 		}
 
 	case UpdateWicketSummaryMsg:
@@ -4440,14 +4454,33 @@ func (m *Model) renderEventLines(item EventItem, selected bool, panelWidth int) 
 	return lines
 }
 
-// applyEventFilter filters m.events into m.filteredEvents based on
-// m.eventFilterText. Called whenever events or the filter text change.
-func (m *Model) applyEventFilter() {
+// applyEventFilter updates the filtered event view based on m.eventFilterText.
+// Called whenever events or the filter text change.
+//
+// When a filter is active, the search runs at the DB level so the entire event
+// log is queried — not just the most recent EventFetchLimit events held in
+// m.events. It returns the command that performs that query; the result arrives
+// asynchronously as an UpdateFilteredEventsMsg. When the filter is empty (or no
+// data source is available, e.g. display-only mode), it falls back to filtering
+// the in-memory slice synchronously and returns nil.
+func (m *Model) applyEventFilter() tea.Cmd {
 	query := strings.ToLower(m.eventFilterText)
 	if query == "" {
 		m.filteredEvents = m.events
-		return
+		return nil
 	}
+	// Prefer a DB-backed search so events older than the loaded window match.
+	if m.data != nil && m.data.DB != nil {
+		return FetchEventsMatching(m.data.DB, m.eventFilterText)
+	}
+	// Fallback: filter the in-memory slice (display-only mode).
+	m.filteredEvents = m.filterEventsInMemory(query)
+	return nil
+}
+
+// filterEventsInMemory returns the subset of m.events matching the given
+// lower-cased query. Used as a fallback when no DB is available.
+func (m *Model) filterEventsInMemory(query string) []EventItem {
 	filtered := make([]EventItem, 0, len(m.events))
 	for _, ev := range m.events {
 		line := strings.ToLower(ev.Timestamp + " " + ev.Type + " " + ev.BeadID + " " + ev.Message)
@@ -4455,7 +4488,7 @@ func (m *Model) applyEventFilter() {
 			filtered = append(filtered, ev)
 		}
 	}
-	m.filteredEvents = filtered
+	return filtered
 }
 
 // displayEvents returns the events to render — filtered if a filter is active,
@@ -4497,6 +4530,15 @@ type UpdateWorkersMsg struct{ Items []WorkerItem }
 
 // UpdateEventsMsg updates the event log panel.
 type UpdateEventsMsg struct{ Items []EventItem }
+
+// UpdateFilteredEventsMsg delivers the result of a DB-backed event filter
+// search. Filter echoes the query the search was issued for, so the model can
+// ignore results that no longer match the current filter text (the user may
+// have kept typing while the query was in flight).
+type UpdateFilteredEventsMsg struct {
+	Filter string
+	Items  []EventItem
+}
 
 // AnvilHealth holds per-anvil poll health status for the Queue panel.
 type AnvilHealth struct {

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1832,9 +1832,10 @@ func (db *DB) RecentEventsMatching(pattern string, n int, excludeTypes []EventTy
 	// case-insensitive for ASCII in SQLite by default; lower-casing both sides
 	// keeps the behavior aligned with the TUI's in-memory filter for any
 	// non-ASCII content as well.
-	like := "%" + strings.ToLower(pattern) + "%"
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(strings.ToLower(pattern))
+	like := "%" + escaped + "%"
 	conditions = append(conditions,
-		"(LOWER(timestamp) LIKE ? OR LOWER(type) LIKE ? OR LOWER(bead_id) LIKE ? OR LOWER(message) LIKE ?)")
+		"(LOWER(timestamp) LIKE ? ESCAPE '\\' OR LOWER(type) LIKE ? ESCAPE '\\' OR LOWER(bead_id) LIKE ? ESCAPE '\\' OR LOWER(message) LIKE ? ESCAPE '\\')")
 	args = append(args, like, like, like, like)
 
 	args = append(args, n)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1802,6 +1802,65 @@ func (db *DB) RecentEventsExcluding(n int, excludeTypes []EventType) ([]Event, e
 	return events, rows.Err()
 }
 
+// RecentEventsMatching returns the n most recent events whose timestamp, type,
+// bead_id, or message contains the given pattern (case-insensitive substring
+// match), excluding the given types. Unlike RecentEventsExcluding, the match is
+// applied at the SQL level so the entire event log is searched — not just the
+// most recent n rows. The LIMIT still caps results at n to protect callers
+// (e.g. the TUI render) from unbounded result sets.
+//
+// An empty pattern is treated as "match everything" and is equivalent to
+// RecentEventsExcluding.
+func (db *DB) RecentEventsMatching(pattern string, n int, excludeTypes []EventType) ([]Event, error) {
+	if pattern == "" {
+		return db.RecentEventsExcluding(n, excludeTypes)
+	}
+
+	var conditions []string
+	var args []any
+
+	if len(excludeTypes) > 0 {
+		placeholders := make([]string, len(excludeTypes))
+		for i, t := range excludeTypes {
+			placeholders[i] = "?"
+			args = append(args, string(t))
+		}
+		conditions = append(conditions, "type NOT IN ("+strings.Join(placeholders, ",")+")")
+	}
+
+	// Case-insensitive substring match across the searchable columns. LIKE is
+	// case-insensitive for ASCII in SQLite by default; lower-casing both sides
+	// keeps the behavior aligned with the TUI's in-memory filter for any
+	// non-ASCII content as well.
+	like := "%" + strings.ToLower(pattern) + "%"
+	conditions = append(conditions,
+		"(LOWER(timestamp) LIKE ? OR LOWER(type) LIKE ? OR LOWER(bead_id) LIKE ? OR LOWER(message) LIKE ?)")
+	args = append(args, like, like, like, like)
+
+	args = append(args, n)
+	query := `SELECT id, timestamp, type, message, bead_id, anvil
+		 FROM events WHERE ` + strings.Join(conditions, " AND ") + `
+		 ORDER BY timestamp DESC, id DESC LIMIT ?`
+	rows, err := db.conn.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var e Event
+		var typ, ts string
+		if err := rows.Scan(&e.ID, &ts, &typ, &e.Message, &e.BeadID, &e.Anvil); err != nil {
+			return nil, err
+		}
+		e.Type = EventType(typ)
+		e.Timestamp = parseTime(ts)
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
 // EventsSince returns events with ID greater than lastID, ordered oldest-first.
 // Used by the web SSE activity stream to deliver new events to connected
 // clients; the oldest-first ordering and id > lastID predicate make it trivial

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -3288,4 +3288,36 @@ func TestDB_RecentEventsMatching(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("escapes LIKE wildcards literally", func(t *testing.T) {
+		if err := db.LogEventAt(EventSmithDone, "100% done", "Forge-PCT1", "anvil-a", base.Add(300*time.Minute)); err != nil {
+			t.Fatalf("seed percent event: %v", err)
+		}
+		// "%" should NOT match everything — only the literal character.
+		results, err := db.RecentEventsMatching("%", 500, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 match for literal '%%', got %d", len(results))
+		}
+		if results[0].BeadID != "Forge-PCT1" {
+			t.Fatalf("unexpected match: %+v", results[0])
+		}
+
+		// "_" should NOT match any single character — only the literal underscore.
+		if err := db.LogEventAt(EventSmithDone, "under_score test", "Forge-US1", "anvil-a", base.Add(301*time.Minute)); err != nil {
+			t.Fatalf("seed underscore event: %v", err)
+		}
+		results, err = db.RecentEventsMatching("r_s", 500, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 match for literal 'r_s', got %d", len(results))
+		}
+		if results[0].BeadID != "Forge-US1" {
+			t.Fatalf("unexpected match: %+v", results[0])
+		}
+	})
 }

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -3183,3 +3183,109 @@ func TestDB_MarkResolved(t *testing.T) {
 		t.Error("expected resolved_at to be set after MarkResolved")
 	}
 }
+
+func TestDB_RecentEventsMatching(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-eventmatch-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Seed one old event that matches our filter, then bury it under far more
+	// than EventFetchLimit (100) newer, non-matching events. An in-memory
+	// filter over the most-recent ~100 rows would never see the old one.
+	if err := db.LogEventAt(EventBeadClaimed, "claimed Forge-OLD1", "Forge-OLD1", "anvil-a", base); err != nil {
+		t.Fatalf("seed old event: %v", err)
+	}
+	for i := 0; i < 150; i++ {
+		at := base.Add(time.Duration(i+1) * time.Minute)
+		if err := db.LogEventAt(EventSmithDone, "smith finished noise", fmt.Sprintf("Forge-N%03d", i), "anvil-a", at); err != nil {
+			t.Fatalf("seed noise event %d: %v", i, err)
+		}
+	}
+	// Excluded poll/poll_error rows that also contain the search term — they
+	// must never appear in results.
+	if err := db.LogEventAt(EventPoll, "poll Forge-OLD1", "Forge-OLD1", "anvil-a", base.Add(200*time.Minute)); err != nil {
+		t.Fatalf("seed poll event: %v", err)
+	}
+	if err := db.LogEventAt(EventPollError, "poll error forge-old1", "Forge-OLD1", "anvil-a", base.Add(201*time.Minute)); err != nil {
+		t.Fatalf("seed poll_error event: %v", err)
+	}
+
+	excluded := []EventType{EventPoll, EventPollError}
+
+	t.Run("matches an event older than the load window", func(t *testing.T) {
+		results, err := db.RecentEventsMatching("Forge-OLD1", 500, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected exactly 1 match, got %d", len(results))
+		}
+		if results[0].BeadID != "Forge-OLD1" || results[0].Type != EventBeadClaimed {
+			t.Fatalf("unexpected match: %+v", results[0])
+		}
+	})
+
+	t.Run("is case-insensitive", func(t *testing.T) {
+		results, err := db.RecentEventsMatching("forge-old1", 500, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected exactly 1 case-insensitive match, got %d", len(results))
+		}
+		if results[0].BeadID != "Forge-OLD1" {
+			t.Fatalf("unexpected match: %+v", results[0])
+		}
+	})
+
+	t.Run("excludes poll and poll_error types", func(t *testing.T) {
+		results, err := db.RecentEventsMatching("Forge-OLD1", 500, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		for _, e := range results {
+			if e.Type == EventPoll || e.Type == EventPollError {
+				t.Fatalf("excluded type leaked into results: %+v", e)
+			}
+		}
+	})
+
+	t.Run("enforces the result cap", func(t *testing.T) {
+		// "smith" matches all 150 noise events; the cap must bound the result.
+		results, err := db.RecentEventsMatching("smith", 25, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		if len(results) != 25 {
+			t.Fatalf("expected capped 25 results, got %d", len(results))
+		}
+		// Newest-first ordering: the most recent noise event should be first.
+		if results[0].BeadID != "Forge-N149" {
+			t.Fatalf("expected newest-first ordering, got first=%+v", results[0])
+		}
+	})
+
+	t.Run("empty pattern falls back to exclusion-only", func(t *testing.T) {
+		results, err := db.RecentEventsMatching("", 10, excluded)
+		if err != nil {
+			t.Fatalf("RecentEventsMatching: %v", err)
+		}
+		if len(results) != 10 {
+			t.Fatalf("expected 10 results for empty pattern, got %d", len(results))
+		}
+		for _, e := range results {
+			if e.Type == EventPoll || e.Type == EventPollError {
+				t.Fatalf("excluded type leaked into empty-pattern results: %+v", e)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Changes

- **Hearth event filter searches the whole log** - The Events panel filter now runs a DB-backed search across the entire event log instead of only the ~100 events loaded in memory, so filtering for an older bead or event id matches correctly. Results are capped at 500 to protect the TUI render. (Forge-1l1s)

## Original Issue (bug): Hearth 2.0: event filter should search the whole event log, not just the loaded ~100

In the Hearth 2.0 event log panel, applying a filter only searches the most recent events currently loaded in memory (max 100, fewer visible on screen). Events older than that window are never matched, so filtering for an older bead/event silently returns nothing even though it exists in the log. The filter should query the entire event log.

---
Bead: Forge-1l1s | Branch: forge/Forge-1l1s
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->