### PR TITLE
Backend: per-anvil PATCH/write with allowlist + persistence (Forge-bfch)

### DIFF
--- a/changelog.d/Forge-bfch.md
+++ b/changelog.d/Forge-bfch.md
@@ -1,0 +1,2 @@
+category: Added
+- **Per-anvil config write API** - Added `PATCH /api/forge/config/anvils/{name}` to update the eight allowlisted per-anvil settings. Validates the anvil name (404 if unknown) and every key (400 if unknown), distinguishes tri-state `*bool` clears (JSON `null` → inherit) from explicit `true`/`false`, persists atomically to `config.yaml` so the daemon hot-reloads, and reports per-key hot-reload coverage (`auto_merge` is instant; the rest apply on next run). (Forge-bfch)

--- a/internal/web/forge_config.go
+++ b/internal/web/forge_config.go
@@ -392,7 +392,8 @@ func (s *Server) handleForgeAnvilConfigPatch(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "failed to load config: "+err.Error())
 		return
 	}
-	if _, ok := cfg.Anvils[name]; !ok {
+	anvilCfg, ok := cfg.Anvils[name]
+	if !ok {
 		writeError(w, http.StatusNotFound, "unknown anvil: "+name)
 		return
 	}
@@ -450,7 +451,7 @@ func (s *Server) handleForgeAnvilConfigPatch(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "could not resolve config file path")
 		return
 	}
-	if err := applyAnvilConfigPatch(path, name, sets, clears); err != nil {
+	if err := applyAnvilConfigPatch(path, name, anvilCfg.Path, sets, clears); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist config: "+err.Error())
 		return
 	}
