### PR TITLE
Backend: extend config API for per-anvil settings (Forge-8s1w)

### DIFF
--- a/changelog.d/Forge-8s1w.md
+++ b/changelog.d/Forge-8s1w.md
@@ -1,0 +1,2 @@
+category: Added
+- **Per-anvil settings in config API** - GET /api/forge/config now returns an `anvils` map keyed by anvil name, exposing each anvil's `auto_merge`, `schematic_enabled`, `golangci_lint`, `go_race_detection`, `depcheck_enabled`, `questgiver_enabled`, `wicket_enabled`, and `wicket_auto_dispatch` settings. Tri-state `*bool` fields serialize as JSON null when unset (inherit global). (Forge-8s1w)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,62 @@ type AnvilConfig struct {
 	Assay *AssayConfig `mapstructure:"assay" yaml:"assay,omitempty"`
 }
 
+// AnvilSettings is the serializable projection of an anvil's per-anvil
+// settings exposed by the config API (GET /api/forge/config), keyed as
+// anvils.<name>.<key>. It is the documented JSON contract that the config
+// write path persists and the settings UI consumes.
+//
+// The *bool fields are tri-state: a non-nil pointer serializes to the literal
+// JSON true/false, while nil serializes to JSON null. Null means "inherit /
+// unset" — the anvil has no explicit override and the corresponding global
+// setting (or built-in default) applies. This distinction must survive the
+// JSON round-trip, so callers must NOT collapse nil to false.
+//
+// AutoMerge and WicketAutoDispatch are plain booleans (no inherit semantics);
+// they are always present as true/false.
+type AnvilSettings struct {
+	AutoMerge          bool  `json:"auto_merge"`
+	SchematicEnabled   *bool `json:"schematic_enabled"`
+	GolangciLint       *bool `json:"golangci_lint"`
+	GoRaceDetection    *bool `json:"go_race_detection"`
+	DepcheckEnabled    *bool `json:"depcheck_enabled"`
+	QuestgiverEnabled  *bool `json:"questgiver_enabled"`
+	WicketEnabled      *bool `json:"wicket_enabled"`
+	WicketAutoDispatch bool  `json:"wicket_auto_dispatch"`
+}
+
+// AnvilSettingsMap projects every configured anvil into an AnvilSettings
+// keyed by anvil name. The result is always non-nil (an empty map when no
+// anvils are configured) so it marshals to "{}" rather than null. Tri-state
+// *bool fields are deep-copied so map entries never alias the same pointer.
+func (c *Config) AnvilSettingsMap() map[string]AnvilSettings {
+	out := make(map[string]AnvilSettings, len(c.Anvils))
+	for name, anvil := range c.Anvils {
+		out[name] = AnvilSettings{
+			AutoMerge:          anvil.AutoMerge,
+			SchematicEnabled:   copyBool(anvil.SchematicEnabled),
+			GolangciLint:       copyBool(anvil.GolangciLint),
+			GoRaceDetection:    copyBool(anvil.GoRaceDetection),
+			DepcheckEnabled:    copyBool(anvil.DepcheckEnabled),
+			QuestgiverEnabled:  copyBool(anvil.QuestgiverEnabled),
+			WicketEnabled:      copyBool(anvil.WicketEnabled),
+			WicketAutoDispatch: anvil.WicketAutoDispatch,
+		}
+	}
+	return out
+}
+
+// copyBool returns a new pointer to a copy of *b, or nil when b is nil. It
+// preserves the tri-state nil ("inherit/unset") semantics while ensuring no
+// two AnvilSettings entries share the same underlying pointer.
+func copyBool(b *bool) *bool {
+	if b == nil {
+		return nil
+	}
+	v := *b
+	return &v
+}
+
 // SmithConfig holds per-anvil Smith configuration.
 type SmithConfig struct {
 	// DenyPatterns defines file and command patterns that Smith is not

--- a/internal/web/forge_config.go
+++ b/internal/web/forge_config.go
@@ -40,7 +40,7 @@ type ConfigKeyInfo struct {
 // configured anvil name to its per-anvil settings (the anvils.<name>.<key>
 // contract); it is always present and serializes to "{}" when no anvils are
 // configured. Tri-state *bool settings serialize to null when unset, meaning
-// the anvil inherits the corresponding global setting.
+// the anvil inherits the corresponding global setting or built-in default.
 type ConfigResponse struct {
 	Keys   []ConfigKeyInfo                 `json:"keys"`
 	Anvils map[string]config.AnvilSettings `json:"anvils"`

--- a/internal/web/forge_config.go
+++ b/internal/web/forge_config.go
@@ -36,9 +36,14 @@ type ConfigKeyInfo struct {
 }
 
 // ConfigResponse is the GET /api/forge/config body. Keys is ordered (stable)
-// so the frontend can render them deterministically.
+// so the frontend can render them deterministically. Anvils maps each
+// configured anvil name to its per-anvil settings (the anvils.<name>.<key>
+// contract); it is always present and serializes to "{}" when no anvils are
+// configured. Tri-state *bool settings serialize to null when unset, meaning
+// the anvil inherits the corresponding global setting.
 type ConfigResponse struct {
-	Keys []ConfigKeyInfo `json:"keys"`
+	Keys   []ConfigKeyInfo                 `json:"keys"`
+	Anvils map[string]config.AnvilSettings `json:"anvils"`
 }
 
 // configKeyDef describes one managed boolean settings key: how to read its
@@ -221,7 +226,10 @@ func (s *Server) handleForgeConfigGet(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to load config: "+err.Error())
 		return
 	}
-	resp := ConfigResponse{Keys: make([]ConfigKeyInfo, 0, len(managedConfigKeys))}
+	resp := ConfigResponse{
+		Keys:   make([]ConfigKeyInfo, 0, len(managedConfigKeys)),
+		Anvils: cfg.AnvilSettingsMap(),
+	}
 	for _, d := range managedConfigKeys {
 		val := d.value(cfg.Settings)
 		resp.Keys = append(resp.Keys, ConfigKeyInfo{

--- a/internal/web/forge_config_test.go
+++ b/internal/web/forge_config_test.go
@@ -371,7 +371,16 @@ func TestForgeConfig_GetEmptyAnvilsIsObjectNotNull(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), `"anvils":{}`) {
-		t.Errorf("expected \"anvils\":{} in body, got: %s", rec.Body.String())
+	var resp struct {
+		Anvils map[string]json.RawMessage `json:"anvils"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Anvils == nil {
+		t.Fatal("expected anvils to be a non-nil empty object, got null")
+	}
+	if len(resp.Anvils) != 0 {
+		t.Errorf("expected empty anvils map, got %d entries", len(resp.Anvils))
 	}
 }

--- a/internal/web/forge_config_test.go
+++ b/internal/web/forge_config_test.go
@@ -280,3 +280,98 @@ func TestForgeConfig_PatchCreatesFileWhenMissing(t *testing.T) {
 		t.Errorf("expected crucible_enabled: true in new file, got:\n%s", string(raw))
 	}
 }
+
+// TestForgeConfig_GetIncludesPerAnvilSettings verifies the anvils.<name>.<key>
+// contract: tri-state *bool settings round-trip as true/false/null and plain
+// bool settings (auto_merge, wicket_auto_dispatch) are always present.
+func TestForgeConfig_GetIncludesPerAnvilSettings(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	// "set" anvil overrides every tri-state field (mix of true/false) and
+	// enables the plain bools; "unset" anvil leaves all tri-state fields nil.
+	withConfigFixture(t, srv, `anvils:
+  set:
+    path: /tmp/set
+    auto_merge: true
+    wicket_auto_dispatch: true
+    schematic_enabled: true
+    golangci_lint: false
+    go_race_detection: true
+    depcheck_enabled: false
+    questgiver_enabled: true
+    wicket_enabled: false
+  unset:
+    path: /tmp/unset
+`)
+
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/config", "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Decode into raw JSON to assert the literal null vs true/false distinction
+	// for tri-state fields, which a *bool struct decode would also handle but
+	// raw map makes the contract explicit.
+	var raw struct {
+		Anvils map[string]map[string]json.RawMessage `json:"anvils"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(raw.Anvils) != 2 {
+		t.Fatalf("expected 2 anvils, got %d: %v", len(raw.Anvils), raw.Anvils)
+	}
+
+	set := raw.Anvils["set"]
+	if set == nil {
+		t.Fatalf("missing 'set' anvil")
+	}
+	expectSet := map[string]string{
+		"auto_merge":           "true",
+		"wicket_auto_dispatch": "true",
+		"schematic_enabled":    "true",
+		"golangci_lint":        "false",
+		"go_race_detection":    "true",
+		"depcheck_enabled":     "false",
+		"questgiver_enabled":   "true",
+		"wicket_enabled":       "false",
+	}
+	for k, want := range expectSet {
+		if got := strings.TrimSpace(string(set[k])); got != want {
+			t.Errorf("set.%s: expected %s, got %q", k, want, got)
+		}
+	}
+
+	unset := raw.Anvils["unset"]
+	if unset == nil {
+		t.Fatalf("missing 'unset' anvil")
+	}
+	// Tri-state fields must be JSON null (inherit/unset).
+	for _, k := range []string{"schematic_enabled", "golangci_lint", "go_race_detection", "depcheck_enabled", "questgiver_enabled", "wicket_enabled"} {
+		if got := strings.TrimSpace(string(unset[k])); got != "null" {
+			t.Errorf("unset.%s: expected null, got %q", k, got)
+		}
+	}
+	// Plain bools are always present and default to false.
+	for _, k := range []string{"auto_merge", "wicket_auto_dispatch"} {
+		if got := strings.TrimSpace(string(unset[k])); got != "false" {
+			t.Errorf("unset.%s: expected false, got %q", k, got)
+		}
+	}
+}
+
+// TestForgeConfig_GetEmptyAnvilsIsObjectNotNull verifies the no-anvils case
+// serializes anvils as {} rather than null.
+func TestForgeConfig_GetEmptyAnvilsIsObjectNotNull(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	withConfigFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodGet, "/api/forge/config", "", cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"anvils":{}`) {
+		t.Errorf("expected \"anvils\":{} in body, got: %s", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Changes

- **Per-anvil settings in config API** - GET /api/forge/config now returns an `anvils` map keyed by anvil name, exposing each anvil's `auto_merge`, `schematic_enabled`, `golangci_lint`, `go_race_detection`, `depcheck_enabled`, `questgiver_enabled`, `wicket_enabled`, and `wicket_auto_dispatch` settings. Tri-state `*bool` fields serialize as JSON null when unset (inherit global). (Forge-8s1w)

## Original Issue (task): Backend: extend config API for per-anvil settings

Modify internal/web (the config handlers from Forge-3hvb) and internal/config/config.go. Extend GET /api/forge/config to include a per-anvil settings map keyed by anvil name, derived from AnvilConfig (internal/config/config.go AnvilConfig ~L42-142): auto_merge (bool), schematic_enabled (*bool), golangci_lint (*bool), go_race_detection (*bool), depcheck_enabled (*bool), questgiver_enabled (*bool), wicket_enabled (*bool), wicket_auto_dispatch (bool). The anvil list comes from config Anvils / existing anvil status data — reuse whatever the dashboard/status already exposes; add to the config endpoint if it isn't surfaced. Serialize *bool as nullable (null = inherit/unset) so the tri-state distinction survives the JSON round-trip. This sub-task defines the JSON shape (anvils.<name>.<key>) that the write sub-task persists and the UI sub-task consumes — agree the field names and null semantics here.

---
Bead: Forge-8s1w | Branch: forge/Forge-8s1w
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->