### PR TITLE
Shared transient/permanent error classifier in vcs/github (Forge-sha2)

### DIFF
--- a/changelog.d/Forge-sha2.md
+++ b/changelog.d/Forge-sha2.md
@@ -1,0 +1,2 @@
+category: Added
+- **Shared GitHub transient/permanent error classifier** - Added `IsTransient`, `Classify`, `ShouldRetry`, and the `TransientError` type to `internal/vcs/github`, giving CreatePR-retry and Bellows a single place to decide which gh/GitHub errors are worth retrying (401, rate-limited 403, 5xx, network/EOF/timeout, GraphQL "Requires authentication") versus surfaced immediately (422 validation, branch-protection refusals, 404). Retries are bounded by `MaxTransientAttempts` so over-classification can't loop forever. (Forge-sha2)

--- a/internal/vcs/github/errors.go
+++ b/internal/vcs/github/errors.go
@@ -1,0 +1,207 @@
+package github
+
+import (
+	"errors"
+	"io"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// MaxTransientAttempts bounds how many times a transient error may be retried.
+// It is the load-bearing safety net so that over-classification (an error
+// mistakenly treated as transient) can never retry forever. Consumers such as
+// the CreatePR-retry and Bellows sub-tasks pair IsTransient with this bound via
+// ShouldRetry.
+const MaxTransientAttempts = 4
+
+// TransientError wraps an error that classification has judged to be transient
+// — i.e. likely to succeed on retry (rate limits, transient auth, 5xx, network
+// blips). Callers can detect it with errors.As or, more conveniently, with
+// IsTransient. The original error remains reachable via Unwrap.
+type TransientError struct {
+	err error
+}
+
+// Error implements the error interface, delegating to the wrapped error.
+func (e *TransientError) Error() string {
+	if e == nil || e.err == nil {
+		return "transient error"
+	}
+	return e.err.Error()
+}
+
+// Unwrap returns the wrapped error so errors.Is/errors.As keep working through
+// the transient marker.
+func (e *TransientError) Unwrap() error { return e.err }
+
+// Classify inspects err and, when it is judged transient, returns it wrapped in
+// a *TransientError so callers can fail-fast on permanent errors and retry on
+// transient ones. Permanent (and nil) errors are returned unchanged.
+//
+// This is the single shared classification point for the vcs/github package:
+// both the CreatePR-retry loop and the Bellows PR monitor route gh/GitHub
+// errors through it instead of re-implementing ad-hoc string matching.
+func Classify(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isTransient(err) {
+		// Avoid double-wrapping if it's already classified transient.
+		var t *TransientError
+		if errors.As(err, &t) {
+			return err
+		}
+		return &TransientError{err: err}
+	}
+	return err
+}
+
+// IsTransient reports whether err is a transient GitHub/gh failure that is
+// worth retrying. It is the load-bearing predicate consumed by the
+// CreatePR-retry and Bellows sub-tasks.
+//
+// Transient classes:
+//   - HTTP 401 (transient auth — token momentarily not accepted)
+//   - HTTP 403 carrying rate-limit / secondary-rate-limit / abuse signals
+//   - any HTTP 5xx
+//   - network failures: dial/timeout/EOF/connection-reset/i-o-timeout, plus
+//     net.Error timeouts and io.EOF
+//   - the literal GraphQL "Requires authentication" error
+//
+// Everything else — including unrecognised errors — is treated as PERMANENT so
+// that misclassification can never cause an unbounded retry loop. Permanent
+// classes explicitly include HTTP 422 validation errors ("No commits between",
+// "a pull request already exists"), branch-protection refusals, and HTTP 404.
+func IsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	// An already-classified transient error stays transient.
+	var t *TransientError
+	if errors.As(err, &t) {
+		return true
+	}
+	return isTransient(err)
+}
+
+// ShouldRetry returns true only when err is transient AND the caller has not
+// yet exhausted MaxTransientAttempts. attempt is the zero-based count of
+// attempts already made (i.e. pass 0 before the first retry). This is the
+// bounded primitive that guarantees over-classification can't retry forever;
+// the actual backoff/sleep loop lives in the consuming sub-tasks.
+func ShouldRetry(err error, attempt int) bool {
+	return IsTransient(err) && attempt < MaxTransientAttempts
+}
+
+// isTransient holds the raw classification logic, free of the TransientError
+// short-circuits in IsTransient/Classify.
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Typed network errors first — these are unambiguous.
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	// Permanent classes win over transient string heuristics: a 422/404 or a
+	// branch-protection refusal must fail fast even if the surrounding text
+	// happens to mention something that looks transient.
+	if isPermanentMessage(msg) {
+		return false
+	}
+
+	// HTTP status code driven classification.
+	if code, ok := statusCode(msg); ok {
+		switch {
+		case code == 401:
+			return true
+		case code == 403:
+			return messageContains(msg, "rate limit", "secondary rate limit", "abuse")
+		case code >= 500 && code <= 599:
+			return true
+		case code == 404 || code == 422:
+			return false
+		}
+	}
+
+	// GraphQL literal that surfaces without a numeric status code.
+	if strings.Contains(msg, "requires authentication") {
+		return true
+	}
+
+	// Network failures expressed as plain strings (wrapped exec/gh output).
+	if messageContains(msg,
+		"dial ",
+		"i/o timeout",
+		"timeout",
+		"connection reset",
+		"connection refused",
+		"no such host",
+		"network is unreachable",
+		"eof",
+		"tls handshake",
+		"unexpected eof",
+	) {
+		return true
+	}
+
+	// Unknown/unrecognised: treat as permanent so retries are always bounded.
+	return false
+}
+
+// isPermanentMessage matches errors that must fail fast regardless of any HTTP
+// status code: 422 validation outcomes, branch-protection refusals, and the
+// "already exists" PR conflict.
+func isPermanentMessage(msg string) bool {
+	return messageContains(msg,
+		"no commits between",
+		"a pull request already exists",
+		"pull request already exists",
+		"already exists for branch",
+		"protected branch",
+		"branch protection",
+		"required status check",
+		"changes must be made through a pull request",
+		"review is required by reviewers with write access",
+		"not authorized to push",
+	)
+}
+
+// statusCodeRe matches a GitHub/gh HTTP status code in error text, e.g.
+// "HTTP 403", "(HTTP 422)", "status: 500", or "status code 502".
+var statusCodeRe = regexp.MustCompile(`(?:http|status(?:\s+code)?)[\s:]+(\d{3})`)
+
+// statusCode extracts an HTTP status code from a (lower-cased) error message.
+// The second return value is false when no status code can be found.
+func statusCode(msg string) (int, bool) {
+	m := statusCodeRe.FindStringSubmatch(msg)
+	if len(m) < 2 {
+		return 0, false
+	}
+	code, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return code, true
+}
+
+// messageContains reports whether msg contains any of the given substrings.
+// msg is expected to already be lower-cased; needles must be lower-case.
+func messageContains(msg string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(msg, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vcs/github/errors.go
+++ b/internal/vcs/github/errors.go
@@ -66,7 +66,7 @@ func Classify(err error) error {
 //   - HTTP 401 (transient auth — token momentarily not accepted)
 //   - HTTP 403 carrying rate-limit / secondary-rate-limit / abuse signals
 //   - any HTTP 5xx
-//   - network failures: dial/timeout/EOF/connection-reset/i-o-timeout, plus
+//   - network failures: dial/timeout/EOF/connection-reset/i/o timeout, plus
 //     net.Error timeouts and io.EOF
 //   - the literal GraphQL "Requires authentication" error
 //
@@ -92,7 +92,7 @@ func IsTransient(err error) bool {
 // bounded primitive that guarantees over-classification can't retry forever;
 // the actual backoff/sleep loop lives in the consuming sub-tasks.
 func ShouldRetry(err error, attempt int) bool {
-	return IsTransient(err) && attempt < MaxTransientAttempts
+	return attempt >= 0 && IsTransient(err) && attempt < MaxTransientAttempts
 }
 
 // isTransient holds the raw classification logic, free of the TransientError
@@ -144,6 +144,7 @@ func isTransient(err error) bool {
 		"dial ",
 		"i/o timeout",
 		"timeout",
+		"context deadline exceeded",
 		"connection reset",
 		"connection refused",
 		"no such host",

--- a/internal/vcs/github/errors_test.go
+++ b/internal/vcs/github/errors_test.go
@@ -46,6 +46,7 @@ func TestIsTransient(t *testing.T) {
 		{"io.EOF wrapped", fmt.Errorf("gh api graphql: %w", io.EOF), true},
 		{"net.Error timeout", timeoutError{}, true},
 		{"net.Error wrapped timeout", fmt.Errorf("request failed: %w", timeoutError{}), true},
+		{"context deadline exceeded", errors.New("context deadline exceeded"), true},
 		{"graphql requires authentication", errors.New("GraphQL: Requires authentication (repository.pullRequest)"), true},
 
 		// --- Permanent (criterion 2: surfaces immediately) ---
@@ -64,7 +65,7 @@ func TestIsTransient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.transient, IsTransient(tt.err),
-				"IsTransient mismatch for %q", tt.err)
+				"IsTransient mismatch for %v", tt.err)
 		})
 	}
 }
