### PR TITLE
Ready-to-merge can fire before in-flight Assay posts findings, bouncing PR back to Burnish (Forge-75cx)

### DIFF
--- a/changelog.d/Forge-75cx.md
+++ b/changelog.d/Forge-75cx.md
@@ -1,0 +1,2 @@
+category: Fixed
+- **Ready-to-merge no longer races in-flight Assay reviews** - Gate the ready-to-merge transition (and auto-merge) on the current PR head having been reviewed by Assay, so a PR with green CI and no threads is not announced ready while an Assay review is still pending or in-flight. The same guard is applied to the `IsPRReadyToMerge`/`ReadyToMergePRs` state queries (which exclude PRs with a pending Assay worker) so the Hearth panel and auto-merge agree. (Forge-75cx)

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -226,8 +226,15 @@ func (m *Monitor) assayEnabled(anvil string) bool {
 // the current head covers BOTH the pre-dispatch window (assay needed but not yet
 // started) and the in-flight window (assay running but findings not yet posted),
 // which a simple "no pending assay worker" check would miss.
+//
+// When headSHA is empty (GitHub did not report it), we return true: no Assay
+// review will be dispatched (shouldEmitReviewNeeded skips empty SHAs), so
+// blocking readiness would be permanent.
 func (m *Monitor) assayUpToDate(pr *state.PR, headSHA string) bool {
 	if !m.assayEnabled(pr.Anvil) {
+		return true
+	}
+	if headSHA == "" {
 		return true
 	}
 	return m.lastReviewedSHA(pr) == headSHA
@@ -537,7 +544,13 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR, dailyAssayCost *flo
 	// for the anvil). Gates ready-to-merge so a PR is not declared ready while an
 	// Assay review is pending or in-flight for this head (Forge-75cx). Computed
 	// before the snapshot lock so it can also seed lastSnap on first sighting.
+	// When dailyAssayCost is nil (query error), no Assay will be dispatched this
+	// cycle, so treat as up-to-date to avoid permanently blocking readiness for
+	// an Assay that cannot run.
 	assayUpToDate := m.assayUpToDate(pr, status.HeadSHA)
+	if dailyAssayCost == nil && m.assayEnabled(pr.Anvil) {
+		assayUpToDate = true
+	}
 	newSnap.AssayUpToDate = assayUpToDate
 
 	if ciInProgress {

--- a/internal/bellows/bellows.go
+++ b/internal/bellows/bellows.go
@@ -129,6 +129,13 @@ type prSnapshot struct {
 	IsMerged             bool
 	IsClosed             bool
 	IsConflicting        bool
+	// AssayUpToDate is true when the PR's current head has been reviewed by
+	// Assay (or Assay is disabled for the anvil). It gates the ready-to-merge
+	// transition so a PR is not announced ready while an Assay review is still
+	// pending or in-flight for this head (Forge-75cx). It is tracked per
+	// snapshot so the ready transition fires on the rising edge — once the
+	// assay lands — rather than prematurely on first sighting.
+	AssayUpToDate bool
 }
 
 // New creates a Bellows monitor. The vcsLookup function returns the VCS
@@ -201,6 +208,29 @@ func (m *Monitor) lastReviewedSHA(pr *state.PR) string {
 		return ""
 	}
 	return sha
+}
+
+// assayEnabled reports whether the Assay trigger is enabled for the anvil. It is
+// false when no Assay config accessor has been registered (the feature is off).
+func (m *Monitor) assayEnabled(anvil string) bool {
+	return m.assayConfig != nil && m.assayConfig(anvil).Enabled
+}
+
+// assayUpToDate reports whether the PR's current head SHA has already been
+// reviewed by Assay, or whether Assay is disabled for the anvil. It gates the
+// ready-to-merge transition (and auto-merge) so a PR is not announced as ready
+// while an Assay review is still pending or in-flight for the head: the assay's
+// inline findings would otherwise land a poll or two later, flip
+// HasUnresolvedThreads 0->1, and bounce the PR back to needs_fix/Burnish after
+// it had already been declared ready (Forge-75cx). Comparing LastReviewedSHA to
+// the current head covers BOTH the pre-dispatch window (assay needed but not yet
+// started) and the in-flight window (assay running but findings not yet posted),
+// which a simple "no pending assay worker" check would miss.
+func (m *Monitor) assayUpToDate(pr *state.PR, headSHA string) bool {
+	if !m.assayEnabled(pr.Anvil) {
+		return true
+	}
+	return m.lastReviewedSHA(pr) == headSHA
 }
 
 // OnEvent registers a handler for PR events.
@@ -503,6 +533,13 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR, dailyAssayCost *flo
 		IsConflicting:        status.Mergeable == "CONFLICTING",
 	}
 
+	// Whether the current head has been reviewed by Assay (or Assay is disabled
+	// for the anvil). Gates ready-to-merge so a PR is not declared ready while an
+	// Assay review is pending or in-flight for this head (Forge-75cx). Computed
+	// before the snapshot lock so it can also seed lastSnap on first sighting.
+	assayUpToDate := m.assayUpToDate(pr, status.HeadSHA)
+	newSnap.AssayUpToDate = assayUpToDate
+
 	if ciInProgress {
 		log.Printf("[bellows] PR #%d (%s): CI checks still in progress, skipping failure evaluation", pr.Number, pr.Anvil)
 	}
@@ -553,6 +590,15 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR, dailyAssayCost *flo
 			// already in needs_fix or post-fix state — masking the secondary
 			// still-unresolved retry branch and dispatching duplicates.
 			NeedsChanges: threadsSeed,
+			// Seed the assay term as "up to date" only when Assay is disabled for
+			// the anvil, preserving the existing restart behaviour there. When Assay
+			// is enabled, seed it false so the ready transition fires on the rising
+			// edge once the head is assayed. This matters because the Assay worker
+			// calls ResetPRState when it finishes, forcing a re-seed on the next
+			// poll: seeding false keeps lastReady=false so a clean assay still emits
+			// EventPRReadyToMerge (and triggers auto-merge) rather than being masked
+			// by the DB's already-green mergeability state (Forge-75cx).
+			AssayUpToDate: !m.assayEnabled(pr.Anvil),
 		}
 	}
 	// When CI is still in progress, preserve the last *completed* CIPassing value