@@ -489,8 +490,9 @@ func anvilKeyOrder(key string) int {
 // (so the anvil inherits the global/default). Like applyConfigPatch it works
 // on a yaml.Node tree to preserve comments and unrelated keys, then writes the
 // result back atomically (temp file + rename) so the fsnotify watcher fires
-// once on a complete file.
-func applyAnvilConfigPatch(path, anvil string, sets map[string]bool, clears []string) error {
+// once on a complete file. When creating a new anvil block, anvilPath is
+// persisted as the "path" key so the file remains a valid config.
+func applyAnvilConfigPatch(path, anvil, anvilPath string, sets map[string]bool, clears []string) error {
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read config: %w", err)
@@ -523,6 +525,11 @@ func applyAnvilConfigPatch(path, anvil string, sets map[string]bool, clears []st
 	if anvilNode == nil || anvilNode.Kind != yaml.MappingNode {
 		anvilNode = &yaml.Node{Kind: yaml.MappingNode}
 		setMappingChild(anvils, anvil, anvilNode)
+		if anvilPath != "" {
+			setMappingChild(anvilNode, "path", &yaml.Node{
+				Kind: yaml.ScalarNode, Tag: "!!str", Value: anvilPath,
+			})
+		}
 	}
 
 	// Apply sets in a stable order so the diff is deterministic.

--- a/internal/web/forge_config.go
+++ b/internal/web/forge_config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Robin831/Forge/internal/config"
+	"github.com/go-chi/chi/v5"
 	"gopkg.in/yaml.v3"
 )
 
@@ -288,6 +289,263 @@ func (s *Server) handleForgeConfigPatch(w http.ResponseWriter, r *http.Request) 
 	s.handleForgeConfigGet(w, r)
 }
 
+// applies* are the hot-reload coverage values reported per key by the
+// per-anvil PATCH handler. "instant" keys are applied by the running daemon
+// without a restart (see internal/hotreload); "next_run" keys are read fresh
+// on the next dispatch/run so they take effect for the next bead, not for
+// work already in flight.
+const (
+	appliesInstant = "instant"
+	appliesNextRun = "next_run"
+)
+
+// anvilKeyDef describes one allowlisted per-anvil settings key: whether it is
+// tri-state (a *bool that can be cleared to inherit) or a plain bool, and
+// whether the daemon hot-reloads it instantly. This is the single source of
+// truth for the anvils.<name>.<key> contract shared by validation and the
+// hot-reload coverage reported in the response.
+type anvilKeyDef struct {
+	Key string
+	// TriState marks a *bool field where JSON null clears the override
+	// (anvil inherits the global/default). Plain bools reject null.
+	TriState bool
+	// Instant marks keys the daemon applies live via internal/hotreload.
+	// Only auto_merge is instant; the rest apply on the next dispatch/run.
+	Instant bool
+}
+
+// managedAnvilKeys is the allowlist of the eight per-anvil settings exposed by
+// the config API, mirroring config.AnvilSettings. Order is preserved in the
+// response's per-key coverage list. Only auto_merge is hot-reloadable (see
+// internal/hotreload/hotreload.go, which diffs anvil auto_merge live); the
+// others are read on the next dispatch/run.
+var managedAnvilKeys = []anvilKeyDef{
+	{Key: "auto_merge", TriState: false, Instant: true},
+	{Key: "schematic_enabled", TriState: true},
+	{Key: "golangci_lint", TriState: true},
+	{Key: "go_race_detection", TriState: true},
+	{Key: "depcheck_enabled", TriState: true},
+	{Key: "questgiver_enabled", TriState: true},
+	{Key: "wicket_enabled", TriState: true},
+	{Key: "wicket_auto_dispatch", TriState: false},
+}
+
+// anvilKeyByName indexes managedAnvilKeys for O(1) allowlist validation.
+var anvilKeyByName = func() map[string]anvilKeyDef {
+	m := make(map[string]anvilKeyDef, len(managedAnvilKeys))
+	for _, d := range managedAnvilKeys {
+		m[d.Key] = d
+	}
+	return m
+}()
+
+// AnvilKeyApplied reports, per edited key, whether the change takes effect
+// instantly (hot-reloaded) or on the next dispatch/run, and whether the edit
+// cleared the override (tri-state *bool reset to inherit) rather than setting
+// an explicit value. The frontend uses Applies to show the "applies on next
+// run" note (consistent with Forge-3hvb).
+type AnvilKeyApplied struct {
+	Key     string `json:"key"`
+	Applies string `json:"applies"`
+	Cleared bool   `json:"cleared"`
+}
+
+// AnvilConfigPatchResponse is the PATCH /api/forge/config/anvils/{name} body.
+// Settings is the re-read projection of the anvil after the edit (same shape
+// as the per-anvil entries in GET /api/forge/config), so the caller sees the
+// persisted result without a second request. Applied lists per-key hot-reload
+// coverage for exactly the keys touched by this request.
+type AnvilConfigPatchResponse struct {
+	Anvil    string               `json:"anvil"`
+	Settings config.AnvilSettings `json:"settings"`
+	Applied  []AnvilKeyApplied    `json:"applied"`
+}
+
+// handleForgeAnvilConfigPatch accepts a map of per-anvil boolean key->value
+// for a single anvil, validates the anvil name (404 if unknown) and every key
+// (400 if unknown), distinguishes tri-state *bool clears (JSON null → remove
+// the key so the anvil inherits) from explicit true/false, persists the
+// changes via a YAML node-tree edit that preserves comments and unrelated
+// keys, and returns the re-read anvil settings plus per-key hot-reload
+// coverage. PATCH /api/forge/config/anvils/{name}.
+func (s *Server) handleForgeAnvilConfigPatch(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "anvil name is required")
+		return
+	}
+
+	// Decode into raw messages so we can distinguish "key present with null"
+	// (clear/inherit) from an explicit true/false, and reject malformed values.
+	var req map[string]json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	if len(req) == 0 {
+		writeError(w, http.StatusBadRequest, "no config keys provided")
+		return
+	}
+
+	cfg, err := s.loadConfig()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config: "+err.Error())
+		return
+	}
+	if _, ok := cfg.Anvils[name]; !ok {
+		writeError(w, http.StatusNotFound, "unknown anvil: "+name)
+		return
+	}
+
+	// All-or-nothing: validate every key and value before writing anything.
+	var unknown []string
+	sets := map[string]bool{}
+	var clears []string
+	applied := make([]AnvilKeyApplied, 0, len(req))
+	for k, raw := range req {
+		def, ok := anvilKeyByName[k]
+		if !ok {
+			unknown = append(unknown, k)
+			continue
+		}
+		switch strings.TrimSpace(string(raw)) {
+		case "true":
+			sets[k] = true
+		case "false":
+			sets[k] = false
+		case "null":
+			if !def.TriState {
+				writeError(w, http.StatusBadRequest,
+					fmt.Sprintf("key %q cannot be cleared (null); it is a plain boolean, send true or false", k))
+				return
+			}
+			clears = append(clears, k)
+		default:
+			allowed := "true or false"
+			if def.TriState {
+				allowed = "true, false, or null"
+			}
+			writeError(w, http.StatusBadRequest,
+				fmt.Sprintf("invalid value for key %q: expected %s", k, allowed))
+			return
+		}
+		appliesVal := appliesNextRun
+		if def.Instant {
+			appliesVal = appliesInstant
+		}
+		applied = append(applied, AnvilKeyApplied{
+			Key:     k,
+			Applies: appliesVal,
+			Cleared: strings.TrimSpace(string(raw)) == "null",
+		})
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		writeError(w, http.StatusBadRequest, "unknown config key(s): "+strings.Join(unknown, ", "))
+		return
+	}
+
+	path := s.configWritePath()
+	if path == "" {
+		writeError(w, http.StatusInternalServerError, "could not resolve config file path")
+		return
+	}
+	if err := applyAnvilConfigPatch(path, name, sets, clears); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist config: "+err.Error())
+		return
+	}
+
+	// Re-read so the caller sees the persisted result (defaults/inherit
+	// applied) rather than echoing the request back.
+	reread, err := s.loadConfig()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to reload config: "+err.Error())
+		return
+	}
+	// Order the per-key coverage to match the allowlist for a stable response.
+	sort.SliceStable(applied, func(i, j int) bool {
+		return anvilKeyOrder(applied[i].Key) < anvilKeyOrder(applied[j].Key)
+	})
+	writeJSON(w, http.StatusOK, AnvilConfigPatchResponse{
+		Anvil:    name,
+		Settings: reread.AnvilSettingsMap()[name],
+		Applied:  applied,
+	})
+}
+
+// anvilKeyOrder returns the index of key within managedAnvilKeys, or a large
+// sentinel when absent, so the response coverage list renders deterministically.
+func anvilKeyOrder(key string) int {
+	for i, d := range managedAnvilKeys {
+		if d.Key == key {
+			return i
+		}
+	}
+	return len(managedAnvilKeys)
+}
+
+// applyAnvilConfigPatch edits the YAML document at path in place, setting each
+// anvils.<name>.<key> in sets to its boolean and removing each key in clears
+// (so the anvil inherits the global/default). Like applyConfigPatch it works
+// on a yaml.Node tree to preserve comments and unrelated keys, then writes the
+// result back atomically (temp file + rename) so the fsnotify watcher fires
+// once on a complete file.
+func applyAnvilConfigPatch(path, anvil string, sets map[string]bool, clears []string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	var doc yaml.Node
+	if len(strings.TrimSpace(string(data))) > 0 {
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parse config: %w", err)
+		}
+	}
+	if doc.Kind == 0 {
+		doc.Kind = yaml.DocumentNode
+	}
+	if len(doc.Content) == 0 {
+		doc.Content = []*yaml.Node{{Kind: yaml.MappingNode}}
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		root = &yaml.Node{Kind: yaml.MappingNode}
+		doc.Content[0] = root
+	}
+
+	anvils := mappingValueNode(root, "anvils")
+	if anvils == nil || anvils.Kind != yaml.MappingNode {
+		anvils = &yaml.Node{Kind: yaml.MappingNode}
+		setMappingChild(root, "anvils", anvils)
+	}
+	anvilNode := mappingValueNode(anvils, anvil)
+	if anvilNode == nil || anvilNode.Kind != yaml.MappingNode {
+		anvilNode = &yaml.Node{Kind: yaml.MappingNode}
+		setMappingChild(anvils, anvil, anvilNode)
+	}
+
+	// Apply sets in a stable order so the diff is deterministic.
+	keys := make([]string, 0, len(sets))
+	for k := range sets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		setBoolNode(anvilNode, key, sets[key])
+	}
+	sort.Strings(clears)
+	for _, key := range clears {
+		removeMappingChild(anvilNode, key)
+	}
+
+	out, err := marshalNode(&doc)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	return writeFileAtomic(path, out)
+}
+
 // applyConfigPatch edits the YAML document at path in place, setting each
 // settings.<key> to the given boolean. It parses into a yaml.Node tree
 // (rather than marshalling a full Config) so comments and unrelated keys are