@@ -118,6 +119,10 @@ func TestShouldRetry(t *testing.T) {
 		// At or beyond the bound, even a transient error must stop retrying.
 		assert.False(t, ShouldRetry(transient, MaxTransientAttempts))
 		assert.False(t, ShouldRetry(transient, MaxTransientAttempts+10))
+	})
+
+	t.Run("negative attempt is not retried", func(t *testing.T) {
+		assert.False(t, ShouldRetry(transient, -1))
 	})
 
 	t.Run("permanent never retried", func(t *testing.T) {

--- a/internal/vcs/github/errors_test.go
+++ b/internal/vcs/github/errors_test.go
@@ -1,0 +1,140 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// timeoutError is a net.Error whose Timeout() reports true, used to exercise the
+// typed network-error branch of the classifier.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "operation timed out" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+// nonTimeoutNetError is a net.Error whose Timeout() reports false.
+type nonTimeoutNetError struct{}
+
+func (nonTimeoutNetError) Error() string   { return "some net problem" }
+func (nonTimeoutNetError) Timeout() bool   { return false }
+func (nonTimeoutNetError) Temporary() bool { return false }
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		// --- Transient (criterion 1: retried) ---
+		{"http 401", errors.New("gh pr create failed: HTTP 401: Bad credentials"), true},
+		{"403 rate limit", errors.New("HTTP 403: API rate limit exceeded"), true},
+		{"403 secondary rate limit", errors.New("HTTP 403: You have exceeded a secondary rate limit"), true},
+		{"403 abuse", errors.New("HTTP 403: You have triggered an abuse detection mechanism"), true},
+		{"500", errors.New("HTTP 500: Internal Server Error"), true},
+		{"502", errors.New("gh api graphql: HTTP 502: Bad Gateway"), true},
+		{"503", errors.New("status: 503 service unavailable"), true},
+		{"dial error", errors.New("dial tcp 140.82.121.6:443: connect: connection refused"), true},
+		{"i/o timeout string", errors.New("read tcp: i/o timeout"), true},
+		{"connection reset", errors.New("read: connection reset by peer"), true},
+		{"eof string", errors.New("unexpected EOF while reading"), true},
+		{"io.EOF wrapped", fmt.Errorf("gh api graphql: %w", io.EOF), true},
+		{"net.Error timeout", timeoutError{}, true},
+		{"net.Error wrapped timeout", fmt.Errorf("request failed: %w", timeoutError{}), true},
+		{"graphql requires authentication", errors.New("GraphQL: Requires authentication (repository.pullRequest)"), true},
+
+		// --- Permanent (criterion 2: surfaces immediately) ---
+		{"422 no commits between", errors.New("HTTP 422: No commits between main and feature"), false},
+		{"422 pr already exists", errors.New("HTTP 422: A pull request already exists for branch"), false},
+		{"already exists for branch", errors.New("gh pr create: pull request already exists for branch foo"), false},
+		{"branch protection", errors.New("HTTP 422: Changes must be made through a pull request (protected branch)"), false},
+		{"required status check", errors.New("HTTP 422: Required status check \"build\" is expected"), false},
+		{"404", errors.New("HTTP 404: Not Found"), false},
+		{"403 plain forbidden (no rate signal)", errors.New("HTTP 403: Resource not accessible by integration"), false},
+		{"unknown error", errors.New("something unexpected happened"), false},
+		{"non-timeout net error", nonTimeoutNetError{}, false},
+		{"nil", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.transient, IsTransient(tt.err),
+				"IsTransient mismatch for %q", tt.err)
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	t.Run("transient error is wrapped", func(t *testing.T) {
+		orig := errors.New("HTTP 403: secondary rate limit hit")
+		got := Classify(orig)
+
+		var te *TransientError
+		assert.True(t, errors.As(got, &te), "expected *TransientError")
+		assert.True(t, IsTransient(got))
+		assert.ErrorIs(t, got, orig, "wrapped error must remain reachable via Unwrap")
+		assert.Equal(t, orig.Error(), got.Error(), "Error() delegates to wrapped error")
+	})
+
+	t.Run("permanent error is returned unchanged", func(t *testing.T) {
+		orig := errors.New("HTTP 422: No commits between main and feature")
+		got := Classify(orig)
+
+		var te *TransientError
+		assert.False(t, errors.As(got, &te), "permanent error must not be wrapped")
+		assert.Same(t, orig, got)
+		assert.False(t, IsTransient(got))
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		assert.Nil(t, Classify(nil))
+	})
+
+	t.Run("already-classified transient is not double-wrapped", func(t *testing.T) {
+		orig := errors.New("HTTP 500")
+		once := Classify(orig)
+		twice := Classify(once)
+		assert.Same(t, once, twice, "Classify must be idempotent for transient errors")
+	})
+}
+
+func TestShouldRetry(t *testing.T) {
+	transient := errors.New("HTTP 503 service unavailable")
+	permanent := errors.New("HTTP 404 not found")
+
+	t.Run("transient retried while under the bound", func(t *testing.T) {
+		for attempt := 0; attempt < MaxTransientAttempts; attempt++ {
+			assert.True(t, ShouldRetry(transient, attempt),
+				"attempt %d should be retried", attempt)
+		}
+	})
+
+	t.Run("over-classification can't retry forever", func(t *testing.T) {
+		// At or beyond the bound, even a transient error must stop retrying.
+		assert.False(t, ShouldRetry(transient, MaxTransientAttempts))
+		assert.False(t, ShouldRetry(transient, MaxTransientAttempts+10))
+	})
+
+	t.Run("permanent never retried", func(t *testing.T) {
+		assert.False(t, ShouldRetry(permanent, 0))
+	})
+}
+
+func TestTransientErrorUnwrap(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	te := &TransientError{err: fmt.Errorf("wrapped: %w", sentinel)}
+	assert.ErrorIs(t, te, sentinel)
+	assert.Equal(t, "wrapped: sentinel", te.Error())
+}
+
+// Ensure the concrete net.Error fixtures actually satisfy the interface so the
+// classifier's errors.As branch is genuinely exercised.
+var (
+	_ net.Error = timeoutError{}
+	_ net.Error = nonTimeoutNetError{}
+)


### PR DESCRIPTION
## Changes

- **Shared GitHub transient/permanent error classifier** - Added `IsTransient`, `Classify`, `ShouldRetry`, and the `TransientError` type to `internal/vcs/github`, giving CreatePR-retry and Bellows a single place to decide which gh/GitHub errors are worth retrying (401, rate-limited 403, 5xx, network/EOF/timeout, GraphQL "Requires authentication") versus surfaced immediately (422 validation, branch-protection refusals, 404). Retries are bounded by `MaxTransientAttempts` so over-classification can't loop forever. (Forge-sha2)

## Original Issue (task): Shared transient/permanent error classifier in vcs/github

Modify `internal/vcs/github` to add a single shared error classification: map GitHub/gh errors to a Transient bool or typed error (e.g. `type TransientError struct{ error }` plus `func IsTransient(err error) bool`). Transient = HTTP 401, 403 with rate-limit/secondary-rate-limit/abuse signals, 5xx, network/dial/timeout/EOF, and the literal 'Requires authentication' GraphQL error. Permanent (fail fast, no retry) = 422 validation ('No commits between', PR already exists), branch-protection refusals, 404. Bound the attempts so over-classification can't retry forever. This is the load-bearing primitive consumed by the CreatePR-retry sub-task and the bellows sub-task — must land first. Unit-test the classifier against each error class. Acceptance ties: criterion (1) transient retried, (2) permanent surfaces immediately.

---
Bead: Forge-sha2 | Branch: forge/Forge-sha2
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->