### PR TITLE
pr_create_failed state + openPRForExistingBranch helper + IPC/CLI (Parts B & D) (Forge-m9cw)

### DIFF
--- a/changelog.d/Forge-m9cw.md
+++ b/changelog.d/Forge-m9cw.md
@@ -1,0 +1,2 @@
+category: Added
+- **Manual create-PR-from-existing-branch recovery** - When PR creation fails after transient retries, the pushed branch, head SHA, and classified error are now recorded on the ingot as `pr_create_failed`. Recover with `forge queue create-pr <id> --anvil <name>`, which opens a PR for the already-pushed `forge/<bead>` branch without re-running Smith (preconditions: branch exists, is ahead of base, has no open PR, and carries the bead's changelog fragment), then clears the needs-attention flag. (Forge-m9cw)

--- a/cmd/forge/queue.go
+++ b/cmd/forge/queue.go
@@ -28,12 +28,15 @@ func init() {
 	queueStopCmd.Flags().StringP("reason", "r", "", "Why the bead is being stopped (optional)")
 	queueClearCmd.Flags().StringP("anvil", "a", "", "Anvil name (required)")
 	_ = queueClearCmd.MarkFlagRequired("anvil")
+	queueCreatePRCmd.Flags().StringP("anvil", "a", "", "Anvil name (required)")
+	_ = queueCreatePRCmd.MarkFlagRequired("anvil")
 	queueCmd.AddCommand(queueRunCmd)
 	queueCmd.AddCommand(queueClarifyCmd)
 	queueCmd.AddCommand(queueUnclarifyCmd)
 	queueCmd.AddCommand(queueRetryCmd)
 	queueCmd.AddCommand(queueStopCmd)
 	queueCmd.AddCommand(queueClearCmd)
+	queueCmd.AddCommand(queueCreatePRCmd)
 	rootCmd.AddCommand(queueCmd)
 }
 
@@ -327,6 +330,69 @@ The bead will not be dispatched again until you run 'forge queue unclarify'.`,
 		}
 
 		fmt.Printf("Bead %s stopped — use 'forge queue unclarify --anvil %s %s' to resume\n", beadID, anvil, beadID)
+		return nil
+	},
+}
+
+var queueCreatePRCmd = &cobra.Command{
+	Use:   "create-pr <id>",
+	Short: "Open a PR for an already-pushed forge branch without re-running Smith",
+	Long: `Recover a bead whose branch was pushed but for which PR creation failed.
+
+This opens a pull request for the existing forge/<bead> branch on origin without
+re-running Smith. It requires that:
+  1. origin/forge/<bead> exists and is ahead of the base branch
+  2. no open PR already targets the branch
+  3. the branch tip carries the bead's changelog fragment (completion signal)
+
+On success the needs-attention flag is cleared and bellows takes over the PR.
+On failure the gh error is surfaced and the bead stays in needs-attention.`,
+	Args:    cobra.ExactArgs(1),
+	Example: "  forge queue create-pr BD-42 --anvil heimdall",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		beadID := args[0]
+		anvil, _ := cmd.Flags().GetString("anvil")
+
+		client, err := ipc.NewClient()
+		if err != nil {
+			return fmt.Errorf("connecting to daemon: %w (is 'forge up' running?)", err)
+		}
+		defer client.Close()
+
+		payload, _ := json.Marshal(ipc.CreatePRPayload{
+			BeadID: beadID,
+			Anvil:  anvil,
+		})
+
+		// PR creation shells out to gh (and bd/git for preconditions), so allow
+		// the longer bd-backed read timeout.
+		resp, err := client.Send(ipc.Command{
+			Type:        "create_pr",
+			Payload:     payload,
+			ReadTimeout: ipc.BdBackedReadTimeout,
+		})
+		if err != nil {
+			return fmt.Errorf("sending command: %w", err)
+		}
+
+		if resp.Type == "error" {
+			var msg map[string]string
+			var errMsg string
+			if err := json.Unmarshal(resp.Payload, &msg); err == nil && msg["message"] != "" {
+				errMsg = msg["message"]
+			} else if len(resp.Payload) > 0 {
+				errMsg = string(resp.Payload)
+			} else {
+				errMsg = "unknown error from daemon"
+			}
+			return fmt.Errorf("daemon error: %s", errMsg)
+		}
+
+		var result map[string]string
+		if err := json.Unmarshal(resp.Payload, &result); err != nil {
+			return fmt.Errorf("failed to unmarshal daemon response: %w", err)
+		}
+		fmt.Printf("Created PR for bead %s: %s\n", beadID, result["message"])
 		return nil
 	},
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3947,6 +3947,8 @@ func (d *Daemon) openPRForExistingBranch(ctx context.Context, beadID, anvilName 
 	} else if pr != nil {
 		d.registerPRIfUntracked(ctx, anvilName, registerID, pr, bead.EpicBranch)
 		d.clearNeedsHumanAfterRecovery(beadID, anvilName)
+		d.ingotRecordPR(beadID, anvilName, pr.Number, "")
+		d.ingotClearPRCreateError(beadID, anvilName)
 		_ = d.db.LogEvent(state.EventPRCreateRecovered,
 			fmt.Sprintf("create-pr: %s already has open PR #%d; registered and cleared needs_human", branch, pr.Number),
 			beadID, anvilName)
@@ -3981,6 +3983,10 @@ func (d *Daemon) openPRForExistingBranch(ctx context.Context, beadID, anvilName 
 			// the existing PR and treat as recovered.
 			n := d.registerExistingPRByBranch(prCtx, anvilName, anvilPath, registerID, branch, bead.EpicBranch)
 			d.clearNeedsHumanAfterRecovery(beadID, anvilName)
+			if n > 0 {
+				d.ingotRecordPR(beadID, anvilName, n, "")
+				d.ingotClearPRCreateError(beadID, anvilName)
+			}
 			_ = d.db.LogEvent(state.EventPRCreateRecovered,
 				fmt.Sprintf("create-pr: PR already existed for %s on create; registered #%d and cleared needs_human", branch, n),
 				beadID, anvilName)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -273,6 +273,11 @@ type Daemon struct {
 	// Defaults to exec.Command; may be replaced in tests.
 	beadShower func(anvilPath, beadID string) (stdout []byte, stderr string, err error)
 
+	// beadFetcher fetches a full bead by ID (via `bd show`) for the manual
+	// create-PR-from-existing-branch recovery. Defaults to crucible.FetchBead;
+	// may be replaced in tests to avoid a real bd invocation.
+	beadFetcher func(ctx context.Context, beadID, dir string) (poller.Bead, error)
+
 	// parentCloser closes a bead with --force. Defaults to exec.Command;
 	// may be replaced in tests.
 	parentCloser func(anvilPath, beadID, reason string) error
@@ -371,15 +376,15 @@ func New(cfg *config.Config) (*Daemon, error) {
 	vcsProviders := buildVCSProviders(cfg, db, logger)
 
 	d := &Daemon{
-		db:            db,
-		logger:        logger,
-		forgeDir:      forgeDir,
-		pidFile:       filepath.Join(forgeDir, PIDFileName),
-		configFile:    config.ConfigFilePath(""),
-		logFile:       logFile,
-		shutdownMgr:   shutdown.NewManager(db, wtMgr, logger, anvilPathMap(cfg)),
-		worktreeMgr:   wtMgr,
-		promptBuilder: prompt.NewBuilder(),
+		db:                    db,
+		logger:                logger,
+		forgeDir:              forgeDir,
+		pidFile:               filepath.Join(forgeDir, PIDFileName),
+		configFile:            config.ConfigFilePath(""),
+		logFile:               logFile,
+		shutdownMgr:           shutdown.NewManager(db, wtMgr, logger, anvilPathMap(cfg)),
+		worktreeMgr:           wtMgr,
+		promptBuilder:         prompt.NewBuilder(),
 		vcsProviders:          vcsProviders,
 		reqTracker:            *ipc.NewRequestTracker("forge-"),
 		crucibleTickerResetCh: make(chan struct{}, 1),
@@ -466,6 +471,7 @@ func New(cfg *config.Config) (*Daemon, error) {
 		out, err := cmd.Output()
 		return out, stderrBuf.String(), err
 	}
+	d.beadFetcher = crucible.FetchBead
 	d.parentCloser = func(anvilPath, beadID, reason string) error {
 		// Use context.Background() so the bd close call succeeds even during
 		// graceful shutdown (d.runCtx may already be cancelled at that point).
@@ -580,6 +586,52 @@ func (d *Daemon) ingotRecordPR(beadID, anvil string, prNumber int, prURL string)
 	}
 	if err := ingot.UpdateIngotStatus(conn, beadID, anvil, ingot.StatusPROpen); err != nil {
 		d.logger.Warn("ingot status update to pr_open failed", "bead", beadID, "error", err)
+	}
+}
+
+// ingotRecordPRCreateFailed is a best-effort helper that records a failed PR
+// creation on an ingot: it persists the pushed branch, head SHA, and classified
+// error and transitions the ingot to pr_create_failed so an operator can recover
+// the branch via `forge queue create-pr` without re-running Smith.
+func (d *Daemon) ingotRecordPRCreateFailed(beadID, anvil, branch, headSHA, classifiedErr string) {
+	if conn := d.db.Conn(); conn != nil {
+		if err := ingot.UpdateIngotPRCreateFailed(conn, beadID, anvil, branch, headSHA, classifiedErr); err != nil {
+			d.logger.Warn("ingot pr_create_failed update failed", "bead", beadID, "error", err)
+		}
+	}
+}
+
+// ingotClearPRCreateError is a best-effort helper that clears a previously
+// recorded PR-creation error on an ingot. It is called on the recovery path so a
+// successfully reopened PR no longer surfaces a stale failure.
+func (d *Daemon) ingotClearPRCreateError(beadID, anvil string) {
+	if conn := d.db.Conn(); conn != nil {
+		if err := ingot.ClearIngotPRCreateError(conn, beadID, anvil); err != nil {
+			d.logger.Warn("ingot pr_create_error clear failed", "bead", beadID, "error", err)
+		}
+	}
+}
+
+// buildPRCreateParams constructs the vcs.CreateParams shared by every PR-creation
+// path (end-of-pipeline finalize, stranded-branch auto-recovery, and the manual
+// create-PR-from-existing-branch primitive). Centralising it here keeps the PR
+// title/body inputs identical across paths so they cannot drift. changeSummary
+// and reviewerNotes are the author-written and reviewer-written body sections;
+// pass "" for either when not available (the provider generates a default body).
+func (d *Daemon) buildPRCreateParams(bead poller.Bead, worktreePath, branch, changeSummary, reviewerNotes, externalRef string) vcs.CreateParams {
+	return vcs.CreateParams{
+		WorktreePath:    worktreePath,
+		BeadID:          bead.ID,
+		Title:           fmt.Sprintf("%s (%s)", bead.Title, bead.ID),
+		Branch:          branch,
+		Base:            bead.EpicBranch, // empty = use provider default base
+		AnvilName:       bead.Anvil,
+		BeadTitle:       bead.Title,
+		BeadDescription: bead.Description,
+		BeadType:        bead.IssueType,
+		ChangeSummary:   changeSummary,
+		ReviewerNotes:   reviewerNotes,
+		ExternalRef:     externalRef,
 	}
 }
 
@@ -1585,17 +1637,17 @@ func (d *Daemon) handleLifecycleAction(ctx context.Context, req lifecycle.Action
 					}
 					if useBatch {
 						res = quench.BatchFix(workerCtx, quench.BatchFixParams{
-						WorktreePath:  wt.Path,
-						BeadID:        req.BeadID,
-						AnvilName:     req.Anvil,
-						PRNumber:      req.PRNumber,
-						Branch:        req.Branch,
-						DB:            d.db,
-						WorkerID:      workerID,
-						ExtraFlags:    cfg.Settings.ClaudeFlags,
-						Providers:     quenchProviders,
-						FailingChecks: failingChecks,
-						CILogs:        ciLogs,
+							WorktreePath:  wt.Path,
+							BeadID:        req.BeadID,
+							AnvilName:     req.Anvil,
+							PRNumber:      req.PRNumber,
+							Branch:        req.Branch,
+							DB:            d.db,
+							WorkerID:      workerID,
+							ExtraFlags:    cfg.Settings.ClaudeFlags,
+							Providers:     quenchProviders,
+							FailingChecks: failingChecks,
+							CILogs:        ciLogs,
 						})
 					}
 				}
@@ -2994,8 +3046,8 @@ normalPipeline:
 		ExtraFlags:      cfg.Settings.ClaudeFlags,
 		TemperConfig:    d.resolveTemperConfig(anvilCfg),
 		GoRaceDetection: d.resolveGoRaceDetection(anvilCfg),
-		Providers: d.filterCopilotIfLimited(provider.FromConfig(config.ProvidersForStageWithAnvil(cfg.Settings, &anvilCfg, "smith"))),
-		Notifier:  d.notifier.Load(),
+		Providers:       d.filterCopilotIfLimited(provider.FromConfig(config.ProvidersForStageWithAnvil(cfg.Settings, &anvilCfg, "smith"))),
+		Notifier:        d.notifier.Load(),
 		BaseBranch:      bead.EpicBranch,
 		WorkerID:        claimWorkerID,
 		MaxIterations:   cfg.Settings.MaxPipelineIterations,
@@ -3215,20 +3267,8 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 		},
 		func() error {
 			var e error
-			pr, e = d.vcsForAnvil(bead.Anvil).CreatePR(ctx, vcs.CreateParams{
-				WorktreePath:    anvilPath,
-				BeadID:          bead.ID,
-				Title:           fmt.Sprintf("%s (%s)", bead.Title, bead.ID),
-				Branch:          outcome.Branch,
-				Base:            bead.EpicBranch, // empty = use provider default base
-				AnvilName:       bead.Anvil,
-				BeadTitle:       bead.Title,
-				BeadDescription: bead.Description,
-				BeadType:        bead.IssueType,
-				ChangeSummary:   changelogSummary,
-				ReviewerNotes:   reviewerNotes,
-				ExternalRef:     externalRef,
-			})
+			pr, e = d.vcsForAnvil(bead.Anvil).CreatePR(ctx,
+				d.buildPRCreateParams(bead, anvilPath, outcome.Branch, changelogSummary, reviewerNotes, externalRef))
 			return e
 		})
 	if err != nil {
@@ -3265,7 +3305,11 @@ func (d *Daemon) finalizePipeline(ctx context.Context, outcome *pipeline.Outcome
 		if dbErr := d.db.UpdateWorkerStatus(workerID, state.WorkerFailed); dbErr != nil {
 			d.logger.Error("failed to update worker status to failed", "worker", workerID, "error", dbErr)
 		}
-		d.ingotMarkFailed(bead.ID, bead.Anvil)
+		// Record the pushed branch, head SHA, and classified error on the ingot
+		// so an operator can recover via `forge queue create-pr <id> --anvil <name>`
+		// without re-running Smith. The work is committed and pushed; only the
+		// final PR open failed.
+		d.ingotRecordPRCreateFailed(bead.ID, bead.Anvil, outcome.Branch, d.localHeadSHA(ctx, anvilPath), err.Error())
 		return
 	}
 
@@ -3741,18 +3785,8 @@ func (d *Daemon) recoverStrandedBranchPR(ctx context.Context, bead poller.Bead, 
 		externalRef = d.fetchExternalRef(anvilPath, bead.ID)
 	}
 
-	pr, err := provider.CreatePR(prCtx, vcs.CreateParams{
-		WorktreePath:    anvilPath,
-		BeadID:          bead.ID,
-		Title:           fmt.Sprintf("%s (%s)", bead.Title, bead.ID),
-		Branch:          branch,
-		Base:            bead.EpicBranch, // empty = use provider default base
-		AnvilName:       bead.Anvil,
-		BeadTitle:       bead.Title,
-		BeadDescription: bead.Description,
-		BeadType:        bead.IssueType,
-		ExternalRef:     externalRef,
-	})
+	pr, err := provider.CreatePR(prCtx,
+		d.buildPRCreateParams(bead, anvilPath, branch, "", "", externalRef))
 	if err != nil {
 		if errors.Is(err, vcs.ErrPRAlreadyExists) {
 			// Lost a race with a concurrent open between the guard and the
@@ -3802,6 +3836,173 @@ func (d *Daemon) recoverStrandedBranchPR(ctx context.Context, bead poller.Bead, 
 		d.logger.Error("failed to clear retry record after stranded-branch recovery PR creation", "bead", bead.ID, "error", clearErr)
 	}
 	return true
+}
+
+// localHeadSHA returns the tip commit SHA of the given worktree (HEAD), or "" on
+// any error. It is a best-effort helper used to record the pushed head SHA when
+// PR creation fails — a missing SHA must never block the failure-recording path.
+func (d *Daemon) localHeadSHA(ctx context.Context, worktreePath string) string {
+	cmd := executil.HideWindow(exec.CommandContext(ctx, "git", "rev-parse", "HEAD"))
+	cmd.Dir = worktreePath
+	cmd.Env = cleanGitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// clearNeedsHumanAfterRecovery clears the needs_human escalation and the stale
+// ingot PR-creation error after a successful create-PR-from-existing-branch
+// recovery. Errors are logged but not surfaced — the recovery itself succeeded.
+func (d *Daemon) clearNeedsHumanAfterRecovery(beadID, anvil string) {
+	if err := d.db.ClearRetry(beadID, anvil); err != nil {
+		d.logger.Error("create-pr: failed to clear retry/needs_human after recovery", "bead", beadID, "anvil", anvil, "error", err)
+	}
+	d.ingotClearPRCreateError(beadID, anvil)
+}
+
+// openPRForExistingBranch opens a PR for an already-pushed forge branch WITHOUT
+// re-running Smith. It is the shared recovery primitive behind the manual
+// `forge queue create-pr <id> --anvil <name>` command (and, via the same IPC
+// path, the Hearth "Create PR" button). It reuses the pushed branch, its head
+// SHA, and the changelog fragment already committed to that branch, then builds
+// the same CreateParams the normal pipeline uses (so the PR body cannot drift)
+// and registers the resulting PR so bellows drives it to merge.
+//
+// Preconditions, each surfaced as a distinct error so an operator understands
+// why a recovery was refused:
+//   - origin/forge/<bead> exists,
+//   - it is ahead of the base branch (carries un-merged commits),
+//   - no open PR already targets it (an existing PR is registered and treated as
+//     a successful recovery rather than an error),
+//   - its tip carries the bead's changelog fragment (the per-PR completion
+//     signal Forge requires), proving the prior worker finished its work.
+//
+// On success it clears needs_human, logs EventPRCreateRecovered, and returns the
+// PR number. On failure it surfaces the gh error and leaves needs_human set so
+// the bead remains in the operator's needs-attention view.
+func (d *Daemon) openPRForExistingBranch(ctx context.Context, beadID, anvilName string) (int, error) {
+	if beadID == "" || anvilName == "" {
+		return 0, fmt.Errorf("bead_id and anvil are required")
+	}
+	anvilCfg, ok := d.cfg.Load().Anvils[anvilName]
+	if !ok {
+		return 0, fmt.Errorf("anvil %q not found", anvilName)
+	}
+	anvilPath := anvilCfg.Path
+	if anvilPath == "" {
+		return 0, fmt.Errorf("anvil %q has no path configured", anvilName)
+	}
+
+	branch := worktree.BranchName(beadID)
+	// The bead_id used to register the PR is derived from the branch so it stays
+	// consistent with the rest of the daemon's branch→bead recovery (ext-<number>
+	// fallback handled by registerPRIfUntracked when no forge branch maps back).
+	registerID := beadID
+	if derived, ok := worktree.BeadIDFromBranch(branch); ok {
+		registerID = derived
+	}
+
+	// Fetch bead metadata for the PR title/body. The worktree is typically gone
+	// by recovery time, so the bead is the only source for title/description.
+	fetchBead := d.beadFetcher
+	if fetchBead == nil {
+		fetchBead = crucible.FetchBead
+	}
+	bead, err := fetchBead(ctx, beadID, anvilPath)
+	if err != nil {
+		return 0, fmt.Errorf("bd show %s: %w", beadID, err)
+	}
+	bead.Anvil = anvilName
+
+	// Precondition: origin/<branch> exists and is ahead of base (stranded).
+	branchState, info, err := worktree.CheckRemoteBranchState(ctx, anvilPath, branch, bead.EpicBranch)
+	if err != nil {
+		return 0, fmt.Errorf("checking remote branch %s: %w", branch, err)
+	}
+	switch branchState {
+	case worktree.RemoteBranchAbsent:
+		return 0, fmt.Errorf("origin/%s does not exist; nothing to open a PR for", branch)
+	case worktree.RemoteBranchMerged:
+		return 0, fmt.Errorf("origin/%s is already merged into the base branch; nothing to open", branch)
+	}
+
+	provider := d.vcsForAnvil(anvilName)
+
+	// Precondition: no open PR already. If one exists, register it (idempotent)
+	// and treat this as a successful recovery — the goal state is reached.
+	if pr, perr := provider.GetPRByHeadBranch(ctx, anvilPath, branch); perr != nil {
+		return 0, fmt.Errorf("looking up existing PR for %s: %w", branch, perr)
+	} else if pr != nil {
+		d.registerPRIfUntracked(ctx, anvilName, registerID, pr, bead.EpicBranch)
+		d.clearNeedsHumanAfterRecovery(beadID, anvilName)
+		_ = d.db.LogEvent(state.EventPRCreateRecovered,
+			fmt.Sprintf("create-pr: %s already has open PR #%d; registered and cleared needs_human", branch, pr.Number),
+			beadID, anvilName)
+		return pr.Number, nil
+	}
+
+	// Precondition: branch tip carries the bead's changelog fragment.
+	hasFragment, fragErr := d.branchHasChangelogFragment(ctx, anvilPath, info.SHA, beadID)
+	if fragErr != nil {
+		return 0, fmt.Errorf("checking changelog fragment on %s: %w", branch, fragErr)
+	}
+	if !hasFragment {
+		return 0, fmt.Errorf("origin/%s does not carry a changelog fragment (changelog.d/%s.md); refusing to open a PR for incomplete work", branch, beadID)
+	}
+
+	// Last-chance external_ref lookup in case it was empty in the bead record.
+	externalRef := bead.ExternalRef
+	if externalRef == "" {
+		externalRef = d.fetchExternalRef(anvilPath, bead.ID)
+	}
+
+	// Dedicated timeout for PR creation independent of the caller ctx, which may
+	// carry a short IPC deadline.
+	prCtx, prCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer prCancel()
+
+	pr, err := provider.CreatePR(prCtx,
+		d.buildPRCreateParams(bead, anvilPath, branch, "", "", externalRef))
+	if err != nil {
+		if errors.Is(err, vcs.ErrPRAlreadyExists) {
+			// Raced a concurrent open between the guard and the create — register
+			// the existing PR and treat as recovered.
+			n := d.registerExistingPRByBranch(prCtx, anvilName, anvilPath, registerID, branch, bead.EpicBranch)
+			d.clearNeedsHumanAfterRecovery(beadID, anvilName)
+			_ = d.db.LogEvent(state.EventPRCreateRecovered,
+				fmt.Sprintf("create-pr: PR already existed for %s on create; registered #%d and cleared needs_human", branch, n),
+				beadID, anvilName)
+			return n, nil
+		}
+		// Surface the gh error and leave needs_human set.
+		_ = d.db.LogEvent(state.EventPRCreationFailed,
+			fmt.Sprintf("create-pr: PR creation failed for branch %s: %v", branch, err), beadID, anvilName)
+		d.ingotRecordPRCreateFailed(beadID, anvilName, branch, info.SHA, err.Error())
+		return 0, fmt.Errorf("gh pr create for %s failed: %w", branch, err)
+	}
+	if pr == nil || pr.URL == "" || pr.Number == 0 {
+		return 0, fmt.Errorf("PR creation for %s returned an invalid PR object", branch)
+	}
+
+	// Register so bellows owns the PR. registerPRIfUntracked is idempotent
+	// (CreatePR already records the PR), so this is a safety net.
+	d.registerPRIfUntracked(prCtx, anvilName, registerID, &vcs.OpenPR{
+		Number: pr.Number,
+		Title:  pr.Title,
+		Branch: branch,
+	}, bead.EpicBranch)
+
+	d.ingotRecordPR(beadID, anvilName, pr.Number, pr.URL)
+	d.notifyWicketPRCreated(beadID, pr.URL, pr.Number)
+	d.clearNeedsHumanAfterRecovery(beadID, anvilName)
+	d.logger.Info("create-pr: opened PR for existing forge branch",
+		"bead", beadID, "anvil", anvilName, "branch", branch, "pr", pr.URL)
+	_ = d.db.LogEvent(state.EventPRCreateRecovered,
+		fmt.Sprintf("create-pr: opened PR #%d for existing branch %s: %s", pr.Number, branch, pr.URL),
+		beadID, anvilName)
+	return pr.Number, nil
 }
 
 // forgeBranchAheadOfMain checks whether the origin remote has a forge branch
@@ -4835,6 +5036,38 @@ func (d *Daemon) handleIPC(cmd ipc.Command) ipc.Response {
 		}()
 		resp, _ := ipc.NewQueuedResponse(reqID, "stopping bead")
 		return resp
+
+	case "create_pr":
+		var cp ipc.CreatePRPayload
+		if err := json.Unmarshal(cmd.Payload, &cp); err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": "invalid create_pr payload"})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		if cp.BeadID == "" || cp.Anvil == "" {
+			msg, _ := json.Marshal(map[string]string{"message": "bead_id and anvil are required"})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		// Canonicalise the anvil name so the helper's config lookup matches the
+		// configured key regardless of how the user typed it on the CLI.
+		anvilName := cp.Anvil
+		if canonical, _, ok := d.resolveAnvilConfig(anvilName); ok {
+			anvilName = canonical
+		}
+		// Handle synchronously so the CLI receives the real PR number (or gh
+		// error). Each IPC connection runs in its own goroutine, so blocking for
+		// the duration of the gh call does not stall other clients. The client
+		// uses ipc.BdBackedReadTimeout for this command.
+		opCtx, opCancel := context.WithTimeout(context.Background(), ipc.BdBackedReadTimeout)
+		defer opCancel()
+		prNumber, err := d.openPRForExistingBranch(opCtx, cp.BeadID, anvilName)
+		if err != nil {
+			msg, _ := json.Marshal(map[string]string{"message": err.Error()})
+			return ipc.Response{Type: "error", Payload: msg}
+		}
+		data, _ := json.Marshal(map[string]string{
+			"message": fmt.Sprintf("opened PR #%d for %s", prNumber, cp.BeadID),
+		})
+		return ipc.Response{Type: "ok", Payload: data}
 
 	case "clear_clarification":
 		var cp ipc.ClarificationPayload

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3916,6 +3916,16 @@ func (d *Daemon) openPRForExistingBranch(ctx context.Context, beadID, anvilName 
 	}
 	bead.Anvil = anvilName
 
+	// Resolve the epic branch so a Crucible child's recovered PR targets the
+	// feature branch rather than the repo default. FetchBead does not populate
+	// EpicBranch (it is json:"-" and normally filled by poller.ResolveEpicBranches),
+	// so we resolve it explicitly here — mirroring the force_smith/warden_rerun
+	// flows. Every downstream use below (base-branch precondition check, CreateParams,
+	// and PR registration) reads bead.EpicBranch, so this must run before them.
+	beads := []poller.Bead{bead}
+	poller.ResolveEpicBranches(ctx, beads, map[string]string{anvilName: anvilPath})
+	bead.EpicBranch = beads[0].EpicBranch
+
 	// Precondition: origin/<branch> exists and is ahead of base (stranded).
 	branchState, info, err := worktree.CheckRemoteBranchState(ctx, anvilPath, branch, bead.EpicBranch)
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2669,6 +2669,10 @@ type mockVCSProvider struct {
 	createPRResult *vcs.PR
 	createPRErr    error
 	createPRCalls  atomic.Int32
+	// lastCreateParams captures the CreateParams of the most recent CreatePR
+	// call so tests can assert the PR base branch (e.g. a Crucible child's
+	// resolved epic branch) is wired through correctly.
+	lastCreateParams vcs.CreateParams
 	// createPRFunc, when non-nil, overrides the static createPRResult/createPRErr
 	// and is passed the 1-based call count so tests can simulate a transient
 	// failure on the first attempt followed by success on a retry.
@@ -2687,7 +2691,8 @@ func (m *mockVCSProvider) MergePR(_ context.Context, _ string, _ int, _ string) 
 	m.mergeCalls.Add(1)
 	return m.mergeErr
 }
-func (m *mockVCSProvider) CreatePR(_ context.Context, _ vcs.CreateParams) (*vcs.PR, error) {
+func (m *mockVCSProvider) CreatePR(_ context.Context, params vcs.CreateParams) (*vcs.PR, error) {
+	m.lastCreateParams = params
 	call := int(m.createPRCalls.Add(1))
 	if m.createPRFunc != nil {
 		return m.createPRFunc(call)

--- a/internal/daemon/openpr_existing_branch_test.go
+++ b/internal/daemon/openpr_existing_branch_test.go
@@ -194,6 +194,73 @@ func TestOpenPRForExistingBranch_CreatePRFailureLeavesNeedsHuman(t *testing.T) {
 	assert.True(t, r.NeedsHuman, "needs_human must remain set when gh pr create fails")
 }
 
+// pushEpicChildBranch creates an epic feature branch on origin and a forge child
+// branch that is one commit ahead of it (carrying the bead's changelog fragment).
+// This mirrors a Crucible child whose PR must target the feature branch, not main.
+func pushEpicChildBranch(t *testing.T, anvilPath, beadID, featureBranch string) {
+	t.Helper()
+	childBranch := worktree.BranchName(beadID)
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = anvilPath
+		cmd.Env = cleanGitTestEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	// Feature branch off main, pushed to origin so it can serve as the PR base.
+	git("checkout", "-b", featureBranch)
+	git("push", "origin", featureBranch)
+	// Child branch off the feature branch, one commit ahead, with the fragment.
+	git("checkout", "-b", childBranch)
+	require.NoError(t, os.MkdirAll(filepath.Join(anvilPath, "changelog.d"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(anvilPath, "changelog.d", beadID+".md"),
+		[]byte("category: Added\n- **Thing** - did a thing. ("+beadID+")\n"), 0o644))
+	git("add", filepath.Join("changelog.d", beadID+".md"))
+	git("commit", "-m", "child work")
+	git("push", "origin", childBranch)
+	git("checkout", "main")
+}
+
+// TestOpenPRForExistingBranch_ResolvesEpicBranch verifies that a Crucible child
+// recovered via openPRForExistingBranch gets its PR targeted at the resolved
+// epic feature branch rather than the repo default. FetchBead does not populate
+// EpicBranch, so the helper must resolve it via poller.ResolveEpicBranches.
+func TestOpenPRForExistingBranch_ResolvesEpicBranch(t *testing.T) {
+	const anvil = "test-anvil"
+	const beadID = "Forge-child1"
+	const epicID = "Forge-epic1"
+	const featureBranch = "feature/Forge-epic1"
+	anvilPath := initTestGitRepo(t)
+	pushEpicChildBranch(t, anvilPath, beadID, featureBranch)
+
+	// Resolve the epic branch without shelling out to bd.
+	restore := poller.SetEpicBranchLookupForTest(func(_ context.Context, parentID, _ string) string {
+		if parentID == epicID {
+			return featureBranch
+		}
+		return ""
+	})
+	defer restore()
+
+	mock := &mockVCSProvider{
+		createPRResult: &vcs.PR{Number: 55, URL: "https://example.test/pr/55", Title: "Recover child"},
+	}
+	d, db := newCreatePRTestDaemon(t, anvil, anvilPath, mock)
+	// Override the canned fetcher with one returning a child that blocks the epic.
+	d.beadFetcher = func(_ context.Context, id, _ string) (poller.Bead, error) {
+		return poller.Bead{ID: id, Title: "Recover child", Description: "desc", IssueType: "task", Blocks: []string{epicID}}, nil
+	}
+	require.NoError(t, db.MarkNeedsHuman(beadID, anvil, "PR creation failed"))
+
+	prNum, err := d.openPRForExistingBranch(context.Background(), beadID, anvil)
+	require.NoError(t, err)
+	assert.Equal(t, 55, prNum)
+	assert.Equal(t, featureBranch, mock.lastCreateParams.Base,
+		"a Crucible child's recovered PR must target the resolved epic feature branch")
+}
+
 func TestOpenPRForExistingBranch_UnknownAnvil(t *testing.T) {
 	mock := &mockVCSProvider{}
 	d, _ := newCreatePRTestDaemon(t, "test-anvil", initTestGitRepo(t), mock)

--- a/internal/daemon/openpr_existing_branch_test.go
+++ b/internal/daemon/openpr_existing_branch_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/config"
+	"github.com/Robin831/Forge/internal/poller"
+	"github.com/Robin831/Forge/internal/state"
+	"github.com/Robin831/Forge/internal/vcs"
+	"github.com/Robin831/Forge/internal/worktree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pushForgeBranch creates a forge/<bead> branch on origin carrying one commit.
+// When withFragment is true the commit includes changelog.d/<bead>.md, the
+// per-PR completion signal openPRForExistingBranch requires.
+func pushForgeBranch(t *testing.T, anvilPath, beadID string, withFragment bool) {
+	t.Helper()
+	branch := worktree.BranchName(beadID)
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = anvilPath
+		cmd.Env = cleanGitTestEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	git("checkout", "-b", branch)
+	require.NoError(t, os.WriteFile(filepath.Join(anvilPath, "work.txt"), []byte("work\n"), 0o644))
+	git("add", "work.txt")
+	if withFragment {
+		require.NoError(t, os.MkdirAll(filepath.Join(anvilPath, "changelog.d"), 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(anvilPath, "changelog.d", beadID+".md"),
+			[]byte("category: Added\n- **Thing** - did a thing. ("+beadID+")\n"), 0o644))
+		git("add", filepath.Join("changelog.d", beadID+".md"))
+	}
+	git("commit", "-m", "stranded work")
+	git("push", "origin", branch)
+	git("checkout", "main")
+}
+
+// newCreatePRTestDaemon builds a Daemon wired to a real temp git repo and state
+// DB, a mock VCS provider, and a canned bead fetcher so openPRForExistingBranch
+// can be exercised without bd or a live GitHub.
+func newCreatePRTestDaemon(t *testing.T, anvil, anvilPath string, mock *mockVCSProvider) (*Daemon, *state.DB) {
+	t.Helper()
+	db, err := state.Open(filepath.Join(t.TempDir(), "state.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	d := &Daemon{
+		db:           db,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		worktreeMgr:  worktree.NewManager(),
+		vcsProviders: map[string]vcs.Provider{anvil: mock},
+		beadFetcher: func(_ context.Context, beadID, _ string) (poller.Bead, error) {
+			return poller.Bead{ID: beadID, Title: "Recover me", Description: "desc", IssueType: "task"}, nil
+		},
+	}
+	d.cfg.Store(&config.Config{Anvils: map[string]config.AnvilConfig{
+		anvil: {Path: anvilPath},
+	}})
+	return d, db
+}
+
+func TestOpenPRForExistingBranch_Success(t *testing.T) {
+	const anvil = "test-anvil"
+	const beadID = "Forge-rec1"
+	anvilPath := initTestGitRepo(t)
+	pushForgeBranch(t, anvilPath, beadID, true)
+
+	mock := &mockVCSProvider{
+		createPRResult: &vcs.PR{Number: 77, URL: "https://example.test/pr/77", Title: "Recover me"},
+	}
+	d, db := newCreatePRTestDaemon(t, anvil, anvilPath, mock)
+
+	// Pre-seed needs_human so we can assert it is cleared on recovery.
+	require.NoError(t, db.MarkNeedsHuman(beadID, anvil, "PR creation failed"))
+
+	prNum, err := d.openPRForExistingBranch(context.Background(), beadID, anvil)
+	require.NoError(t, err)
+	assert.Equal(t, 77, prNum)
+	assert.Equal(t, int32(1), mock.createPRCalls.Load(), "CreatePR should be called exactly once")
+
+	// PR registered in state.db.
+	pr, err := db.GetPRByNumber(anvil, 77)
+	require.NoError(t, err)
+	require.NotNil(t, pr, "PR should be registered for bellows to own")
+	assert.Equal(t, beadID, pr.BeadID)
+
+	// needs_human cleared.
+	r, err := db.GetRetry(beadID, anvil)
+	require.NoError(t, err)
+	assert.Nil(t, r, "needs_human/retry record should be cleared after recovery")
+
+	// Recovery event logged.
+	events, err := db.RecentEvents(50)
+	require.NoError(t, err)
+	assert.True(t, hasEventType(events, state.EventPRCreateRecovered), "expected pr_create_recovered event")
+}
+
+func TestOpenPRForExistingBranch_MissingBranch(t *testing.T) {
+	const anvil = "test-anvil"
+	const beadID = "Forge-nob"
+	anvilPath := initTestGitRepo(t) // no forge branch pushed
+
+	mock := &mockVCSProvider{}
+	d, _ := newCreatePRTestDaemon(t, anvil, anvilPath, mock)
+
+	_, err := d.openPRForExistingBranch(context.Background(), beadID, anvil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Equal(t, int32(0), mock.createPRCalls.Load(), "CreatePR must not be called when branch is absent")
+}
+
+func TestOpenPRForExistingBranch_MissingChangelogFragment(t *testing.T) {
+	const anvil = "test-anvil"
+	const beadID = "Forge-nofrag"
+	anvilPath := initTestGitRepo(t)
+	pushForgeBranch(t, anvilPath, beadID, false) // ahead of base but no fragment
+
+	mock := &mockVCSProvider{}
+	d, db := newCreatePRTestDaemon(t, anvil, anvilPath, mock)
+	require.NoError(t, db.MarkNeedsHuman(beadID, anvil, "PR creation failed"))
+
+	_, err := d.openPRForExistingBranch(context.Background(), beadID, anvil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changelog fragment")
+	assert.Equal(t, int32(0), mock.createPRCalls.Load(), "CreatePR must not be called without a completion signal")
+
+	// needs_human must remain set on a refused recovery.
+	r, err := db.GetRetry(beadID, anvil)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.True(t, r.NeedsHuman, "needs_human must remain set when recovery is refused")
+}
+
+func TestOpenPRForExistingBranch_ExistingOpenPR(t *testing.T) {
+	const anvil = "test-anvil"
+	const beadID = "Forge-haspr"
+	anvilPath := initTestGitRepo(t)
+	pushForgeBranch(t, anvilPath, beadID, true)
+
+	branch := worktree.BranchName(beadID)
+	mock := &mockVCSProvider{
+		openPRs: []vcs.OpenPR{{Number: 99, Title: "Already open", Branch: branch}},
+	}
+	d, db := newCreatePRTestDaemon(t, anvil, anvilPath, mock)
+	require.NoError(t, db.MarkNeedsHuman(beadID, anvil, "PR creation failed"))
+
+	prNum, err := d.openPRForExistingBranch(context.Background(), beadID, anvil)
+	require.NoError(t, err, "an existing open PR should be treated as a successful recovery")
+	assert.Equal(t, 99, prNum)
+	assert.Equal(t, int32(0), mock.createPRCalls.Load(), "CreatePR must not be called when a PR already exists")
+
+	// The existing PR is registered and needs_human cleared.
+	pr, err := db.GetPRByNumber(anvil, 99)
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	r, err := db.GetRetry(beadID, anvil)
+	require.NoError(t, err)
+	assert.Nil(t, r, "needs_human should be cleared once the existing PR is registered")
+}
+
+func TestOpenPRForExistingBranch_CreatePRFailureLeavesNeedsHuman(t *testing.T) {
+	const anvil = "test-anvil"
+	const beadID = "Forge-ghfail"
+	anvilPath := initTestGitRepo(t)
+	pushForgeBranch(t, anvilPath, beadID, true)
+
+	mock := &mockVCSProvider{
+		createPRErr: fmt.Errorf("gh: 422 protected branch"),
+	}
+	d, db := newCreatePRTestDaemon(t, anvil, anvilPath, mock)
+	require.NoError(t, db.MarkNeedsHuman(beadID, anvil, "PR creation failed"))
+
+	_, err := d.openPRForExistingBranch(context.Background(), beadID, anvil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "protected branch")
+
+	// needs_human must remain set so the bead stays in the attention view.
+	r, err := db.GetRetry(beadID, anvil)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.True(t, r.NeedsHuman, "needs_human must remain set when gh pr create fails")
+}
+
+func TestOpenPRForExistingBranch_UnknownAnvil(t *testing.T) {
+	mock := &mockVCSProvider{}
+	d, _ := newCreatePRTestDaemon(t, "test-anvil", initTestGitRepo(t), mock)
+
+	_, err := d.openPRForExistingBranch(context.Background(), "Forge-x", "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func hasEventType(events []state.Event, typ state.EventType) bool {
+	for _, e := range events {
+		if e.Type == typ {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ingot/db.go
+++ b/internal/ingot/db.go
@@ -107,13 +107,53 @@ func UpdateIngotPR(db *sql.DB, beadID, anvil string, prNum int, prURL string, pr
 	return nil
 }
 
+// UpdateIngotPRCreateFailed records a failed PR creation on the ingot: it sets
+// the status to pr_create_failed and persists the pushed branch, head SHA, and
+// classified error so the work can be recovered via the manual
+// create-PR-from-existing-branch path without re-running Smith. It also clears
+// any stale pr_number/pr_url so the record unambiguously reflects "branch pushed
+// but no PR". The row must already exist (created at dispatch time); this is an
+// UPDATE, not an upsert.
+func UpdateIngotPRCreateFailed(db *sql.DB, beadID, anvil, branch, headSHA, classifiedErr string) error {
+	_, err := db.Exec(`
+		UPDATE ingots
+		SET status = ?, branch = ?, head_sha = ?, pr_create_error = ?,
+		    pr_number = NULL, pr_url = '', updated_at = ?
+		WHERE bead_id = ? AND anvil = ?`,
+		string(StatusPRCreateFailed), branch, headSHA, classifiedErr,
+		formatTime(time.Now()), beadID, anvil,
+	)
+	if err != nil {
+		return fmt.Errorf("recording ingot pr_create_failed: %w", err)
+	}
+	return nil
+}
+
+// ClearIngotPRCreateError clears the recorded PR-creation error on the ingot.
+// It is called on the recovery path once a PR has been (re)opened so the record
+// no longer surfaces a stale failure. It intentionally does not touch the status
+// — the caller transitions the ingot to pr_open via UpdateIngotPR/Status.
+func ClearIngotPRCreateError(db *sql.DB, beadID, anvil string) error {
+	_, err := db.Exec(`
+		UPDATE ingots
+		SET pr_create_error = '', updated_at = ?
+		WHERE bead_id = ? AND anvil = ?`,
+		formatTime(time.Now()), beadID, anvil,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing ingot pr_create_error: %w", err)
+	}
+	return nil
+}
+
 // GetIngot fetches a single ingot by (beadID, anvil), eager-loading its
 // TestResults. Returns nil, nil if not found.
 func GetIngot(db *sql.DB, beadID, anvil string) (*Ingot, error) {
 	row := db.QueryRow(`
 		SELECT id, bead_id, anvil, pr_id, worker_id, status,
 		       temper_passed, temper_failed_step, temper_duration_ms,
-		       pr_number, pr_url, title, branch, created_at, updated_at
+		       pr_number, pr_url, title, branch, head_sha, pr_create_error,
+		       created_at, updated_at
 		FROM ingots
 		WHERE bead_id = ? AND anvil = ?`,
 		beadID, anvil,
@@ -140,7 +180,8 @@ func GetIngotByBeadID(db *sql.DB, beadID string) ([]Ingot, error) {
 	rows, err := db.Query(`
 		SELECT id, bead_id, anvil, pr_id, worker_id, status,
 		       temper_passed, temper_failed_step, temper_duration_ms,
-		       pr_number, pr_url, title, branch, created_at, updated_at
+		       pr_number, pr_url, title, branch, head_sha, pr_create_error,
+		       created_at, updated_at
 		FROM ingots
 		WHERE bead_id = ?
 		ORDER BY anvil`,
@@ -170,7 +211,8 @@ func GetIngotsByStatus(db *sql.DB, status Status, limit int) ([]Ingot, error) {
 	rows, err := db.Query(`
 		SELECT id, bead_id, anvil, pr_id, worker_id, status,
 		       temper_passed, temper_failed_step, temper_duration_ms,
-		       pr_number, pr_url, title, branch, created_at, updated_at
+		       pr_number, pr_url, title, branch, head_sha, pr_create_error,
+		       created_at, updated_at
 		FROM ingots
 		WHERE status = ?
 		ORDER BY updated_at DESC
@@ -206,7 +248,8 @@ func GetIngots(db *sql.DB, anvil string, status string, limit int) ([]Ingot, err
 	query := `
 		SELECT id, bead_id, anvil, pr_id, worker_id, status,
 		       temper_passed, temper_failed_step, temper_duration_ms,
-		       pr_number, pr_url, title, branch, created_at, updated_at
+		       pr_number, pr_url, title, branch, head_sha, pr_create_error,
+		       created_at, updated_at
 		FROM ingots
 		WHERE 1=1`
 	var args []any
@@ -338,6 +381,7 @@ func scanIngot(s scanner) (*Ingot, error) {
 		&prID, &ingot.WorkerID, &statusStr,
 		&temperPassed, &ingot.TemperFailedStep, &ingot.TemperDurationMs,
 		&prNumber, &ingot.PRURL, &ingot.Title, &ingot.Branch,
+		&ingot.HeadSHA, &ingot.PRCreateError,
 		&createdAtStr, &updatedAtStr,
 	); err != nil {
 		return nil, err

--- a/internal/ingot/db.go
+++ b/internal/ingot/db.go
@@ -111,14 +111,14 @@ func UpdateIngotPR(db *sql.DB, beadID, anvil string, prNum int, prURL string, pr
 // the status to pr_create_failed and persists the pushed branch, head SHA, and
 // classified error so the work can be recovered via the manual
 // create-PR-from-existing-branch path without re-running Smith. It also clears
-// any stale pr_number/pr_url so the record unambiguously reflects "branch pushed
-// but no PR". The row must already exist (created at dispatch time); this is an
-// UPDATE, not an upsert.
+// any stale pr_number/pr_url/pr_id so the record unambiguously reflects "branch
+// pushed but no PR". The row must already exist (created at dispatch time); this
+// is an UPDATE, not an upsert.
 func UpdateIngotPRCreateFailed(db *sql.DB, beadID, anvil, branch, headSHA, classifiedErr string) error {
 	_, err := db.Exec(`
 		UPDATE ingots
 		SET status = ?, branch = ?, head_sha = ?, pr_create_error = ?,
-		    pr_number = NULL, pr_url = '', updated_at = ?
+		    pr_number = NULL, pr_url = '', pr_id = NULL, updated_at = ?
 		WHERE bead_id = ? AND anvil = ?`,
 		string(StatusPRCreateFailed), branch, headSHA, classifiedErr,
 		formatTime(time.Now()), beadID, anvil,

--- a/internal/ingot/db_test.go
+++ b/internal/ingot/db_test.go
@@ -337,3 +337,62 @@ func TestEagerLoadTestResults(t *testing.T) {
 		t.Errorf("StepName = %q; want go build", got.TestResults[0].StepName)
 	}
 }
+
+func TestUpdateIngotPRCreateFailed_RoundTrip(t *testing.T) {
+	sdb, cleanup := openTestDB(t)
+	defer cleanup()
+	db := sdb.Conn()
+
+	ig := &Ingot{
+		BeadID:   "bd-pcf",
+		Anvil:    "anvil-1",
+		WorkerID: "worker-pcf",
+		Status:   StatusApproved,
+		Title:    "Failed PR feature",
+		Branch:   "forge/bd-pcf",
+	}
+	if err := InsertIngot(db, ig); err != nil {
+		t.Fatalf("InsertIngot: %v", err)
+	}
+
+	const (
+		branch  = "forge/bd-pcf"
+		headSHA = "deadbeefcafe1234567890abcdef000011112222"
+		errMsg  = "gh pr create failed: HTTP 403 rate limited"
+	)
+	if err := UpdateIngotPRCreateFailed(db, "bd-pcf", "anvil-1", branch, headSHA, errMsg); err != nil {
+		t.Fatalf("UpdateIngotPRCreateFailed: %v", err)
+	}
+
+	got, err := GetIngot(db, "bd-pcf", "anvil-1")
+	if err != nil {
+		t.Fatalf("GetIngot: %v", err)
+	}
+	if got.Status != StatusPRCreateFailed {
+		t.Errorf("Status = %q; want %q", got.Status, StatusPRCreateFailed)
+	}
+	if got.Branch != branch {
+		t.Errorf("Branch = %q; want %q", got.Branch, branch)
+	}
+	if got.HeadSHA != headSHA {
+		t.Errorf("HeadSHA = %q; want %q", got.HeadSHA, headSHA)
+	}
+	if got.PRCreateError != errMsg {
+		t.Errorf("PRCreateError = %q; want %q", got.PRCreateError, errMsg)
+	}
+
+	// Recovery path: clearing the error must not touch the other fields.
+	if err := ClearIngotPRCreateError(db, "bd-pcf", "anvil-1"); err != nil {
+		t.Fatalf("ClearIngotPRCreateError: %v", err)
+	}
+	got, err = GetIngot(db, "bd-pcf", "anvil-1")
+	if err != nil {
+		t.Fatalf("GetIngot after clear: %v", err)
+	}
+	if got.PRCreateError != "" {
+		t.Errorf("PRCreateError after clear = %q; want empty", got.PRCreateError)
+	}
+	if got.HeadSHA != headSHA {
+		t.Errorf("HeadSHA after clear = %q; want preserved %q", got.HeadSHA, headSHA)
+	}
+}

--- a/internal/ingot/ingot.go
+++ b/internal/ingot/ingot.go
@@ -19,43 +19,55 @@ const (
 	StatusPRMerged Status = "pr_merged"
 	StatusFailed   Status = "failed"
 	StatusStalled  Status = "stalled"
+	// StatusPRCreateFailed marks an ingot whose branch was pushed but for which
+	// the final PR creation failed (after transient retries were exhausted). The
+	// pushed branch, head SHA, and classified error are persisted alongside it so
+	// the bead can be recovered via the manual create-PR-from-existing-branch path
+	// without re-running Smith.
+	StatusPRCreateFailed Status = "pr_create_failed"
 )
 
 // Ingot bundles a bead, PR, worker lifecycle, and test results into a
 // single queryable record.
 type Ingot struct {
-	ID               int          `json:"id"`
-	BeadID           string       `json:"bead_id"`
-	Anvil            string       `json:"anvil"`
-	PRID             *int         `json:"pr_id,omitempty"`       // FK to prs.id, NULL until PR created
-	WorkerID         string       `json:"worker_id"`
-	Status           Status       `json:"status"`
-	TemperPassed     bool         `json:"temper_passed"`
-	TemperFailedStep string       `json:"temper_failed_step,omitempty"`
-	TemperDurationMs int          `json:"temper_duration_ms"`
-	PRNumber         *int         `json:"pr_number,omitempty"` // GitHub PR number
-	PRURL            string       `json:"pr_url,omitempty"`
-	Title            string       `json:"title"`
-	Branch           string       `json:"branch"`
-	TestResults      []TestResult `json:"test_results,omitempty"` // eager-loaded
-	CreatedAt        time.Time    `json:"created_at"`
-	UpdatedAt        time.Time    `json:"updated_at"`
+	ID               int    `json:"id"`
+	BeadID           string `json:"bead_id"`
+	Anvil            string `json:"anvil"`
+	PRID             *int   `json:"pr_id,omitempty"` // FK to prs.id, NULL until PR created
+	WorkerID         string `json:"worker_id"`
+	Status           Status `json:"status"`
+	TemperPassed     bool   `json:"temper_passed"`
+	TemperFailedStep string `json:"temper_failed_step,omitempty"`
+	TemperDurationMs int    `json:"temper_duration_ms"`
+	PRNumber         *int   `json:"pr_number,omitempty"` // GitHub PR number
+	PRURL            string `json:"pr_url,omitempty"`
+	Title            string `json:"title"`
+	Branch           string `json:"branch"`
+	// HeadSHA is the tip commit of the pushed forge branch, recorded when PR
+	// creation fails so a recovery can reference the exact pushed work.
+	HeadSHA string `json:"head_sha,omitempty"`
+	// PRCreateError is the classified error string from the last failed PR
+	// creation attempt. Empty when the ingot is not in a pr_create_failed state.
+	PRCreateError string       `json:"pr_create_error,omitempty"`
+	TestResults   []TestResult `json:"test_results,omitempty"` // eager-loaded
+	CreatedAt     time.Time    `json:"created_at"`
+	UpdatedAt     time.Time    `json:"updated_at"`
 }
 
 // TestResult stores the outcome of a single temper step for an ingot.
 type TestResult struct {
-	ID             int       `json:"id"`
-	IngotID        int       `json:"ingot_id"`
-	StepIndex      int       `json:"step_index"`
-	StepName       string    `json:"step_name"`
-	Command        string    `json:"command"`
-	ExitCode       int       `json:"exit_code"`
-	DurationMs     int       `json:"duration_ms"`
-	Passed         bool      `json:"passed"`
-	Optional       bool      `json:"optional"`
+	ID         int    `json:"id"`
+	IngotID    int    `json:"ingot_id"`
+	StepIndex  int    `json:"step_index"`
+	StepName   string `json:"step_name"`
+	Command    string `json:"command"`
+	ExitCode   int    `json:"exit_code"`
+	DurationMs int    `json:"duration_ms"`
+	Passed     bool   `json:"passed"`
+	Optional   bool   `json:"optional"`
 	// Skipped is true when the step was path-gated off (no changed files matched its Paths globs).
 	Skipped        bool      `json:"skipped"`
-	OutputSummary  string    `json:"output_summary,omitempty"`  // first ~1000 chars or key errors
+	OutputSummary  string    `json:"output_summary,omitempty"` // first ~1000 chars or key errors
 	FullOutputPath string    `json:"full_output_path,omitempty"`
 	RecordedAt     time.Time `json:"recorded_at"`
 }

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -31,7 +31,7 @@ import (
 
 // Command is a message sent from a client to the daemon.
 type Command struct {
-	Type    string          `json:"type"`    // "status", "kill_worker", "refresh", "queue", "run_bead", "set_clarification", "clear_clarification", "assay_rerun", "pause_dispatch", "resume_dispatch"
+	Type    string          `json:"type"`    // "status", "kill_worker", "refresh", "queue", "run_bead", "create_pr", "set_clarification", "clear_clarification", "assay_rerun", "pause_dispatch", "resume_dispatch"
 	Payload json.RawMessage `json:"payload"` // Type-specific data
 	// ReadTimeout is an optional client-side timeout for reading the response.
 	// Zero uses DefaultReadTimeout. Long-running commands that go through bd or
@@ -232,6 +232,15 @@ type StopBeadPayload struct {
 	Reason string `json:"reason"` // Optional; defaults to "manually stopped"
 }
 
+// CreatePRPayload is the payload for a "create_pr" command. It triggers the
+// manual create-PR-from-existing-branch recovery: the daemon opens a PR for the
+// already-pushed forge/<bead> branch without re-running Smith. Used by
+// `forge queue create-pr <id> --anvil <name>` and the Hearth "Create PR" button.
+type CreatePRPayload struct {
+	BeadID string `json:"bead_id"`
+	Anvil  string `json:"anvil"`
+}
+
 // QueueActionPayload is the payload for the queue resolution verbs:
 // "queue_clarify", "queue_unclarify", "queue_retry", "queue_clear", and
 // "queue_stop". These are thin IPC wrappers around the shared queueactions
@@ -347,9 +356,9 @@ type GetIngotPayload struct {
 type WicketStatusPayload struct {
 	Enabled        bool           `json:"enabled"`
 	Interval       string         `json:"interval"`
-	MonitoredRepos []string       `json:"monitored_repos"`  // explicitly configured repos
-	DerivedAnvils  int            `json:"derived_anvils"`   // anvil count deriving repo from git remote at runtime
-	IssueCounts    map[string]int `json:"issue_counts"`     // state -> count
+	MonitoredRepos []string       `json:"monitored_repos"` // explicitly configured repos
+	DerivedAnvils  int            `json:"derived_anvils"`  // anvil count deriving repo from git remote at runtime
+	IssueCounts    map[string]int `json:"issue_counts"`    // state -> count
 	LastScanAt     *time.Time     `json:"last_scan_at,omitempty"`
 }
 

--- a/internal/ipc/ipc_test.go
+++ b/internal/ipc/ipc_test.go
@@ -342,3 +342,33 @@ func TestQueuedResponseJSON(t *testing.T) {
 		t.Fatalf("expected request_id abc, got %s", decoded.RequestID)
 	}
 }
+
+func TestCreatePRPayload_RoundTrip(t *testing.T) {
+	cmd := Command{
+		Type:    "create_pr",
+		Payload: mustMarshal(CreatePRPayload{BeadID: "Forge-abc1", Anvil: "heimdall"}),
+	}
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatalf("marshal command: %v", err)
+	}
+
+	var gotCmd Command
+	if err := json.Unmarshal(data, &gotCmd); err != nil {
+		t.Fatalf("unmarshal command: %v", err)
+	}
+	if gotCmd.Type != "create_pr" {
+		t.Errorf("Type = %q; want create_pr", gotCmd.Type)
+	}
+
+	var p CreatePRPayload
+	if err := json.Unmarshal(gotCmd.Payload, &p); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if p.BeadID != "Forge-abc1" {
+		t.Errorf("BeadID = %q; want Forge-abc1", p.BeadID)
+	}
+	if p.Anvil != "heimdall" {
+		t.Errorf("Anvil = %q; want heimdall", p.Anvil)
+	}
+}

--- a/internal/poller/epicbranch.go
+++ b/internal/poller/epicbranch.go
@@ -25,6 +25,16 @@ const DefaultEpicBranchPrefix = "epic/"
 // It defaults to lookupEpicBranch but can be replaced in tests.
 var epicBranchLookupFunc = lookupEpicBranch
 
+// SetEpicBranchLookupForTest overrides the epic-branch lookup function and
+// returns a restore function. It lets packages outside poller (e.g. daemon)
+// exercise epic-branch resolution without shelling out to bd. Intended for
+// tests only; always defer the returned restore.
+func SetEpicBranchLookupForTest(fn func(ctx context.Context, parentID, anvilPath string) string) (restore func()) {
+	orig := epicBranchLookupFunc
+	epicBranchLookupFunc = fn
+	return func() { epicBranchLookupFunc = orig }
+}
+
 // ResolveEpicBranches enriches beads that belong to an epic with the epic's
 // branch name. It discovers the epic relationship via two paths:
 //

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1006,12 +1006,6 @@ const (
 	PRMerged   PRStatus = "merged"
 	PRClosed   PRStatus = "closed"
 	PRNeedsFix PRStatus = "needs_fix"
-	// PRCreateFailed marks a bead whose branch was pushed but for which the
-	// final PR creation failed (after Part A transient retries were exhausted).
-	// It is recorded on the ingot record together with the pushed branch, head
-	// SHA, and classified error so an operator can recover via the manual
-	// create-PR-from-existing-branch path without re-running Smith.
-	PRCreateFailed PRStatus = "pr_create_failed"
 )
 
 // nonTerminalPRStatuses lists every PR status that is not yet resolved.

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -131,6 +131,8 @@ func (db *DB) migrate() error {
 		{"forge_session_messages", "metadata", `ALTER TABLE forge_session_messages ADD COLUMN metadata TEXT NOT NULL DEFAULT ''`},
 		{"prs", "bellows_manually_assigned", `ALTER TABLE prs ADD COLUMN bellows_manually_assigned INTEGER NOT NULL DEFAULT 0`},
 		{"ingot_test_results", "skipped", `ALTER TABLE ingot_test_results ADD COLUMN skipped INTEGER NOT NULL DEFAULT 0`},
+		{"ingots", "head_sha", `ALTER TABLE ingots ADD COLUMN head_sha TEXT NOT NULL DEFAULT ''`},
+		{"ingots", "pr_create_error", `ALTER TABLE ingots ADD COLUMN pr_create_error TEXT NOT NULL DEFAULT ''`},
 	}
 	for _, m := range migrations {
 		exists, err := db.columnExists(m.table, m.column)
@@ -336,6 +338,8 @@ CREATE TABLE IF NOT EXISTS ingots (
     pr_url              TEXT NOT NULL DEFAULT '',
     title               TEXT NOT NULL DEFAULT '',
     branch              TEXT NOT NULL DEFAULT '',
+    head_sha            TEXT NOT NULL DEFAULT '',
+    pr_create_error     TEXT NOT NULL DEFAULT '',
     UNIQUE(bead_id, anvil)
 );
 
@@ -1002,6 +1006,12 @@ const (
 	PRMerged   PRStatus = "merged"
 	PRClosed   PRStatus = "closed"
 	PRNeedsFix PRStatus = "needs_fix"
+	// PRCreateFailed marks a bead whose branch was pushed but for which the
+	// final PR creation failed (after Part A transient retries were exhausted).
+	// It is recorded on the ingot record together with the pushed branch, head
+	// SHA, and classified error so an operator can recover via the manual
+	// create-PR-from-existing-branch path without re-running Smith.
+	PRCreateFailed PRStatus = "pr_create_failed"
 )
 
 // nonTerminalPRStatuses lists every PR status that is not yet resolved.
@@ -1623,6 +1633,10 @@ const (
 	EventNoChangesNeeded                 EventType = "no_changes_needed"
 	EventPRCreationFailed                EventType = "pr_creation_failed"
 	EventPRAlreadyExists                 EventType = "pr_already_exists"
+	// EventPRCreateRecovered fires when the manual create-PR-from-existing-branch
+	// recovery opens (or registers) a PR for an already-pushed forge branch
+	// without re-running Smith, clearing the needs_human escalation.
+	EventPRCreateRecovered EventType = "pr_create_recovered"
 
 	// Crucible events — parent bead orchestration with children on feature branches.
 	EventCrucibleStarted         EventType = "crucible_started"


### PR DESCRIPTION
## Changes

- **Manual create-PR-from-existing-branch recovery** - When PR creation fails after transient retries, the pushed branch, head SHA, and classified error are now recorded on the ingot as `pr_create_failed`. Recover with `forge queue create-pr <id> --anvil <name>`, which opens a PR for the already-pushed `forge/<bead>` branch without re-running Smith (preconditions: branch exists, is ahead of base, has no open PR, and carries the bead's changelog fragment), then clears the needs-attention flag. (Forge-m9cw)

## Original Issue (task): pr_create_failed state + openPRForExistingBranch helper + IPC/CLI (Parts B & D)

Part D: in `internal/state`/`internal/ingot`, persist on the pr/ingot record a `pr_create_failed` status plus the pushed `forge/<bead>` branch and head SHA and the classified error, recorded on CreatePR failure after Part A retries. Part B: factor a shared `openPRForExistingBranch(beadID)` helper in `internal/daemon/daemon.go` that opens a PR for an already-pushed branch WITHOUT re-running Smith — reuses branch + pushed SHA + changelog fragment, builds the same CreateParams, sets the forge-managed marker, and calls `registerPRIfUntracked` with bead_id derived from the branch (ext-<number> fix per bead 21). Preconditions: `origin/forge/<bead>` exists, ahead of base, no open PR, carries the bead changelog fragment. On success: clear needs_human, log a recovery event. On failure: surface gh error, leave needs_human. Expose via a new command in `internal/ipc` and `forge queue create-pr <id> --anvil <name>` in `cmd/forge`. This helper is the factored primitive bead 21 also calls. Depends on the classifier (for recorded error) and the state status. Satisfies acceptance criteria (3) and (5).

---
Bead: Forge-m9cw | Branch: forge/Forge-m9cw
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->