### PR TITLE
Forge: schematic-phase workers drop out of max_total_smiths count, allowing a 2nd Smith (Forge-n34d)

### DIFF
--- a/changelog.d/Forge-n34d.md
+++ b/changelog.d/Forge-n34d.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Schematic-phase workers now count against the dispatch cap** - A dispatched worker in the schematic pre-analysis phase no longer drops out of the `max_total_smiths`/`max_smiths` count, closing a window where a second Smith could be dispatched concurrently. (Forge-n34d)

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -671,9 +671,9 @@ func (db *DB) ActiveWorkers() ([]Worker, error) {
 // All phases listed in backgroundPhases are excluded from the global check
 // because they only produce log output when external state changes (e.g. PR
 // events) and can be legitimately silent for long stretches. However,
-// lifecycle workers (quench/burnish/rebase/assay) that were registered with a
-// per-worker StaleTimeout are additionally checked using that shorter
-// threshold — these phases appear in backgroundPhases and are therefore
+// lifecycle workers (quench/cifix/burnish/reviewfix/rebase/assay) that were
+// registered with a per-worker StaleTimeout are additionally checked using that
+// shorter threshold — these phases appear in backgroundPhases and are therefore
 // absent from the first result set, so there is no risk of duplicates.
 func (db *DB) StalledWorkers(staleThreshold time.Duration) ([]Worker, error) {
 	if staleThreshold <= 0 {
@@ -782,8 +782,8 @@ func (db *DB) MarkWorkerStalled(id string) error {
 }
 
 // ActiveDispatchWorkers returns active workers that are running primary dispatch
-// pipeline phases (schematic, smith, temper, warden). Bellows (PR monitoring) and lifecycle
-// workers (quench, burnish, rebase, assay) are excluded so they don't consume dispatch capacity slots.
+// pipeline phases (schematic, smith, temper, warden). All phases in backgroundPhases
+// are excluded so they don't consume dispatch capacity slots.
 // Stalled workers are included so they continue to count against capacity and
 // prevent the daemon from over-subscribing while stalled processes are still running.
 func (db *DB) ActiveDispatchWorkers() ([]Worker, error) {
@@ -794,7 +794,7 @@ func (db *DB) ActiveDispatchWorkers() ([]Worker, error) {
 }
 
 // ActiveDispatchWorkersByAnvil returns active dispatch workers for a given anvil,
-// excluding bellows and lifecycle workers (quench, burnish, rebase, assay).
+// excluding all phases in backgroundPhases.
 // Stalled workers are included so they continue to count against per-anvil capacity.
 func (db *DB) ActiveDispatchWorkersByAnvil(anvil string) ([]Worker, error) {
 	return db.queryWorkers(`SELECT id, bead_id, anvil, branch, pid, status, phase, title, pr_number, started_at, completed_at, log_path

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -544,10 +544,18 @@ const (
 //     depupdate [legacy], etc.) that do not represent active Smith work and
 //     should not block dispatch capacity or be treated as stale.
 //
+// Note: 'schematic' is deliberately NOT listed here. Schematic is a pre-analysis
+// phase that runs on the dispatched (claimed) worker before Smith, so it is part
+// of the dispatch pipeline and must keep counting against the dispatch cap —
+// otherwise a worker in the schematic phase becomes invisible to the
+// max_total_smiths check, opening a window for a second concurrent Smith. It is
+// also an active Claude session that produces log output, so subjecting it to
+// the global stale check is correct.
+//
 // Note: depupdate is retained here only for backward compatibility with
 // historical DB rows; there is no active depupdate worker flow anymore.
 // Update this constant when new background or synthetic phases are added.
-const backgroundPhases = "'bellows', 'quench', 'cifix', 'burnish', 'reviewfix', 'rebase', 'assay', 'crucible', 'schematic', 'warden_rerun', 'approve_as_is', 'force_smith', 'smelter', 'depupdate'"
+const backgroundPhases = "'bellows', 'quench', 'cifix', 'burnish', 'reviewfix', 'rebase', 'assay', 'crucible', 'warden_rerun', 'approve_as_is', 'force_smith', 'smelter', 'depupdate'"
 
 // Worker represents a Smith worker entry.
 type Worker struct {
@@ -774,7 +782,7 @@ func (db *DB) MarkWorkerStalled(id string) error {
 }
 
 // ActiveDispatchWorkers returns active workers that are running primary dispatch
-// pipeline phases (smith, temper, warden). Bellows (PR monitoring) and lifecycle
+// pipeline phases (schematic, smith, temper, warden). Bellows (PR monitoring) and lifecycle
 // workers (quench, burnish, rebase, assay) are excluded so they don't consume dispatch capacity slots.
 // Stalled workers are included so they continue to count against capacity and
 // prevent the daemon from over-subscribing while stalled processes are still running.

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -3321,3 +3321,63 @@ func TestDB_RecentEventsMatching(t *testing.T) {
 		}
 	})
 }
+
+// TestDB_ActiveDispatchWorkers_CountsSchematic is a regression test for the bug
+// where a dispatched worker in the 'schematic' pre-analysis phase dropped out of
+// the dispatch capacity count, allowing a second Smith to be dispatched while the
+// max_total_smiths cap was 1. Schematic runs on the claimed worker before Smith,
+// so it must keep counting against the dispatch cap.
+func TestDB_ActiveDispatchWorkers_CountsSchematic(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-state-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// A worker that has entered the schematic pre-analysis phase.
+	if err := db.InsertWorker(&Worker{
+		ID: "w-schematic", BeadID: "BD-1", Anvil: "anvil-1",
+		Status: WorkerRunning, Phase: "schematic",
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// A bellows (background) worker that must NOT count against the dispatch cap.
+	if err := db.InsertWorker(&Worker{
+		ID: "w-bellows", BeadID: "BD-2", Anvil: "anvil-1",
+		Status: WorkerMonitoring, Phase: "bellows",
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Global dispatch count must include the schematic worker.
+	dispatch, err := db.ActiveDispatchWorkers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dispatch) != 1 {
+		t.Fatalf("expected 1 dispatch worker (schematic), got %d: %+v", len(dispatch), dispatch)
+	}
+	if dispatch[0].ID != "w-schematic" {
+		t.Errorf("expected w-schematic to count against dispatch cap, got %s", dispatch[0].ID)
+	}
+
+	// Per-anvil dispatch count must also include the schematic worker so a second
+	// dispatch is blocked when max_smiths/max_total_smiths is 1.
+	byAnvil, err := db.ActiveDispatchWorkersByAnvil("anvil-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byAnvil) != 1 {
+		t.Fatalf("expected 1 per-anvil dispatch worker (schematic), got %d: %+v", len(byAnvil), byAnvil)
+	}
+	if byAnvil[0].ID != "w-schematic" {
+		t.Errorf("expected w-schematic in per-anvil dispatch count, got %s", byAnvil[0].ID)
+	}
+}


### PR DESCRIPTION
## Changes

- **Schematic-phase workers now count against the dispatch cap** - A dispatched worker in the schematic pre-analysis phase no longer drops out of the `max_total_smiths`/`max_smiths` count, closing a window where a second Smith could be dispatched concurrently. (Forge-n34d)

## Original Issue (bug): Forge: schematic-phase workers drop out of max_total_smiths count, allowing a 2nd Smith

With max_total_smiths=1 and schematic_enabled=true, two Smith sessions can run at once. When a dispatched worker enters the schematic pre-analysis phase, its phase is set to 'schematic', which is in backgroundPhases — so it stops counting against the global dispatch cap. A later poll then sees globalActive==0 and dispatches a second bead as a Smith. The first worker transitions schematic→smith and now two Smiths run concurrently. Only happens when there's a queue of ready beads and schematic is enabled.

---
Bead: Forge-n34d | Branch: forge/Forge-n34d
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->