### PR TITLE
Backend config read/write API (GET + PATCH /api/forge/config) (Forge-e4xe)

### DIFF
--- a/changelog.d/Forge-e4xe.md
+++ b/changelog.d/Forge-e4xe.md
@@ -1,0 +1,2 @@
+category: Added
+- **Forge config read/write API** - New `GET /api/forge/config` returns the managed boolean settings with per-key metadata (value, default, doc string, area, label, and a hotReloadable flag), and `PATCH /api/forge/config` persists one or more of them to `~/.forge/config.yaml` via a comment-preserving YAML node-tree edit so the daemon hot-reloads. (Forge-e4xe)

--- a/internal/daemon/web.go
+++ b/internal/daemon/web.go
@@ -49,6 +49,11 @@ func (d *Daemon) startWebServer(ctx context.Context) error {
 		return fmt.Errorf("constructing web server: %w", err)
 	}
 
+	// Tell the web server which config file the daemon is using so
+	// GET/PATCH /api/forge/config target the same file the hot-reloader
+	// watches (honours --config).
+	srv.SetConfigFile(d.configFile)
+
 	// Plug in the Beads-Forge AI runner using the daemon's configured
 	// providers. We pick the head of the resolved list — fallbacks are not
 	// needed here because a turn is interactive and should fail fast.

--- a/internal/web/forge_config.go
+++ b/internal/web/forge_config.go
@@ -176,21 +176,24 @@ var configKeyByName = func() map[string]configKeyDef {
 }()
 
 // loadConfig reads the current forge config. Tests override s.configLoader to
-// point at a fixture; production falls back to the standard resolution chain
-// (config.Load("")), which honours --config/forge.yaml/~/.forge/config.yaml.
+// point at a fixture; production uses s.configFile (the daemon's --config
+// path) so the web layer reads the same file the daemon hot-reloads.
 func (s *Server) loadConfig() (*config.Config, error) {
 	if s.configLoader != nil {
 		return s.configLoader()
 	}
-	return config.Load("")
+	return config.Load(s.configFile)
 }
 
 // configWritePath resolves the file the PATCH handler edits. Tests override
-// s.configPath; production uses the resolved config path, falling back to
-// ~/.forge/config.yaml when no file exists yet.
+// s.configPath; production uses s.configFile (the daemon's --config path) so
+// edits land in the same file the daemon hot-reloads.
 func (s *Server) configWritePath() string {
 	if s.configPath != nil {
 		return s.configPath()
+	}
+	if s.configFile != "" {
+		return s.configFile
 	}
 	return defaultConfigWritePath()
 }
@@ -316,8 +319,13 @@ func applyConfigPatch(path string, patch map[string]bool) error {
 		setMappingChild(root, "settings", settings)
 	}
 