@@ -366,6 +624,20 @@ func setMappingChild(m *yaml.Node, key string, valNode *yaml.Node) {
 	m.Content = append(m.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
 		valNode)
+}
+
+// removeMappingChild deletes the key/value pair for key from mapping m,
+// returning true when a pair was removed. Removing a tri-state *bool key
+// (rather than writing null) lets the anvil inherit the global/default and
+// keeps the persisted file minimal.
+func removeMappingChild(m *yaml.Node, key string) bool {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content = append(m.Content[:i:i], m.Content[i+2:]...)
+			return true
+		}
+	}
+	return false
 }
 
 // setBoolNode sets m[key] to a boolean scalar, editing the existing scalar in

--- a/internal/web/forge_config_test.go
+++ b/internal/web/forge_config_test.go
@@ -360,6 +360,368 @@ func TestForgeConfig_GetIncludesPerAnvilSettings(t *testing.T) {
 	}
 }
 
+// anvilFixture seeds a config with a single "forge" anvil and points the
+// server's read/write hooks at it, returning the file path.
+func anvilFixture(t *testing.T, srv *Server, extra string) string {
+	t.Helper()
+	return withConfigFixture(t, srv, `anvils:
+  forge:
+    path: /tmp/forge
+`+extra)
+}
+
+// decodeAnvilPatch decodes an AnvilConfigPatchResponse from a recorder.
+func decodeAnvilPatch(t *testing.T, body []byte) AnvilConfigPatchResponse {
+	t.Helper()
+	var resp AnvilConfigPatchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode anvil patch response: %v (body=%s)", err, string(body))
+	}
+	return resp
+}
+
+func TestForgeAnvilConfig_PatchRequiresAuth(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"auto_merge":true}`, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+// TestForgeAnvilConfig_PatchAutoMergeIsInstant verifies the hot-reloadable
+// key reports applies=instant and persists.
+func TestForgeAnvilConfig_PatchAutoMergeIsInstant(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"auto_merge":true}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeAnvilPatch(t, rec.Body.Bytes())
+	if resp.Anvil != "forge" {
+		t.Errorf("expected anvil=forge, got %q", resp.Anvil)
+	}
+	if !resp.Settings.AutoMerge {
+		t.Errorf("expected settings.auto_merge=true, got %+v", resp.Settings)
+	}
+	if len(resp.Applied) != 1 || resp.Applied[0].Key != "auto_merge" || resp.Applied[0].Applies != appliesInstant {
+		t.Errorf("expected auto_merge=instant, got %+v", resp.Applied)
+	}
+	if resp.Applied[0].Cleared {
+		t.Errorf("explicit true should not be marked cleared")
+	}
+
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "auto_merge: true") {
+		t.Errorf("expected auto_merge: true persisted, got:\n%s", string(raw))
+	}
+}
+
+// TestForgeAnvilConfig_PatchNextRunKey verifies a non-hot-reloadable key
+// reports applies=next_run.
+func TestForgeAnvilConfig_PatchNextRunKey(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"schematic_enabled":true}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeAnvilPatch(t, rec.Body.Bytes())
+	if len(resp.Applied) != 1 || resp.Applied[0].Applies != appliesNextRun {
+		t.Errorf("expected schematic_enabled=next_run, got %+v", resp.Applied)
+	}
+	if resp.Settings.SchematicEnabled == nil || !*resp.Settings.SchematicEnabled {
+		t.Errorf("expected schematic_enabled=true in settings, got %+v", resp.Settings.SchematicEnabled)
+	}
+}
+
+// TestForgeAnvilConfig_PatchExplicitTrueVsFalse verifies explicit true and
+// false both persist as concrete pointer values (not cleared/inherited).
+func TestForgeAnvilConfig_PatchExplicitTrueVsFalse(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "")
+
+	// Explicit false.
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"golangci_lint":false}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("explicit false: expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeAnvilPatch(t, rec.Body.Bytes())
+	if resp.Settings.GolangciLint == nil || *resp.Settings.GolangciLint {
+		t.Errorf("expected golangci_lint=false (non-nil), got %+v", resp.Settings.GolangciLint)
+	}
+	if resp.Applied[0].Cleared {
+		t.Errorf("explicit false should not be marked cleared")
+	}
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "golangci_lint: false") {
+		t.Errorf("expected golangci_lint: false persisted, got:\n%s", string(raw))
+	}
+
+	// Explicit true.
+	rec = forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"golangci_lint":true}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("explicit true: expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp = decodeAnvilPatch(t, rec.Body.Bytes())
+	if resp.Settings.GolangciLint == nil || !*resp.Settings.GolangciLint {
+		t.Errorf("expected golangci_lint=true (non-nil), got %+v", resp.Settings.GolangciLint)
+	}
+}
+
+// TestForgeAnvilConfig_PatchClearInherits verifies that null clears a
+// tri-state key — the key is removed from the file (inherit) and the re-read
+// settings report nil, distinct from an explicit false.
+func TestForgeAnvilConfig_PatchClearInherits(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "    schematic_enabled: true\n")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"schematic_enabled":null}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeAnvilPatch(t, rec.Body.Bytes())
+	if resp.Settings.SchematicEnabled != nil {
+		t.Errorf("expected schematic_enabled cleared to nil (inherit), got %v", *resp.Settings.SchematicEnabled)
+	}
+	if len(resp.Applied) != 1 || !resp.Applied[0].Cleared {
+		t.Errorf("expected schematic_enabled marked cleared, got %+v", resp.Applied)
+	}
+
+	raw, _ := os.ReadFile(path)
+	if strings.Contains(string(raw), "schematic_enabled") {
+		t.Errorf("expected schematic_enabled removed from file, got:\n%s", string(raw))
+	}
+	// The anvil itself and unrelated keys must survive.
+	if !strings.Contains(string(raw), "path: /tmp/forge") {
+		t.Errorf("expected anvil path preserved, got:\n%s", string(raw))
+	}
+}
+
+// TestForgeAnvilConfig_PatchClearRejectedForPlainBool verifies null is
+// rejected for plain bool keys (auto_merge, wicket_auto_dispatch) which have
+// no inherit semantics.
+func TestForgeAnvilConfig_PatchClearRejectedForPlainBool(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "    auto_merge: true\n")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"auto_merge":null}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "auto_merge") {
+		t.Errorf("error should name the key, got %s", rec.Body.String())
+	}
+	// Nothing written: the original value survives.
+	raw, _ := os.ReadFile(path)
+	if !strings.Contains(string(raw), "auto_merge: true") {
+		t.Errorf("file should be unchanged, got:\n%s", string(raw))
+	}
+}
+
+// TestForgeAnvilConfig_PatchUnknownAnvil verifies an unknown anvil name is
+// rejected with 404 and nothing is written.
+func TestForgeAnvilConfig_PatchUnknownAnvil(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "")
+	original, _ := os.ReadFile(path)
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/nope", `{"auto_merge":true}`, cookie)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	raw, _ := os.ReadFile(path)
+	if string(raw) != string(original) {
+		t.Errorf("file should be unchanged, got:\n%s", string(raw))
+	}
+}
+
+// TestForgeAnvilConfig_PatchUnknownKey verifies an unknown key is rejected
+// 400 (all-or-nothing) and the valid key alongside it is not written.
+func TestForgeAnvilConfig_PatchUnknownKey(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "")
+	original, _ := os.ReadFile(path)
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge",
+		`{"auto_merge":true,"bogus_key":true}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "bogus_key") {
+		t.Errorf("error should name the offending key, got %s", rec.Body.String())
+	}
+	raw, _ := os.ReadFile(path)
+	if string(raw) != string(original) {
+		t.Errorf("all-or-nothing: file should be unchanged, got:\n%s", string(raw))
+	}
+}
+
+// TestForgeAnvilConfig_PatchInvalidValue verifies a non-bool/non-null value
+// is rejected with 400.
+func TestForgeAnvilConfig_PatchInvalidValue(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{"auto_merge":"yes"}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestForgeAnvilConfig_PatchEmptyBody verifies an empty patch is rejected.
+func TestForgeAnvilConfig_PatchEmptyBody(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge", `{}`, cookie)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty patch, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestForgeAnvilConfig_PatchPreservesCommentsAndOtherAnvils verifies the
+// node-tree edit preserves comments, unrelated keys, and sibling anvils, and
+// that the result is re-readable (atomic write).
+func TestForgeAnvilConfig_PatchPreservesCommentsAndOtherAnvils(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := withConfigFixture(t, srv, `# top comment
+settings:
+  poll_interval: 7m
+anvils:
+  forge:
+    # keep me
+    path: /tmp/forge
+    schematic_enabled: true
+  other:
+    path: /tmp/other
+    auto_merge: true
+`)
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge",
+		`{"auto_merge":true,"schematic_enabled":null}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(raw)
+	for _, want := range []string{
+		"# top comment",
+		"poll_interval: 7m",
+		"# keep me",
+		"path: /tmp/forge",
+		"path: /tmp/other",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected preserved %q, got:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "auto_merge: true") {
+		t.Errorf("expected auto_merge: true on forge, got:\n%s", got)
+	}
+
+	// The sibling anvil's auto_merge must be untouched, and the cleared key
+	// gone from the forge anvil.
+	reread, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reread.Anvils["forge"].AutoMerge {
+		t.Errorf("forge.auto_merge should be true after edit")
+	}
+	if reread.Anvils["forge"].SchematicEnabled != nil {
+		t.Errorf("forge.schematic_enabled should be cleared (nil)")
+	}
+	if !reread.Anvils["other"].AutoMerge {
+		t.Errorf("other.auto_merge should remain true")
+	}
+}
+
+// TestForgeAnvilConfig_PatchMultipleKeysOrderedCoverage verifies multiple
+// keys in one request all persist and the per-key coverage is reported in
+// allowlist order with the correct instant/next_run split.
+func TestForgeAnvilConfig_PatchMultipleKeysOrderedCoverage(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge",
+		`{"wicket_enabled":true,"auto_merge":true}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	resp := decodeAnvilPatch(t, rec.Body.Bytes())
+	if len(resp.Applied) != 2 {
+		t.Fatalf("expected 2 applied entries, got %d: %+v", len(resp.Applied), resp.Applied)
+	}
+	// auto_merge precedes wicket_enabled in the allowlist order.
+	if resp.Applied[0].Key != "auto_merge" || resp.Applied[0].Applies != appliesInstant {
+		t.Errorf("expected first=auto_merge/instant, got %+v", resp.Applied[0])
+	}
+	if resp.Applied[1].Key != "wicket_enabled" || resp.Applied[1].Applies != appliesNextRun {
+		t.Errorf("expected second=wicket_enabled/next_run, got %+v", resp.Applied[1])
+	}
+}
+
+// TestForgeAnvilConfig_PatchRequiresCSRFHeader mirrors the global config
+// CSRF guard for the per-anvil route.
+func TestForgeAnvilConfig_PatchRequiresCSRFHeader(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	anvilFixture(t, srv, "")
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/forge/config/anvils/forge",
+		strings.NewReader(`{"auto_merge":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "forge_session", Value: cookie})
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without CSRF header, got %d", rec.Code)
+	}
+}
+
+// TestForgeAnvilConfig_PatchCreatesAnvilKeysWhenAbsent verifies that setting a
+// key on an anvil whose YAML block has only a path adds the key without
+// disturbing the path, and the file round-trips.
+func TestForgeAnvilConfig_PatchCreatesAnvilKeysWhenAbsent(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+	path := anvilFixture(t, srv, "")
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge",
+		`{"depcheck_enabled":false}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	reread, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	dc := reread.Anvils["forge"].DepcheckEnabled
+	if dc == nil || *dc {
+		t.Errorf("expected depcheck_enabled=false (non-nil), got %v", dc)
+	}
+}
+
 // TestForgeConfig_GetEmptyAnvilsIsObjectNotNull verifies the no-anvils case
 // serializes anvils as {} rather than null.
 func TestForgeConfig_GetEmptyAnvilsIsObjectNotNull(t *testing.T) {

--- a/internal/web/forge_config_test.go
+++ b/internal/web/forge_config_test.go
@@ -722,6 +722,44 @@ func TestForgeAnvilConfig_PatchCreatesAnvilKeysWhenAbsent(t *testing.T) {
 	}
 }
 
+// TestForgeAnvilConfig_PatchCreatesAnvilBlockWithPath verifies that when the
+// anvil exists in the loaded config but not in the YAML file, patching it
+// creates a new anvil block that includes the path field so the file stays valid.
+func TestForgeAnvilConfig_PatchCreatesAnvilBlockWithPath(t *testing.T) {
+	srv := newServerWithDefaults(t, nil)
+	cookie := loginAndGetCookie(t, srv)
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(""), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	srv.configLoader = func() (*config.Config, error) {
+		return &config.Config{
+			Anvils: map[string]config.AnvilConfig{
+				"forge": {Path: "/srv/forge"},
+			},
+		}, nil
+	}
+	srv.configPath = func() string { return cfgPath }
+
+	rec := forgeRequest(t, srv, http.MethodPatch, "/api/forge/config/anvils/forge",
+		`{"auto_merge":true}`, cookie)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	content := string(raw)
+	if !strings.Contains(content, "path: /srv/forge") {
+		t.Errorf("expected written config to contain anvil path, got:\n%s", content)
+	}
+	if !strings.Contains(content, "auto_merge: true") {
+		t.Errorf("expected written config to contain auto_merge, got:\n%s", content)
+	}
+}
+
 // TestForgeConfig_GetEmptyAnvilsIsObjectNotNull verifies the no-anvils case
 // serializes anvils as {} rather than null.
 func TestForgeConfig_GetEmptyAnvilsIsObjectNotNull(t *testing.T) {

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -135,6 +135,13 @@ func (s *Server) routes() http.Handler {
 		// internal/hotreload picks the change up.
 		r.Get("/forge/config", s.handleForgeConfigGet)
 		r.Patch("/forge/config", s.handleForgeConfigPatch)
+		// Per-anvil settings write (Forge-bfch). PATCH accepts a map of
+		// anvils.<name>.<key> updates (the eight allowlisted keys), validates
+		// the anvil name and every key, distinguishes tri-state *bool clears
+		// (JSON null → inherit) from explicit true/false, and persists to the
+		// same config.yaml so internal/hotreload picks the change up. The
+		// response reports per-key hot-reload coverage (instant vs next_run).
+		r.Patch("/forge/config/anvils/{name}", s.handleForgeAnvilConfigPatch)
 	})
 
 	// Static UI fallback. The next bead replaces this with the embedded

--- a/internal/web/router.go
+++ b/internal/web/router.go
@@ -135,12 +135,13 @@ func (s *Server) routes() http.Handler {
 		// internal/hotreload picks the change up.
 		r.Get("/forge/config", s.handleForgeConfigGet)
 		r.Patch("/forge/config", s.handleForgeConfigPatch)
-		// Per-anvil settings write (Forge-bfch). PATCH accepts a map of
-		// anvils.<name>.<key> updates (the eight allowlisted keys), validates
-		// the anvil name and every key, distinguishes tri-state *bool clears
-		// (JSON null → inherit) from explicit true/false, and persists to the
-		// same config.yaml so internal/hotreload picks the change up. The
-		// response reports per-key hot-reload coverage (instant vs next_run).
+		// Per-anvil settings write (Forge-bfch). PATCH accepts a flat JSON
+		// object of allowlisted keys (e.g. {"auto_merge": true, "schematic_enabled": null})
+		// — the anvil name is taken from the URL, not the body. Validates the
+		// anvil name (404 if unknown) and every key, distinguishes tri-state
+		// *bool clears (JSON null → inherit) from explicit true/false, and
+		// persists to the same config.yaml so internal/hotreload picks the
+		// change up. The response reports per-key hot-reload coverage.
 		r.Patch("/forge/config/anvils/{name}", s.handleForgeAnvilConfigPatch)
 	})
 


### PR DESCRIPTION
## Changes

- **Per-anvil config write API** - Added `PATCH /api/forge/config/anvils/{name}` to update the eight allowlisted per-anvil settings. Validates the anvil name (404 if unknown) and every key (400 if unknown), distinguishes tri-state `*bool` clears (JSON `null` → inherit) from explicit `true`/`false`, persists atomically to `config.yaml` so the daemon hot-reloads, and reports per-key hot-reload coverage (`auto_merge` is instant; the rest apply on next run). (Forge-bfch)

## Original Issue (task): Backend: per-anvil PATCH/write with allowlist + persistence

Extend PATCH /api/forge/config (or add a per-anvil variant) in internal/web to accept anvils.<name>.<key> updates and persist them to ~/.forge/config.yaml so fsnotify hot-reloads. Validate both anvil name and key against an allowlist (the eight keys above; reject unknown anvils/keys with 4xx). Distinguish *bool clears (set to inherit/null → remove the key or write null) from explicit true/false. Surface hot-reload coverage: anvils.<name>.auto_merge is hot-reloadable via internal/hotreload; the others apply on next dispatch/run — return or document which keys are instant vs next-run so the UI can show the 'applies on next run' note (as in Forge-3hvb). Depends on the GET sub-task for the shared JSON shape and field naming; the UI sub-task calls this endpoint on toggle.

---
Bead: Forge-bfch | Branch: forge/Forge-bfch
Generated by [The Forge](https://github.com/Robin831/Forge) (Smith → Temper → Warden)
<!-- forge-managed: hytte-prod -->