@@ -817,7 +863,9 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR, dailyAssayCost *flo
 	// COMMENTED reviews, never APPROVED, so requiring it would prevent PRs
 	// from ever reaching the Ready-to-Merge state.
 	// ciInProgress is excluded: a PR is not truly ready while CI is still running.
-	if newSnap.CIPassing && !ciInProgress && !newSnap.IsConflicting && !newSnap.HasUnresolvedThreads && !newSnap.HasPendingReviews {
+	// assayUpToDate is required so the status is not restored to approved while an
+	// Assay review is still pending/in-flight for the current head (Forge-75cx).
+	if newSnap.CIPassing && !ciInProgress && !newSnap.IsConflicting && !newSnap.HasUnresolvedThreads && !newSnap.HasPendingReviews && assayUpToDate {
 		_ = m.db.UpdatePRStatusIfNeedsFix(pr.ID, state.PRApproved)
 	}
 
@@ -834,8 +882,14 @@ func (m *Monitor) checkPR(ctx context.Context, pr *state.PR, dailyAssayCost *flo
 	// ciInProgress is excluded from both sides: a PR is not ready while CI is
 	// still running, and the previous poll must also have been fully completed
 	// (not in-progress) to count as "was already ready".
-	newReady := newSnap.CIPassing && !ciInProgress && !newSnap.IsConflicting && !newSnap.HasUnresolvedThreads && !newSnap.HasPendingReviews
-	lastReady := lastSnap.CIPassing && !lastSnap.CIInProgress && !lastSnap.IsConflicting && !lastSnap.HasUnresolvedThreads && !lastSnap.HasPendingReviews
+	// assayUpToDate gates both sides so the rising-edge transition fires only once
+	// the current head has been assayed (or Assay is disabled). Without it, a PR
+	// with green CI and no threads would be announced ready on first sighting,
+	// before its in-flight Assay posts findings — bouncing it back to Burnish a
+	// poll or two later (Forge-75cx). Tracking it per snapshot keeps lastReady
+	// honest so the transition still fires exactly once when the assay lands.
+	newReady := newSnap.CIPassing && !ciInProgress && !newSnap.IsConflicting && !newSnap.HasUnresolvedThreads && !newSnap.HasPendingReviews && newSnap.AssayUpToDate
+	lastReady := lastSnap.CIPassing && !lastSnap.CIInProgress && !lastSnap.IsConflicting && !lastSnap.HasUnresolvedThreads && !lastSnap.HasPendingReviews && lastSnap.AssayUpToDate
 	if newReady && !lastReady {
 		m.emit(ctx, PREvent{
 			PRNumber:  pr.Number,

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -933,6 +933,76 @@ func TestCheckPR_AssayDisabled_ReadyFiresImmediately(t *testing.T) {
 	assert.True(t, ready, "IsPRReadyToMerge must be true when Assay is disabled and the PR is clean")
 }
 
+// TestCheckPR_AssayEmptyHeadSHA_DoesNotBlockReady verifies that when GitHub
+// returns an empty HeadSHA, AssayUpToDate is true and does not permanently
+// block the ready-to-merge transition.
+func TestCheckPR_AssayEmptyHeadSHA_DoesNotBlockReady(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    903,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-assayemptysha",
+		Branch:    "forge/forge-assayemptysha",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:   "OPEN",
+		HeadSHA: "", // empty — GitHub did not report it
+	}}
+
+	var events []string
+	m := assayEnabledMonitor(db, fake, "test-anvil")
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.Contains(t, events, EventPRReadyToMerge,
+		"ready-to-merge must fire when HeadSHA is empty (no Assay can be dispatched)")
+}
+
+// TestCheckPR_AssayCostQueryError_DoesNotBlockReady verifies that when the
+// daily Assay cost query fails (dailyAssayCost is nil), the Assay gate does
+// not block the ready-to-merge transition — since no Assay can be dispatched
+// without a cost check, blocking readiness would be permanent.
+func TestCheckPR_AssayCostQueryError_DoesNotBlockReady(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    904,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-assaycosterr",
+		Branch:    "forge/forge-assaycosterr",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:   "OPEN",
+		HeadSHA: "deadbeefcafe",
+	}}
+
+	var events []string
+	m := assayEnabledMonitor(db, fake, "test-anvil")
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	// Simulate nil dailyAssayCost by calling checkPR directly with nil.
+	m.checkPR(context.Background(), pr, nil)
+
+	assert.Contains(t, events, EventPRReadyToMerge,
+		"ready-to-merge must fire when dailyAssayCost is nil (no Assay can be dispatched)")
+}
+
 // TestCheckPR_StillConflicting_ReemitsEvent is the end-to-end regression test
 // for Forge-h2a6: after a rebase action dispatched (whether it ran or bailed
 // at worktree creation) and the PR is still CONFLICTING, the next bellows

--- a/internal/bellows/bellows_test.go
+++ b/internal/bellows/bellows_test.go
@@ -182,14 +182,14 @@ func TestSnapshotTransitionLogic(t *testing.T) {
 		},
 		{
 			name: "CI passes with no blockers → pr_ready_to_merge (no approval needed)",
-			old:  prSnapshot{CIPassing: false},
-			new:  prSnapshot{CIPassing: true},
+			old:  prSnapshot{CIPassing: false, AssayUpToDate: true},
+			new:  prSnapshot{CIPassing: true, AssayUpToDate: true},
 			wantEvents: []string{EventPRReadyToMerge},
 		},
 		{
 			name: "already ready → no pr_ready_to_merge event",
-			old:  prSnapshot{CIPassing: true},
-			new:  prSnapshot{CIPassing: true},
+			old:  prSnapshot{CIPassing: true, AssayUpToDate: true},
+			new:  prSnapshot{CIPassing: true, AssayUpToDate: true},
 			noEvents: []string{EventPRReadyToMerge},
 		},
 		{
@@ -224,8 +224,20 @@ func TestSnapshotTransitionLogic(t *testing.T) {
 		},
 		{
 			name: "threads resolved while CI passing → pr_ready_to_merge",
-			old:  prSnapshot{CIPassing: true, HasUnresolvedThreads: true},
-			new:  prSnapshot{CIPassing: true, HasUnresolvedThreads: false},
+			old:  prSnapshot{CIPassing: true, HasUnresolvedThreads: true, AssayUpToDate: true},
+			new:  prSnapshot{CIPassing: true, HasUnresolvedThreads: false, AssayUpToDate: true},
+			wantEvents: []string{EventPRReadyToMerge},
+		},
+		{
+			name:       "assay pending for current head → not ready even with green CI and no threads",
+			old:        prSnapshot{CIPassing: false, AssayUpToDate: false},
+			new:        prSnapshot{CIPassing: true, AssayUpToDate: false},
+			noEvents:   []string{EventPRReadyToMerge},
+		},
+		{
+			name:       "assay lands clean after green CI → pr_ready_to_merge fires once",
+			old:        prSnapshot{CIPassing: true, AssayUpToDate: false},
+			new:        prSnapshot{CIPassing: true, AssayUpToDate: true},
 			wantEvents: []string{EventPRReadyToMerge},
 		},
 		{
@@ -241,8 +253,8 @@ func TestSnapshotTransitionLogic(t *testing.T) {
 			// After CI completes passing following an in-progress poll, pr_ready_to_merge must fire.
 			// lastSnap has CIInProgress=true (from the in-progress poll); newSnap has CIInProgress=false.
 			name:       "CI completes passing after in-progress poll → pr_ready_to_merge fires",
-			old:        prSnapshot{CIPassing: true, CIInProgress: true},
-			new:        prSnapshot{CIPassing: true, CIInProgress: false},
+			old:        prSnapshot{CIPassing: true, CIInProgress: true, AssayUpToDate: true},
+			new:        prSnapshot{CIPassing: true, CIInProgress: false, AssayUpToDate: true},
 			wantEvents: []string{EventPRReadyToMerge},
 		},
 	}
@@ -312,8 +324,10 @@ func computeTransitionEventsWithPR(old, new *prSnapshot, prStatus string, ciFixC
 	// threads, or pending reviews. HasApproval is intentionally excluded
 	// because Copilot only submits COMMENTED reviews, never APPROVED.
 	// CIInProgress is excluded: a PR is not ready while CI is still running.
-	newReady := new.CIPassing && !new.CIInProgress && !new.IsConflicting && !new.HasUnresolvedThreads && !new.HasPendingReviews
-	lastReady := old.CIPassing && !old.CIInProgress && !old.IsConflicting && !old.HasUnresolvedThreads && !old.HasPendingReviews
+	// AssayUpToDate is required so the PR is not declared ready while an Assay
+	// review is still pending/in-flight for the current head (Forge-75cx).
+	newReady := new.CIPassing && !new.CIInProgress && !new.IsConflicting && !new.HasUnresolvedThreads && !new.HasPendingReviews && new.AssayUpToDate
+	lastReady := old.CIPassing && !old.CIInProgress && !old.IsConflicting && !old.HasUnresolvedThreads && !old.HasPendingReviews && old.AssayUpToDate
 	if newReady && !lastReady {
 		events = append(events, EventPRReadyToMerge)
 	}
@@ -750,6 +764,173 @@ func TestCheckPR_ReviewStillUnresolved_SkipsInFlightBurnish(t *testing.T) {
 
 	assert.NotContains(t, events, EventReviewChanges,
 		"EventReviewChanges must NOT fire while a burnish is already in flight (status=needs_fix)")
+}
+
+// assayEnabledMonitor builds a Monitor whose Assay trigger is enabled for the
+// given anvil, with a generous debounce/cost budget so the gate logic — not a
+// secondary limit — is what is under test.
+func assayEnabledMonitor(db *state.DB, fake vcs.Provider, anvil string) *Monitor {
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{anvil: "/fake"}, nil, nil, func() int { return 5 }, nil)
+	m.SetAssayConfig(func(string) AssayGateConfig {
+		return AssayGateConfig{Enabled: true, DebounceSeconds: 1}
+	})
+	return m
+}
+
+// TestCheckPR_AssayPending_BlocksReadyToMerge is the core regression test for
+// Forge-75cx: a PR with green CI, no conflicts, and no unresolved threads must
+// NOT be announced ready-to-merge while its current head has not yet been
+// assayed. Otherwise the in-flight Assay would post findings a poll later and
+// bounce the PR back to Burnish after it had already been declared ready.
+func TestCheckPR_AssayPending_BlocksReadyToMerge(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    900,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-assaypending",
+		Branch:    "forge/forge-assaypending",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	// Green CI, no threads, no pending reviews — would be ready if not for the
+	// missing Assay. No assay_runs row exists, so LastReviewedSHA != head.
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:   "OPEN",
+		HeadSHA: "deadbeefcafe",
+	}}
+
+	var events []string
+	m := assayEnabledMonitor(db, fake, "test-anvil")
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.NotContains(t, events, EventPRReadyToMerge,
+		"ready-to-merge must NOT fire while the current head is unassayed")
+	assert.Contains(t, events, EventPRReviewNeeded,
+		"an Assay review should be requested for the unassayed head")
+
+	// The DB-level readiness queries must agree: a pending Assay worker blocks
+	// readiness even though CI/threads/conflicts are clean.
+	require.NoError(t, db.InsertWorker(&state.Worker{
+		ID:        "assay-test-anvil-900",
+		BeadID:    pr.BeadID,
+		Anvil:     pr.Anvil,
+		Status:    state.WorkerRunning,
+		Phase:     "assay",
+		PRNumber:  pr.Number,
+		StartedAt: time.Now(),
+	}))
+	ready, err := db.IsPRReadyToMerge(pr.ID)
+	require.NoError(t, err)
+	assert.False(t, ready, "IsPRReadyToMerge must be false while an Assay worker is in flight")
+	readyList, err := db.ReadyToMergePRs()
+	require.NoError(t, err)
+	assert.Empty(t, readyList, "ReadyToMergePRs must exclude PRs with an in-flight Assay worker")
+}
+
+// TestCheckPR_AssayClean_FiresReadyToMerge verifies the rising edge: once the
+// current head has been assayed cleanly (LastReviewedSHA == head, no findings),
+// the next poll emits EventPRReadyToMerge exactly once. This mirrors production,
+// where the Assay worker calls ResetPRState on completion, forcing a re-seed.
+func TestCheckPR_AssayClean_FiresReadyToMerge(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	const head = "deadbeefcafe"
+	pr := &state.PR{
+		Number:    901,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-assayclean",
+		Branch:    "forge/forge-assayclean",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:   "OPEN",
+		HeadSHA: head,
+	}}
+
+	var events []string
+	m := assayEnabledMonitor(db, fake, "test-anvil")
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	// Poll 1: head unassayed → not ready.
+	m.checkAll(context.Background())
+	assert.NotContains(t, events, EventPRReadyToMerge,
+		"ready must not fire before the head is assayed")
+
+	// Assay lands cleanly for the current head and resets the snapshot, exactly
+	// as the Assay worker does on completion.
+	require.NoError(t, db.RecordAssayRun(&state.AssayRun{
+		Anvil:    pr.Anvil,
+		PRNumber: pr.Number,
+		HeadSHA:  head,
+	}))
+	m.ResetPRState(pr.Anvil, pr.Number)
+
+	events = nil
+	// Poll 2: head is now assayed → ready fires.
+	m.checkAll(context.Background())
+	readyCount := 0
+	for _, e := range events {
+		if e == EventPRReadyToMerge {
+			readyCount++
+		}
+	}
+	assert.Equal(t, 1, readyCount,
+		"ready-to-merge must fire exactly once after a clean assay lands; got events: %v", events)
+}
+
+// TestCheckPR_AssayDisabled_ReadyFiresImmediately verifies that the new gate is
+// inert when Assay is disabled: a clean PR is announced ready on first sighting
+// just as before, and the DB readiness queries surface it.
+func TestCheckPR_AssayDisabled_ReadyFiresImmediately(t *testing.T) {
+	db, cleanup := openTempDB(t)
+	defer cleanup()
+
+	pr := &state.PR{
+		Number:    902,
+		Anvil:     "test-anvil",
+		BeadID:    "forge-assaydisabled",
+		Branch:    "forge/forge-assaydisabled",
+		Status:    state.PROpen,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertPR(pr))
+
+	fake := &fakeVCSProvider{status: &vcs.PRStatus{
+		State:   "OPEN",
+		HeadSHA: "deadbeefcafe",
+	}}
+
+	var events []string
+	// No SetAssayConfig → Assay disabled.
+	m := New(db, func(_ string) vcs.Provider { return fake }, time.Minute,
+		map[string]string{"test-anvil": "/fake"}, nil, nil, func() int { return 5 }, nil)
+	m.OnEvent(func(_ context.Context, e PREvent) {
+		events = append(events, e.EventType)
+	})
+
+	m.checkAll(context.Background())
+
+	assert.Contains(t, events, EventPRReadyToMerge,
+		"ready-to-merge must fire immediately for a clean PR when Assay is disabled")
+
+	ready, err := db.IsPRReadyToMerge(pr.ID)
+	require.NoError(t, err)
+	assert.True(t, ready, "IsPRReadyToMerge must be true when Assay is disabled and the PR is clean")
 }
 
 // TestCheckPR_StillConflicting_ReemitsEvent is the end-to-end regression test

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1490,14 +1490,15 @@ func (db *DB) UpdatePRTitle(id int, title string) error {
 // (matched on anvil + pr_number). A PR with an in-flight Assay is not ready to
 // merge: its inline findings have not yet posted, so green CI and no unresolved
 // threads cannot yet be trusted — once the assay lands it may add threads and
-// bounce the PR back to Burnish (Forge-75cx). When Assay is disabled for an
-// anvil no such workers are ever created, so this predicate naturally evaluates
-// to false and readiness is unaffected.
+// bounce the PR back to Burnish (Forge-75cx). Stalled workers are included
+// because they may recover and still post findings. When Assay is disabled for
+// an anvil no such workers are ever created, so this predicate naturally
+// evaluates to false and readiness is unaffected.
 func pendingAssayExistsSQL(prAlias string) string {
 	return `EXISTS (
 		SELECT 1 FROM workers w
 		WHERE w.phase = 'assay'
-		  AND w.status IN ('pending', 'running')
+		  AND w.status IN ('pending', 'running', 'stalled')
 		  AND w.anvil = ` + prAlias + `.anvil
 		  AND w.pr_number = ` + prAlias + `.number
 	)`

--- a/internal/state/db.go
+++ b/internal/state/db.go
@@ -1485,9 +1485,28 @@ func (db *DB) UpdatePRTitle(id int, title string) error {
 	return err
 }
 
+// pendingAssayExistsSQL returns a correlated subquery that matches when an Assay
+// review worker is still pending or running for the PR referenced by prAlias
+// (matched on anvil + pr_number). A PR with an in-flight Assay is not ready to
+// merge: its inline findings have not yet posted, so green CI and no unresolved
+// threads cannot yet be trusted — once the assay lands it may add threads and
+// bounce the PR back to Burnish (Forge-75cx). When Assay is disabled for an
+// anvil no such workers are ever created, so this predicate naturally evaluates
+// to false and readiness is unaffected.
+func pendingAssayExistsSQL(prAlias string) string {
+	return `EXISTS (
+		SELECT 1 FROM workers w
+		WHERE w.phase = 'assay'
+		  AND w.status IN ('pending', 'running')
+		  AND w.anvil = ` + prAlias + `.anvil
+		  AND w.pr_number = ` + prAlias + `.number
+	)`
+}
+
 // IsPRReadyToMerge reports whether the given PR currently satisfies all
 // ready-to-merge conditions: CI passing, not conflicting, no unresolved
-// review threads, no pending review requests, and not in a needs_fix/closed/merged state.
+// review threads, no pending review requests, no in-flight Assay review, and not
+// in a needs_fix/closed/merged state.
 // Approval is not required — repos without branch protection rules
 // should still surface PRs as mergeable; GitHub enforces required
 // reviews at merge time.
@@ -1500,7 +1519,8 @@ func (db *DB) IsPRReadyToMerge(id int) (bool, error) {
 		   AND ci_passing = 1
 		   AND is_conflicting = 0
 		   AND has_unresolved_threads = 0
-		   AND has_pending_reviews = 0`,
+		   AND has_pending_reviews = 0
+		   AND NOT `+pendingAssayExistsSQL("prs"),
 		id,
 	).Scan(&count)
 	if err != nil {
@@ -1520,7 +1540,8 @@ type ReadyToMergePR struct {
 }
 
 // ReadyToMergePRs returns PRs where: CI passing, not conflicting,
-// no unresolved review threads, no pending review requests, and not in a terminal/fix state.
+// no unresolved review threads, no pending review requests, no in-flight Assay
+// review, and not in a terminal/fix state.
 // Title is resolved with a best-effort lookup from queue_cache or workers.
 func (db *DB) ReadyToMergePRs() ([]ReadyToMergePR, error) {
 	rows, err := db.conn.Query(
@@ -1542,6 +1563,7 @@ func (db *DB) ReadyToMergePRs() ([]ReadyToMergePR, error) {
 		   AND p.is_conflicting = 0
 		   AND p.has_unresolved_threads = 0
 		   AND p.has_pending_reviews = 0
+		   AND NOT `+pendingAssayExistsSQL("p")+`
 		 ORDER BY p.number`,
 	)
 	if err != nil {

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -2043,6 +2043,17 @@ func TestDB_ReadyToMerge_PendingAssayWorker(t *testing.T) {
 		t.Errorf("with running assay worker ReadyToMergePRs: got %d (err %v), want 0", len(list), err)
 	}
 
+	// A stalled Assay worker still blocks readiness (it may recover).
+	if err := db.UpdateWorkerStatus(worker.ID, WorkerStalled); err != nil {
+		t.Fatalf("UpdateWorkerStatus stalled: %v", err)
+	}
+	if ok, err := db.IsPRReadyToMerge(pr.ID); err != nil || ok {
+		t.Errorf("with stalled assay worker IsPRReadyToMerge: got %v (err %v), want false", ok, err)
+	}
+	if list, err := db.ReadyToMergePRs(); err != nil || len(list) != 0 {
+		t.Errorf("with stalled assay worker ReadyToMergePRs: got %d (err %v), want 0", len(list), err)
+	}
+
 	// Once the worker completes, the PR is ready again.
 	if err := db.UpdateWorkerStatus(worker.ID, WorkerDone); err != nil {
 		t.Fatalf("UpdateWorkerStatus: %v", err)

--- a/internal/state/db_test.go
+++ b/internal/state/db_test.go
@@ -1983,6 +1983,78 @@ func TestDB_ReadyToMerge(t *testing.T) {
 	}
 }
 
+// TestDB_ReadyToMerge_PendingAssayWorker verifies the Forge-75cx guard: a PR
+// that is otherwise ready must be excluded from both IsPRReadyToMerge and
+// ReadyToMergePRs while an Assay review worker is pending or running for it, and
+// surface again once that worker completes.
+func TestDB_ReadyToMerge_PendingAssayWorker(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "forge-rtm-assay-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	db, err := Open(filepath.Join(tmpDir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	pr := &PR{
+		Number:    300,
+		Anvil:     "anvil-assay",
+		BeadID:    "bd-300",
+		Branch:    "branch-300",
+		Status:    PRApproved,
+		CreatedAt: time.Now(),
+	}
+	if err := db.InsertPR(pr); err != nil {
+		t.Fatalf("InsertPR: %v", err)
+	}
+	// Clean mergeability: CI passing, no conflicts/threads/pending reviews.
+	if err := db.UpdatePRMergeability(pr.ID, true, false, false, false, false); err != nil {
+		t.Fatalf("UpdatePRMergeability: %v", err)
+	}
+
+	// Baseline: no assay worker → ready.
+	if ok, err := db.IsPRReadyToMerge(pr.ID); err != nil || !ok {
+		t.Fatalf("baseline IsPRReadyToMerge: got %v (err %v), want true", ok, err)
+	}
+	if list, err := db.ReadyToMergePRs(); err != nil || len(list) != 1 {
+		t.Fatalf("baseline ReadyToMergePRs: got %d (err %v), want 1", len(list), err)
+	}
+
+	// A running Assay worker for this PR blocks readiness.
+	worker := &Worker{
+		ID:        "assay-anvil-assay-300",
+		BeadID:    pr.BeadID,
+		Anvil:     pr.Anvil,
+		Status:    WorkerRunning,
+		Phase:     "assay",
+		PRNumber:  pr.Number,
+		StartedAt: time.Now(),
+	}
+	if err := db.InsertWorker(worker); err != nil {
+		t.Fatalf("InsertWorker: %v", err)
+	}
+	if ok, err := db.IsPRReadyToMerge(pr.ID); err != nil || ok {
+		t.Errorf("with running assay worker IsPRReadyToMerge: got %v (err %v), want false", ok, err)
+	}
+	if list, err := db.ReadyToMergePRs(); err != nil || len(list) != 0 {
+		t.Errorf("with running assay worker ReadyToMergePRs: got %d (err %v), want 0", len(list), err)
+	}
+
+	// Once the worker completes, the PR is ready again.
+	if err := db.UpdateWorkerStatus(worker.ID, WorkerDone); err != nil {
+		t.Fatalf("UpdateWorkerStatus: %v", err)
+	}
+	if ok, err := db.IsPRReadyToMerge(pr.ID); err != nil || !ok {
+		t.Errorf("after assay worker done IsPRReadyToMerge: got %v (err %v), want true", ok, err)
+	}
+	if list, err := db.ReadyToMergePRs(); err != nil || len(list) != 1 {
+		t.Errorf("after assay worker done ReadyToMergePRs: got %d (err %v), want 1", len(list), err)
+	}
+}
+
 // TestDB_InsertPR_DefaultsPendingReviews verifies that newly inserted PRs
 // default to has_pending_reviews=1 so they don't appear in Ready to Merge
 // until bellows confirms no reviews are pending.


### PR DESCRIPTION
## Changes

- **Ready-to-merge no longer races in-flight Assay reviews** - Gate the ready-to-merge transition (and auto-merge) on the current PR head having been reviewed by Assay, so a PR with green CI and no threads is not announced ready while an Assay review is still pending or in-flight. The same guard is applied to the `IsPRReadyToMerge`/`ReadyToMergePRs` state queries (which exclude PRs with a pending Assay worker) so the Hearth panel and auto-merge agree. (Forge-75cx)

## Original Issue (bug): Ready-to-merge can fire before in-flight Assay posts findings, bouncing PR back to Burnish

A PR can be flagged 'Ready to merge' while an Assay review is still pending/in-flight for the current head SHA. When the Assay then lands and posts inline comments, the PR gains unresolved threads, bellows emits EventReviewChanges, and the PR bounces back to needs_fix/Burnish — after already having been announced as ready to merge (and possibly auto-merge attempted).

## Root cause
In internal/bellows/bellows.go (bellows.processPR), within a single poll cycle the assay trigger gate is evaluated and THEN the ready-to-merge transition is checked:

  L829  m.maybeEmitReviewNeeded(...)        // may emit EventPRReviewNeeded -> dispatch async assay worker
  L837  newReady := newSnap.CIPassing && !ciInProgress && !newSnap.IsConflicting && !newSnap.HasUnresolvedThreads && !newSnap.HasPendingReviews
  L839  if newReady && !lastReady { emit EventPRReadyToMerge; autoMerge }

The ready condition (L820 for status restore, L837 for the event) has NO term for an outstanding/incomplete Assay. Assay runs asynchronously (phase='assay', dispatched via lifecycle.ActionAssayReview, posts findings later in internal/assay/post.go). So on first sighting of a PR that already has green CI and no threads, ready-to-merge fires immediately; the assay posts comments a poll or two later; HasUnresolvedThreads flips 0->1; L775 emits EventReviewChanges -> burnish.

The design comment at bellows.go:824-828 even states the intent ('Assay reviews on first sighting regardless of CI state ... so its findings are available early enough to feed the Burnish fix loop') — but because assay is async and ready-to-merge isn't gated on it, the findings frequently arrive AFTER ready-to-merge rather than before.

The same missing guard exists in the state-layer queries that the panel/auto-merge rely on: state/db.go IsPRReadyToMerge (~L1373) and ReadyToMergePRs (~L1404) check ci_passing/is_conflicting/has_unresolved_threads/has_pending_reviews but never the workers table for a pending assay.

## Suggested fix
A clean guard already has the needed data: db.LastReviewedSHA(anvil, prNumber) (state/db.go:3834) returns the head SHA most recently reviewed by Assay, and bellows already uses it in the trigger gate (bellows.go:197 lastReviewedSHA, used by shouldEmitReviewNeeded). Gate ready-to-merge on the current head having been assayed:
  ready = ... && (assay disabled || LastReviewedSHA(anvil, number) == headSHA)
This covers BOTH the pre-dispatch window and the in-flight window, which a simple 'no pending assay worker' check would miss. Apply consistently to the bellows transition (L820/L837) and the IsPRReadyToMerge / ReadyToMergePRs queries so the panel and auto-merge agree.

## Severity
Minor / cosmetic-to-moderate: mostly causes a confusing ready -> burnish flip in the Hearth panel and event log. Higher impact if auto-merge is enabled for the anvil (autoMergeHandler at bellows.go:855), since a PR could be merged before its assay findings are even posted.

Investigated against current main; line numbers approximate.

---
Bead: Forge-75cx | Branch: forge/Forge-75cx
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->