-	for key, val := range patch {
-		setBoolNode(settings, key, val)
+	keys := make([]string, 0, len(patch))
+	for k := range patch {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		setBoolNode(settings, key, patch[key])
 	}
 
 	out, err := marshalNode(&doc)

--- a/internal/web/forge_config.go
+++ b/internal/web/forge_config.go
@@ -1,0 +1,429 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Robin831/Forge/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigKeyInfo is the per-key metadata returned by GET /api/forge/config and
+// consumed by the SettingsPage frontend. It is the documented data contract:
+//
+//   - Key           the forge.yaml settings key (e.g. "schematic_enabled")
+//   - Value         the current effective boolean value (defaults applied for
+//                   tri-state *bool keys that are unset)
+//   - IsDefault     true when Value equals the documented default
+//   - HotReloadable true only for keys the running daemon applies without a
+//                   restart (see internal/hotreload)
+//   - Area          UI grouping for the settings page
+//   - Label         short human-readable name
+//   - Description    one-line explanation sourced from config.go doc comments
+type ConfigKeyInfo struct {
+	Key           string `json:"key"`
+	Value         bool   `json:"value"`
+	IsDefault     bool   `json:"isDefault"`
+	HotReloadable bool   `json:"hotReloadable"`
+	Area          string `json:"area"`
+	Label         string `json:"label"`
+	Description   string `json:"description"`
+}
+
+// ConfigResponse is the GET /api/forge/config body. Keys is ordered (stable)
+// so the frontend can render them deterministically.
+type ConfigResponse struct {
+	Keys []ConfigKeyInfo `json:"keys"`
+}
+
+// configKeyDef describes one managed boolean settings key: how to read its
+// current value, its documented default, its metadata, and whether the daemon
+// hot-reloads it. This is the single source of truth shared by the GET
+// (serialisation) and PATCH (allowlist validation) handlers.
+type configKeyDef struct {
+	Key           string
+	Area          string
+	Label         string
+	Description   string
+	HotReloadable bool
+	Default       bool
+	// value resolves the effective boolean from settings, applying the
+	// documented default for tri-state *bool keys that are nil/unset.
+	value func(s config.SettingsConfig) bool
+}
+
+// managedConfigKeys is the allowlist of boolean settings exposed by the
+// config API. Order is preserved in the GET response. HotReloadable is true
+// only for keys the daemon applies live (cross-checked against
+// internal/hotreload/hotreload.go: copilot_combined_smith_warden and
+// smelter_enabled). The tri-state *bool keys (auto_merge_crucible_children,
+// vulncheck_enabled, smelter_enabled) default to true and resolve nil via
+// their config helpers.
+var managedConfigKeys = []configKeyDef{
+	{
+		Key:         "schematic_enabled",
+		Area:        "Pipeline",
+		Label:       "Schematic pre-analysis",
+		Description: "Enable the Schematic pre-worker globally. Beads exceeding the word threshold or carrying the \"decompose\" tag are analysed before Smith starts.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.SchematicEnabled },
+	},
+	{
+		Key:         "go_race_detection",
+		Area:        "Temper",
+		Label:       "Go race detection",
+		Description: "Run the Go race detector (-race) as a separate temper step globally. Per-anvil settings override this.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.GoRaceDetection },
+	},
+	{
+		Key:         "auto_learn_rules",
+		Area:        "Warden",
+		Label:       "Auto-learn Warden rules",
+		Description: "Automatically learn Warden review rules from Copilot comments when a PR is merged.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.AutoLearnRules },
+	},
+	{
+		Key:         "crucible_enabled",
+		Area:        "Crucible",
+		Label:       "Crucible orchestration",
+		Description: "Enable automatic Crucible orchestration for parent beads that have children (blocks other beads).",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.CrucibleEnabled },
+	},
+	{
+		Key:         "auto_merge_crucible_children",
+		Area:        "Crucible",
+		Label:       "Auto-merge Crucible children",
+		Description: "Automatically merge (squash) child PRs targeting a Crucible feature branch after the pipeline succeeds. Defaults to true.",
+		Default:     true,
+		value:       func(s config.SettingsConfig) bool { return s.IsAutoMergeCrucibleChildren() },
+	},
+	{
+		Key:         "copilot_skip_warden_small_diffs",
+		Area:        "Copilot",
+		Label:       "Skip Warden on small diffs",
+		Description: "Automatically skip Warden for small, low-risk diffs when the primary provider is Copilot. Saves one premium request for trivial changes.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.CopilotSkipWardenSmallDiffs },
+	},
+	{
+		Key:         "copilot_batch_ci_fixes",
+		Area:        "Copilot",
+		Label:       "Batch CI fixes",
+		Description: "Batch multiple CI failures into a single Smith invocation when the provider is Copilot. Saves premium requests on PRs with multiple failing checks.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.CopilotBatchCIFixes },
+	},
+	{
+		Key:         "copilot_batch_review_fixes",
+		Area:        "Copilot",
+		Label:       "Batch review fixes",
+		Description: "Batch multiple review comments into a single Smith invocation when the provider is Copilot. Saves premium requests on PRs with multiple review comments.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.CopilotBatchReviewFixes },
+	},
+	{
+		Key:         "warden_full_rereview",
+		Area:        "Warden",
+		Label:       "Full Warden re-review",
+		Description: "Force the Warden to do a full independent review on every iteration instead of a focused re-review that only checks whether prior feedback was addressed.",
+		Default:     false,
+		value:       func(s config.SettingsConfig) bool { return s.WardenFullRereview },
+	},
+	{
+		Key:           "copilot_combined_smith_warden",
+		Area:          "Copilot",
+		Label:         "Combined Smith+Warden",
+		Description:   "Embed Warden review criteria into the Smith prompt so Smith self-reviews its own diff, eliminating the separate Warden request (Copilot only, high risk).",
+		Default:       false,
+		HotReloadable: true,
+		value:         func(s config.SettingsConfig) bool { return s.CopilotCombinedSmithWarden },
+	},
+	{
+		Key:         "vulncheck_enabled",
+		Area:        "Vulncheck",
+		Label:       "Vulnerability scanning",
+		Description: "Enable vulnerability scanning with govulncheck. When false, scheduled scanning and \"forge scan\" are disabled. Defaults to true.",
+		Default:     true,
+		value:       func(s config.SettingsConfig) bool { return s.IsVulncheckEnabled() },
+	},
+	{
+		Key:           "smelter_enabled",
+		Area:          "Smelter",
+		Label:         "Smelter background process",
+		Description:   "Enable the Smelter background process, which batches pending Warden rules into PRs on a schedule. Defaults to true.",
+		Default:       true,
+		HotReloadable: true,
+		value:         func(s config.SettingsConfig) bool { return s.IsSmelterEnabled() },
+	},
+}
+
+// configKeyByName indexes managedConfigKeys for O(1) allowlist validation in
+// the PATCH handler.
+var configKeyByName = func() map[string]configKeyDef {
+	m := make(map[string]configKeyDef, len(managedConfigKeys))
+	for _, d := range managedConfigKeys {
+		m[d.Key] = d
+	}
+	return m
+}()
+
+// loadConfig reads the current forge config. Tests override s.configLoader to
+// point at a fixture; production falls back to the standard resolution chain
+// (config.Load("")), which honours --config/forge.yaml/~/.forge/config.yaml.
+func (s *Server) loadConfig() (*config.Config, error) {
+	if s.configLoader != nil {
+		return s.configLoader()
+	}
+	return config.Load("")
+}
+
+// configWritePath resolves the file the PATCH handler edits. Tests override
+// s.configPath; production uses the resolved config path, falling back to
+// ~/.forge/config.yaml when no file exists yet.
+func (s *Server) configWritePath() string {
+	if s.configPath != nil {
+		return s.configPath()
+	}
+	return defaultConfigWritePath()
+}
+
+// defaultConfigWritePath returns the path the daemon should persist config
+// edits to. It prefers an existing resolved config file so edits land where
+// the daemon already reads from; when none exists it falls back to the
+// documented ~/.forge/config.yaml so a fresh install gets a sensible file.
+func defaultConfigWritePath() string {
+	if path := config.ConfigFilePath(""); path != "" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".forge", "config.yaml")
+}
+
+// handleForgeConfigGet returns the managed boolean settings with per-key
+// metadata. GET /api/forge/config.
+func (s *Server) handleForgeConfigGet(w http.ResponseWriter, r *http.Request) {
+	cfg, err := s.loadConfig()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config: "+err.Error())
+		return
+	}
+	resp := ConfigResponse{Keys: make([]ConfigKeyInfo, 0, len(managedConfigKeys))}
+	for _, d := range managedConfigKeys {
+		val := d.value(cfg.Settings)
+		resp.Keys = append(resp.Keys, ConfigKeyInfo{
+			Key:           d.Key,
+			Value:         val,
+			IsDefault:     val == d.Default,
+			HotReloadable: d.HotReloadable,
+			Area:          d.Area,
+			Label:         d.Label,
+			Description:   d.Description,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleForgeConfigPatch accepts a map of boolean key->value, validates every
+// key against the allowlist (all-or-nothing), persists the changes via a YAML
+// node-tree edit that preserves comments and unrelated keys, and returns the
+// freshly re-read config (same shape as GET). PATCH /api/forge/config.
+func (s *Server) handleForgeConfigPatch(w http.ResponseWriter, r *http.Request) {
+	var req map[string]bool
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	if len(req) == 0 {
+		writeError(w, http.StatusBadRequest, "no config keys provided")
+		return
+	}
+
+	// All-or-nothing: validate every key before writing anything.
+	var unknown []string
+	for k := range req {
+		if _, ok := configKeyByName[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		writeError(w, http.StatusBadRequest, "unknown config key(s): "+strings.Join(unknown, ", "))
+		return
+	}
+
+	path := s.configWritePath()
+	if path == "" {
+		writeError(w, http.StatusInternalServerError, "could not resolve config file path")
+		return
+	}
+	if err := applyConfigPatch(path, req); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist config: "+err.Error())
+		return
+	}
+
+	// Return the re-read config so the caller sees the persisted result. The
+	// loader reads from disk, so it reflects the edit we just wrote.
+	s.handleForgeConfigGet(w, r)
+}
+
+// applyConfigPatch edits the YAML document at path in place, setting each
+// settings.<key> to the given boolean. It parses into a yaml.Node tree
+// (rather than marshalling a full Config) so comments and unrelated keys are
+// preserved, locates or creates the top-level `settings` mapping and each
+// target scalar, then writes the result back atomically (temp file + rename)
+// so the fsnotify watcher fires once on a complete file.
+func applyConfigPatch(path string, patch map[string]bool) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	var doc yaml.Node
+	if len(strings.TrimSpace(string(data))) > 0 {
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
+	}
+	// Normalise to a DocumentNode wrapping a MappingNode root so we always
+	// have somewhere to attach keys, even for an empty/new file.
+	if doc.Kind == 0 {
+		doc.Kind = yaml.DocumentNode
+	}
+	if len(doc.Content) == 0 {
+		doc.Content = []*yaml.Node{{Kind: yaml.MappingNode}}
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		// e.g. the file was a bare scalar/null — replace with an empty map.
+		root = &yaml.Node{Kind: yaml.MappingNode}
+		doc.Content[0] = root
+	}
+
+	settings := mappingValueNode(root, "settings")
+	if settings == nil || settings.Kind != yaml.MappingNode {
+		settings = &yaml.Node{Kind: yaml.MappingNode}
+		setMappingChild(root, "settings", settings)
+	}
+
+	for key, val := range patch {
+		setBoolNode(settings, key, val)
+	}
+
+	out, err := marshalNode(&doc)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	return writeFileAtomic(path, out)
+}
+
+// mappingValueNode returns the value node for key in mapping m, or nil when
+// the key is absent. m.Content holds alternating key/value nodes.
+func mappingValueNode(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setMappingChild sets key -> valNode in mapping m, replacing an existing
+// value node or appending a new key/value pair.
+func setMappingChild(m *yaml.Node, key string, valNode *yaml.Node) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content[i+1] = valNode
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		valNode)
+}
+
+// setBoolNode sets m[key] to a boolean scalar, editing the existing scalar in
+// place (preserving its surrounding comments) or appending a new pair.
+func setBoolNode(m *yaml.Node, key string, val bool) {
+	valStr := "false"
+	if val {
+		valStr = "true"
+	}
+	if vn := mappingValueNode(m, key); vn != nil {
+		vn.Kind = yaml.ScalarNode
+		vn.Tag = "!!bool"
+		vn.Style = 0
+		vn.Value = valStr
+		// Drop any child content a previous non-scalar value may have held.
+		vn.Content = nil
+		return
+	}
+	setMappingChild(m, key, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: valStr})
+}
+
+// marshalNode renders a yaml.Node tree with 2-space indentation to match the
+// project's existing config files.
+func marshalNode(n *yaml.Node) ([]byte, error) {
+	var b strings.Builder
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	if err := enc.Encode(n); err != nil {
+		_ = enc.Close()
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return []byte(b.String()), nil
+}
+
+// writeFileAtomic writes data to path via a temp file in the same directory
+// followed by a rename, so a concurrent fsnotify watcher only ever observes a
+// complete file. The parent directory is created when missing.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	// Preserve the existing file mode where possible; default to 0644.
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	tmp, err := os.CreateTemp(dir, ".forge-config-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	cleanup = false
+	return nil
+}

--- a/internal/web/forge_config_test.go
+++ b/internal/web/forge_config_test.go
@@ -110,7 +110,9 @@ func TestForgeConfig_GetReflectsFileValues(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
 	byKey := map[string]ConfigKeyInfo{}
 	for _, k := range resp.Keys {
 		byKey[k.Key] = k

--- a/internal/web/forge_config_test.go
+++ b/internal/web/forge_config_test.go
@@ -1,0 +1,280 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Robin831/Forge/internal/config"
+)
+
+// withConfigFixture points the server's config read/write hooks at a temp
+// file seeded with the given YAML, returning the file path.
+func withConfigFixture(t *testing.T, srv *Server, yaml string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	srv.configLoader = func() (*config.Config, error) { return config.Load(path) }
+	srv.configPath = func() string { return path }
+	return path
+}
+
+func TestForgeConfig_RequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	withConfigFixture(t, srv, "")
+
+	// GET without a session.
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/config", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("GET: expected 401, got %d", rec.Code)
+	}
+	// PATCH without a session.
+	rec = forgeRequest(t, srv, http.MethodPatch, "/api/forge/config", `{"schematic_enabled":true}`, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("PATCH: expected 401, got %d", rec.Code)
+	}
+}
+
+func TestForgeConfig_GetReturnsAllManagedKeys(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	// Empty config file: every key falls back to its documented default.
+	withConfigFixture(t, srv, "")
+
+	var resp ConfigResponse
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/config", "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Keys) != len(managedConfigKeys) {
+		t.Fatalf("expected %d keys, got %d", len(managedConfigKeys), len(resp.Keys))
+	}
+
+	byKey := map[string]ConfigKeyInfo{}
+	for _, k := range resp.Keys {
+		byKey[k.Key] = k
+		if k.Area == "" || k.Label == "" || k.Description == "" {
+			t.Errorf("key %s missing metadata: %+v", k.Key, k)
+		}
+	}
+
+	// All defaults => IsDefault must be true for every key.
+	for _, k := range resp.Keys {
+		if !k.IsDefault {
+			t.Errorf("key %s: expected IsDefault=true on empty config, got value=%v", k.Key, k.Value)
+		}
+	}
+
+	// Tri-state *bool keys default to true.
+	for _, key := range []string{"auto_merge_crucible_children", "vulncheck_enabled", "smelter_enabled"} {
+		if !byKey[key].Value {
+			t.Errorf("tri-state key %s: expected default true, got false", key)
+		}
+	}
+	// Plain bool keys default to false.
+	if byKey["schematic_enabled"].Value {
+		t.Errorf("schematic_enabled: expected default false")
+	}
+
+	// Only the two hot-reloadable keys are flagged.
+	hot := map[string]bool{}
+	for _, k := range resp.Keys {
+		if k.HotReloadable {
+			hot[k.Key] = true
+		}
+	}
+	if len(hot) != 2 || !hot["copilot_combined_smith_warden"] || !hot["smelter_enabled"] {
+		t.Errorf("expected exactly copilot_combined_smith_warden + smelter_enabled hotReloadable, got %v", hot)
+	}
+}
+
+func TestForgeConfig_GetReflectsFileValues(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	withConfigFixture(t, srv, `settings:
+  schematic_enabled: true
+  smelter_enabled: false
+`)
+
+	var resp ConfigResponse
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/config", "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	byKey := map[string]ConfigKeyInfo{}
+	for _, k := range resp.Keys {
+		byKey[k.Key] = k
+	}
+
+	// schematic_enabled flipped to true => not default.
+	if !byKey["schematic_enabled"].Value || byKey["schematic_enabled"].IsDefault {
+		t.Errorf("schematic_enabled: expected value=true, isDefault=false, got %+v", byKey["schematic_enabled"])
+	}
+	// smelter_enabled explicitly false => not default (default is true).
+	if byKey["smelter_enabled"].Value || byKey["smelter_enabled"].IsDefault {
+		t.Errorf("smelter_enabled: expected value=false, isDefault=false, got %+v", byKey["smelter_enabled"])
+	}
+}
+
+func TestForgeConfig_PatchPersistsAndPreservesCommentsAndKeys(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := withConfigFixture(t, srv, `# top-level comment
+settings:
+  # keep me — comment on poll_interval
+  poll_interval: 7m
+  schematic_enabled: false
+anvils:
+  forge:
+    path: /tmp/forge
+`)
+
+	body := `{"schematic_enabled":true,"vulncheck_enabled":false}`
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config", body, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH: expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Response is the re-read config reflecting the change.
+	var resp ConfigResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	byKey := map[string]ConfigKeyInfo{}
+	for _, k := range resp.Keys {
+		byKey[k.Key] = k
+	}
+	if !byKey["schematic_enabled"].Value {
+		t.Errorf("response: schematic_enabled not true")
+	}
+	if byKey["vulncheck_enabled"].Value {
+		t.Errorf("response: vulncheck_enabled not false")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(raw)
+
+	// Comments and unrelated keys must survive the node-tree edit.
+	for _, want := range []string{
+		"# top-level comment",
+		"keep me — comment on poll_interval",
+		"poll_interval: 7m",
+		"path: /tmp/forge",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected preserved %q in file, got:\n%s", want, got)
+		}
+	}
+	// The edited keys are written.
+	if !strings.Contains(got, "schematic_enabled: true") {
+		t.Errorf("expected schematic_enabled: true, got:\n%s", got)
+	}
+	if !strings.Contains(got, "vulncheck_enabled: false") {
+		t.Errorf("expected vulncheck_enabled: false, got:\n%s", got)
+	}
+}
+
+func TestForgeConfig_PatchUnknownKeyRejectedAndNoWrite(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	original := `settings:
+  schematic_enabled: false
+`
+	path := withConfigFixture(t, srv, original)
+
+	body := `{"schematic_enabled":true,"not_a_real_key":true}`
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config", body, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not_a_real_key") {
+		t.Errorf("error should name the offending key, got %s", rec.Body.String())
+	}
+
+	// All-or-nothing: nothing was written, including the valid key.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(raw) != original {
+		t.Errorf("file should be unchanged, got:\n%s", string(raw))
+	}
+}
+
+func TestForgeConfig_PatchEmptyBodyRejected(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	withConfigFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config", `{}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty patch, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestForgeConfig_PatchRequiresCSRFHeader(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	withConfigFixture(t, srv, "")
+
+	// Authenticated PATCH without the X-Forge-Action header must be rejected.
+	req := httptest.NewRequest(http.MethodPatch, "/api/forge/config",
+		strings.NewReader(`{"schematic_enabled":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without CSRF header, got %d", rec.Code)
+	}
+}
+
+// TestForgeConfig_TriStateNilResolvesToDefault verifies the value accessors
+// resolve a nil *bool to its documented default directly (independent of the
+// viper loader, which may materialise defaults of its own).
+func TestForgeConfig_TriStateNilResolvesToDefault(t *testing.T) {
+	var empty config.SettingsConfig // all *bool fields nil
+	for _, key := range []string{"auto_merge_crucible_children", "vulncheck_enabled", "smelter_enabled"} {
+		def := configKeyByName[key]
+		if !def.value(empty) {
+			t.Errorf("key %s: nil *bool should resolve to true, got false", key)
+		}
+		if !def.Default {
+			t.Errorf("key %s: expected documented default true", key)
+		}
+	}
+}
+
+func TestForgeConfig_PatchCreatesFileWhenMissing(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	// Point at a path that does not yet exist (and whose dir is missing).
+	path := filepath.Join(t.TempDir(), "nested", "config.yaml")
+	srv.configLoader = func() (*config.Config, error) { return config.Load(path) }
+	srv.configPath = func() string { return path }
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config", `{"crucible_enabled":true}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected created file: %v", err)
+	}
+	if !strings.Contains(string(raw), "crucible_enabled: true") {
+		t.Errorf("expected crucible_enabled: true in new file, got:\n%s", string(raw))
+	}
+}

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -127,6 +127,14 @@ func (s *Server) routes() http.Handler {
 		// escalations are findable and resolvable regardless of whether a
 		// live worker row still exists.
 		r.Get("/forge/needs-attention", s.handleForgeNeedsAttention)
+
+		// Forge config read/write (Forge-e4xe). GET returns the managed
+		// boolean settings with per-key metadata; PATCH persists one or
+		// more of them to ~/.forge/config.yaml via a YAML node-tree edit
+		// (preserving comments/unrelated keys) so the fsnotify watcher in
+		// internal/hotreload picks the change up.
+		r.Get("/forge/config", s.handleForgeConfigGet)
+		r.Patch("/forge/config", s.handleForgeConfigPatch)
 	})
 
 	// Static UI fallback. The next bead replaces this with the embedded

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -130,6 +130,17 @@ type Server struct {
 	// handleLoginPage can fall back to it without re-walking the embedded
 	// filesystem on every request.
 	staticH http.HandlerFunc
+
+	// configLoader loads the current forge config for the GET
+	// /api/forge/config endpoint. nil falls back to config.Load(""). Tests
+	// override it to point at a fixture file.
+	configLoader func() (*config.Config, error)
+
+	// configPath resolves the file the PATCH /api/forge/config handler
+	// writes to. nil falls back to defaultConfigWritePath() (the resolved
+	// config path, or ~/.forge/config.yaml when none exists yet). Tests
+	// override it to point at a temp fixture.
+	configPath func() string
 }
 
 // SetChatRunner installs the AI runner used by the Beads-Forge page. The

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -131,6 +131,12 @@ type Server struct {
 	// filesystem on every request.
 	staticH http.HandlerFunc
 
+	// configFile is the --config path the daemon was started with. When
+	// set, loadConfig and configWritePath use it instead of the default
+	// resolution chain, so GET/PATCH /api/forge/config read and write the
+	// same file the daemon hot-reloads.
+	configFile string
+
 	// configLoader loads the current forge config for the GET
 	// /api/forge/config endpoint. nil falls back to config.Load(""). Tests
 	// override it to point at a fixture file.
@@ -175,6 +181,13 @@ func (s *Server) SetAnvilDispatchTagLister(a AnvilDispatchTagLister) {
 // nil restores the default (forgechat.DefaultBdRunner).
 func (s *Server) SetBdRunner(r BdRunnerFn) {
 	s.bdRunner = r
+}
+
+// SetConfigFile tells the web server which config file the daemon is using.
+// When set, loadConfig and configWritePath honour the explicit path so
+// GET/PATCH /api/forge/config target the same file the daemon hot-reloads.
+func (s *Server) SetConfigFile(path string) {
+	s.configFile = path
 }
 
 // TurnStore exposes the in-flight turn registry for the SSE / polling


### PR DESCRIPTION
## Changes

- **Forge config read/write API** - New `GET /api/forge/config` returns the managed boolean settings with per-key metadata (value, default, doc string, area, label, and a hotReloadable flag), and `PATCH /api/forge/config` persists one or more of them to `~/.forge/config.yaml` via a comment-preserving YAML node-tree edit so the daemon hot-reloads. (Forge-e4xe)

## Original Issue (task): Backend config read/write API (GET + PATCH /api/forge/config)

Create internal/web/forge_config.go with two handlers behind the existing session auth, wired in router.go alongside other /api/forge/* routes. GET /api/forge/config: read the current config (the boolean SettingsConfig fields listed in the bead: schematic_enabled, go_race_detection, auto_learn_rules, crucible_enabled, auto_merge_crucible_children (*bool), copilot_skip_warden_small_diffs, copilot_batch_ci_fixes, copilot_batch_review_fixes, warden_full_rereview, copilot_combined_smith_warden, vulncheck_enabled (*bool), smelter_enabled) and return as JSON, including per-key metadata: current value, default, doc string, and a 'hotReloadable' flag (true only for copilot_combined_smith_warden, smelter_enabled per hotreload.go). PATCH /api/forge/config: accept a map of one or more boolean key->value, validate each key against a known allowlist, persist to ~/.forge/config.yaml preserving comments/unrelated keys where reasonably possible (use a YAML node-tree edit rather than full marshal/overwrite), so the existing fsnotify watcher (internal/hotreload) hot-reloads. Handle *bool tri-state keys (nil = documented default). This is the data contract the frontend depends on — define and document the JSON response shape (key, value, isDefault, hotReloadable, area, label, description) so the SettingsPage sub-task can consume it. Reference internal/config/config.go SettingsConfig ~L241-406 for field names, yaml tags, and doc strings.

---
Bead: Forge-e4xe | Branch: forge/Forge-e4xe
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->